### PR TITLE
removing requirement of install to be in current directory

### DIFF
--- a/compiler/install
+++ b/compiler/install
@@ -17,7 +17,6 @@ fi
 wd=`dirname $0`
 cd $wd
 
-
 dir=`dirname $dest`
 dir=`cd $dir; pwd`
 base=`basename $dest`


### PR DESCRIPTION
This has the install tool cd into its own directory before running the install.  This allows it to be run from anywhere.

Previously the user was required to:

```
cd fpp-tools/compiler
./install
```

Now a user may, but is not required to, cd into that directory.  

i.e. the following builds as expected.
```
cd fpp-tools
./compiler/install
```




