### PR TITLE
Revise string interfaces for dictionary elements

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriterUtils.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriterUtils.scala
@@ -554,8 +554,8 @@ abstract class ComponentCppWriterUtils(
     )
 
   /** Write a channel type as a C++ type */
-  def writeChannelType(t: Type): String =
-    TypeCppWriter.getName(s, t, Some("Fw::TlmString"))
+  def writeChannelType(t: Type, stringRep: String = "Fw::StringBase"): String =
+    TypeCppWriter.getName(s, t, Some(stringRep))
 
   def writeSendMessageLogic(
     bufferName: String,

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriterUtils.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriterUtils.scala
@@ -626,8 +626,8 @@ abstract class ComponentCppWriterUtils(
     }
 
   /** Write a parameter type as a C++ type */
-  def writeParamType(t: Type) =
-    TypeCppWriter.getName(s, t, Some("Fw::ParamString"))
+  def writeParamType(t: Type, stringRep: String = "Fw::StringBase") =
+    TypeCppWriter.getName(s, t, Some(stringRep))
 
   /** Get the name for a general port enumerated constant in cpp file */
   def portCppConstantName(p: PortInstance) =

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriterUtils.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriterUtils.scala
@@ -336,13 +336,13 @@ abstract class ComponentCppWriterUtils(
       )
     )).toMap
 
+  def getEventParamTypes(event: Event, stringRep: String = "Fw::StringBase") =
+    event.aNode._2.data.params.map(param =>
+      (param._2.data.name, writeEventParamType(param._2.data, stringRep))
+    )
+
   val eventParamTypeMap: Map[Event.Id, List[(String, String)]] =
-    sortedEvents.map((id, event) => (
-      id,
-      event.aNode._2.data.params.map(param =>
-        (param._2.data.name, writeEventParamType(param._2.data))
-      )
-    )).toMap
+    sortedEvents.map((id, event) => (id, getEventParamTypes(event))).toMap
 
   // Map from a port instance name to param list
   private val portParamMap =
@@ -545,12 +545,12 @@ abstract class ComponentCppWriterUtils(
       Some("Fw::InternalInterfaceString")
     )
 
-  /** Write an the type of an event param as a C++ type */
-  def writeEventParamType(param: Ast.FormalParam) =
+  /** Write the type of an event param as a C++ type */
+  def writeEventParamType(param: Ast.FormalParam, stringRep: String = "Fw::StringBase") =
     TypeCppWriter.getName(
       s,
       s.a.typeMap(param.typeName.id),
-      Some("Fw::LogStringArg")
+      Some(stringRep)
     )
 
   /** Write a channel type as a C++ type */

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriterUtils.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriterUtils.scala
@@ -139,15 +139,19 @@ abstract class ComponentCppWriterUtils(
     case _ => false
   })
 
-  /** Map from command opcodes to command parameters */
-  val cmdParamMap: Map[Command.Opcode, List[CppDoc.Function.Param]] = nonParamCmds.map((opcode, cmd) => {(
-    opcode,
+  /** Get the CppDoc formal parameters for a non-parameter command */
+  def getNonParamCmdFormalParams(cmd: Command.NonParam, stringRep: String): List[CppDoc.Function.Param] =
     formalParamsCppWriter.write(
       cmd.aNode._2.data.params,
       Nil,
-      Some("Fw::CmdStringArg"),
+      Some(stringRep),
       FormalParamsCppWriter.Value
     )
+
+  /** Map from command opcodes to command parameters */
+  val cmdParamMap: Map[Command.Opcode, List[CppDoc.Function.Param]] = nonParamCmds.map((opcode, cmd) => {(
+    opcode,
+    getNonParamCmdFormalParams(cmd, "Fw::CmdStringArg")
   )}).toMap
 
   /** List of events sorted by ID */
@@ -338,7 +342,7 @@ abstract class ComponentCppWriterUtils(
 
   def getEventParamTypes(event: Event, stringRep: String = "Fw::StringBase") =
     event.aNode._2.data.params.map(param =>
-      (param._2.data.name, writeEventParamType(param._2.data, stringRep))
+      (param._2.data.name, writeFormalParamType(param._2.data, stringRep))
     )
 
   val eventParamTypeMap: Map[Event.Id, List[(String, String)]] =
@@ -545,8 +549,8 @@ abstract class ComponentCppWriterUtils(
       Some("Fw::InternalInterfaceString")
     )
 
-  /** Write the type of an event param as a C++ type */
-  def writeEventParamType(param: Ast.FormalParam, stringRep: String = "Fw::StringBase") =
+  /** Write the type of an formal parameter as a C++ type */
+  def writeFormalParamType(param: Ast.FormalParam, stringRep: String = "Fw::StringBase") =
     TypeCppWriter.getName(
       s,
       s.a.typeMap(param.typeName.id),

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentDataProducts.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentDataProducts.scala
@@ -378,7 +378,7 @@ case class ComponentDataProducts (
       // Get the parameter type
       // For strings this is a const reference to Fw::StringBase
       // For primitive types it is the type name
-      // For othe types it is a const reference to the type name
+      // For other types it is a const reference to the type name
       val paramType = t match {
         case Type.String(_) => "const Fw::StringBase&"
         case _ =>

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentEvents.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentEvents.scala
@@ -134,9 +134,11 @@ case class ComponentEvents (
 
                   List.concat(
                     s.a.typeMap(param._2.data.typeName.id) match {
-                      case t: Type.String => lines(
-                        s"_status = $name.serialize(_logBuff, ${stringCppWriter.getSize(t)});"
-                      )
+                      case t: Type.String =>
+                        val serialSize = stringCppWriter.getSize(t)
+                        lines(
+                          s"_status = $name.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, $serialSize));"
+                        )
                       case t => lines(
                         s"""|#if FW_AMPCS_COMPATIBLE
                             |// Serialize the argument size
@@ -295,7 +297,7 @@ case class ComponentEvents (
           formalParamsCppWriter.write(
             event.aNode._2.data.params,
             Nil,
-            Some("Fw::LogStringArg"),
+            Some("Fw::StringBase"),
             FormalParamsCppWriter.Value
           ),
           CppDoc.Type("void"),

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentEvents.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentEvents.scala
@@ -143,7 +143,7 @@ case class ComponentEvents (
                         s"""|#if FW_AMPCS_COMPATIBLE
                             |// Serialize the argument size
                             |_status = _logBuff.serialize(
-                            |  static_cast<U8>(${s.getSerializedSizeExpr(t, writeEventParamType(param._2.data))})
+                            |  static_cast<U8>(${s.getSerializedSizeExpr(t, writeFormalParamType(param._2.data))})
                             |);
                             |FW_ASSERT(
                             |  _status == Fw::FW_SERIALIZE_OK,
@@ -201,7 +201,7 @@ case class ComponentEvents (
             event.aNode._2.data.params.flatMap(param =>
               s.a.typeMap(param._2.data.typeName.id) match {
                 case Type.String(_) => Nil
-                case t if s.isPrimitive(t, writeEventParamType(param._2.data)) => Nil
+                case t if s.isPrimitive(t, writeFormalParamType(param._2.data)) => Nil
                 case _ => lines(
                   s"""|Fw::String ${param._2.data.name}Str;
                       |${param._2.data.name}.toString(${param._2.data.name}Str);
@@ -226,7 +226,7 @@ case class ComponentEvents (
                     val name = param._2.data.name
                     s.a.typeMap(param._2.data.typeName.id) match {
                       case Type.String(_) => s"$name.toChar()"
-                      case t if s.isPrimitive(t, writeEventParamType(param._2.data)) => name
+                      case t if s.isPrimitive(t, writeFormalParamType(param._2.data)) => name
                       case _ => s"${name}Str.toChar()"
                     }
                   })).mkString(",\n")

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentParameters.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentParameters.scala
@@ -73,19 +73,19 @@ case class ComponentParameters (
       addAccessTagAndComment(
         "PRIVATE",
         "Parameter variables",
-        sortedParams.map((_, param) =>
+        sortedParams.map((_, param) => {
+          val paramType = writeParamType(param.paramType, "Fw::ParamString")
+          val paramVarName = paramVariableName(param.getName)
           linesClassMember(
             List.concat(
               addSeparatedPreComment(
                 s"Parameter ${param.getName}",
                 AnnotationCppWriter.asStringOpt(param.aNode)
               ),
-              lines(
-                s"${writeParamType(param.paramType)} ${paramVariableName(param.getName)};"
-              )
+              lines(s"$paramType $paramVarName;")
             )
           )
-        ),
+        }),
         CppDoc.Lines.Hpp
       )
     ).flatten
@@ -244,9 +244,9 @@ case class ComponentParameters (
               Some("Whether the parameter is valid")
             )
           ),
-          CppDoc.Type(writeParamType(param.paramType)),
+          CppDoc.Type(writeParamType(param.paramType, "Fw::ParamString")),
           lines(
-            s"""|${writeParamType(param.paramType)} _local;
+            s"""|${writeParamType(param.paramType, "Fw::ParamString")} _local;
                 |this->m_paramLock.lock();
                 |valid = this->${paramValidityFlagName(param.getName)};
                 |_local = this->${paramVariableName(param.getName)};
@@ -281,7 +281,7 @@ case class ComponentParameters (
           ),
           CppDoc.Type("Fw::CmdResponse"),
           lines(
-            s"""|${writeParamType(param.paramType)} _local_val;
+            s"""|${writeParamType(param.paramType, "Fw::ParamString")} _local_val;
                 |Fw::SerializeStatus _stat = val.deserialize(_local_val);
                 |if (_stat != Fw::FW_SERIALIZE_OK) {
                 |  return Fw::CmdResponse::VALIDATION_ERROR;

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentTelemetry.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentTelemetry.scala
@@ -55,16 +55,19 @@ case class ComponentTelemetry (
       addAccessTagAndComment(
         "PRIVATE",
         "Last value storage for telemetry channels",
-        updateOnChangeChannels.map((_, channel) =>
+        updateOnChangeChannels.map((_, channel) => {
+          val channelName = channel.getName
+          val channelType = writeChannelType(channel.channelType, "Fw::TlmString")
+          val channelStoreName = channelStorageName(channel.getName)
           linesClassMember(
             lines(
               s"""|
-                  |//! Records the last emitted value for channel ${channel.getName}
-                  |${writeChannelType(channel.channelType)} ${channelStorageName(channel.getName)};
+                  |//! Records the last emitted value for channel $channelName
+                  |$channelType $channelStoreName;
                   |"""
             )
           )
-        ),
+        }),
         CppDoc.Lines.Hpp
       )
     ).flatten
@@ -110,7 +113,8 @@ case class ComponentTelemetry (
             lines(
               channel.channelType match {
                 case t: Type.String =>
-                  s"Fw::SerializeStatus _stat = arg.serialize(_tlmBuff, ${stringCppWriter.getSize(t)});"
+                  val serialSize = stringCppWriter.getSize(t)
+                  s"Fw::SerializeStatus _stat = arg.serialize(_tlmBuff, FW_MIN(FW_TLM_STRING_MAX_SIZE, $serialSize));"
                 case _ =>
                   "Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);"
               }
@@ -171,7 +175,6 @@ case class ComponentTelemetry (
 
   private def writeChannelParam(t: Type) = {
     val typeName = writeChannelType(t)
-
     t match {
       case t if s.isPrimitive(t, typeName) => typeName
       case _ => s"const $typeName&"

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentHistory.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentHistory.scala
@@ -409,7 +409,7 @@ case class ComponentHistory(
       )
     val eventHistories = linesClassMember(
       sortedEvents.flatMap((id, event) =>
-        eventParamTypeMap(id) match {
+        getEventParamTypes(event, "Fw::LogStringArg") match {
           case Nil => Nil
           case params =>
             val eventName = event.getName

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentHistory.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentHistory.scala
@@ -586,7 +586,7 @@ case class ComponentHistory(
       sortedChannels.flatMap((_, channel) => {
         val channelName = channel.getName
         val entryName = tlmEntryName(channelName)
-        val channelType = writeChannelType(channel.channelType)
+        val channelType = writeChannelType(channel.channelType, "Fw::TlmString")
         Line.blank ::
         line(s"//! A history entry for telemetry channel $channelName") ::
         wrapInScope(

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentTestUtils.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentTestUtils.scala
@@ -128,13 +128,13 @@ abstract class ComponentTestUtils(
 
   def writeEventValue(value: String, typeName: String): String =
     typeName match {
-      case "Fw::LogStringArg" => s"$value.toChar()"
+      case "Fw::StringBase" => s"$value.toChar()"
       case _ => value
     }
 
   def writeEventAssertEq(typeName: String): String =
     typeName match {
-      case "Fw::LogStringArg" => "ASSERT_STREQ"
+      case "Fw::StringBase" => "ASSERT_STREQ"
       case _ => "ASSERT_EQ"
     }
 

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentTestUtils.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentTestUtils.scala
@@ -138,11 +138,14 @@ abstract class ComponentTestUtils(
       case _ => "ASSERT_EQ"
     }
 
-  def writeCppType(t: Type): String = {
-    val typeName = TypeCppWriter.getName(s, t, Some("char*"))
+  def writeCppType(t: Type, stringRepOpt: Option[String] = None): String = {
+    val typeName = TypeCppWriter.getName(s, t, stringRepOpt)
     t match {
       case t if s.isPrimitive(t, typeName) => s"const $typeName"
-      case _: Type.String => s"const $typeName const"
+      case _: Type.String => stringRepOpt match {
+        case Some(stringRep) => s"const $stringRep&"
+        case _ => s"const char* const"
+      }
       case _ => s"const $typeName&"
     }
   }

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentTesterBaseWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentTesterBaseWriter.scala
@@ -1277,7 +1277,7 @@ case class ComponentTesterBaseWriter(
             val idConstantName = paramIdConstantName(paramName)
             val paramNameVal = s"${paramName}Val"
             val paramVarName = paramVariableName(paramName)
-            val paramType = writeParamType(prm.paramType)
+            val paramType = writeParamType(prm.paramType, "Fw::ParamString")
             wrapInScope(
               s"case $className::$idConstantName: {",
               lines(
@@ -1483,7 +1483,7 @@ case class ComponentTesterBaseWriter(
         "Parameter variables",
         sortedParams.map((_, prm) => {
           val paramName = prm.getName
-          val paramType = writeParamType(prm.paramType)
+          val paramType = writeParamType(prm.paramType, "Fw::ParamString")
           val varName = paramVariableName(paramName)
           linesClassMember(
             Line.blank :: lines(

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentTesterBaseWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentTesterBaseWriter.scala
@@ -665,16 +665,30 @@ case class ComponentTesterBaseWriter(
                    |"""
               ),
               Line.blank :: intersperseBlankLines(
-                cmdFormalParams.map(param =>
-                  lines(
-                    s"""|_status = buf.serialize(${param._2.data.name});
-                        |FW_ASSERT(
-                        |  _status == Fw::FW_SERIALIZE_OK,
-                        |  static_cast<FwAssertArgType>(_status)
-                        |);
-                        |"""
-                  )
-                )
+                cmdFormalParams.map(param => {
+                  val t = s.a.typeMap(param._2.data.typeName.id)
+                  val varName = param._2.data.name
+                  t match {
+                    case ts: Type.String =>
+                      lines(
+                        s"""|_status = $varName.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+                            |FW_ASSERT(
+                            |  _status == Fw::FW_SERIALIZE_OK,
+                            |  static_cast<FwAssertArgType>(_status)
+                            |);
+                            |"""
+                      )
+                    case _ =>
+                      lines(
+                        s"""|_status = buf.serialize($varName);
+                            |FW_ASSERT(
+                            |  _status == Fw::FW_SERIALIZE_OK,
+                            |  static_cast<FwAssertArgType>(_status)
+                            |);
+                            |"""
+                      )
+                  }
+                })
               )
             ),
             lines(

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentTesterBaseWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentTesterBaseWriter.scala
@@ -636,7 +636,7 @@ case class ComponentTesterBaseWriter(
       )
     }
 
-    def writeCmdSendFunc(opcode: Command.Opcode, cmd: Command) = functionClassMember(
+    def writeCmdSendFunc(opcode: Command.Opcode, cmd: Command.NonParam) = functionClassMember(
       Some(s"Send a ${cmd.getName} command"),
       commandSendName(cmd.getName),
       List.concat(
@@ -648,11 +648,10 @@ case class ComponentTesterBaseWriter(
           ),
           cmdSeqParam
         ),
-        cmdParamMap(opcode)
+        getNonParamCmdFormalParams(cmd, "Fw::StringBase")
       ),
       CppDoc.Type("void"),
       {
-        val cmd @ Command.NonParam(_, _) = component.commandMap(opcode)
         val cmdFormalParams = cmd.aNode._2.data.params
         intersperseBlankLines(
           List(
@@ -828,7 +827,7 @@ case class ComponentTesterBaseWriter(
           event.aNode._2.data.params.flatMap(aNode => {
             val data = aNode._2.data
             val name = data.name
-            val tn = writeEventParamType(data, "Fw::LogStringArg")
+            val tn = writeFormalParamType(data, "Fw::LogStringArg")
             val paramType = s.a.typeMap(data.typeName.id)
             val serializedSizeExpr = s.getSerializedSizeExpr(paramType, tn)
 

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentTesterBaseWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentTesterBaseWriter.scala
@@ -984,10 +984,11 @@ case class ComponentTesterBaseWriter(
           val channelName = channel.getName
           val constantName = channelIdConstantName(channelName)
           val handlerName = tlmHandlerName(channelName)
+          val channelType = writeChannelType(channel.channelType, "Fw::TlmString")
           wrapInScope(
             s"case $className::$constantName: {",
             lines(
-              s"""|${writeChannelType(channel.channelType)} arg;
+              s"""|$channelType arg;
                   |const Fw::SerializeStatus _status = val.deserialize(arg);
                   |
                   |if (_status != Fw::FW_SERIALIZE_OK) {
@@ -1051,7 +1052,7 @@ case class ComponentTesterBaseWriter(
           guardedList (hasTelemetry) (List(dispatchTlm)),
           sortedChannels.map((_, channel) => {
             val channelName = channel.getName
-            val channelType = writeChannelType(channel.channelType)
+            val channelType = writeCppType(channel.channelType, Some("Fw::StringBase"))
             val entryName = tlmEntryName(channelName)
             val historyName = tlmHistoryName(channelName)
             functionClassMember(
@@ -1060,7 +1061,7 @@ case class ComponentTesterBaseWriter(
               List(
                 timeTagParam,
                 CppDoc.Function.Param(
-                  CppDoc.Type(s"const $channelType&"),
+                  CppDoc.Type(channelType),
                   "val",
                   Some("The channel value")
                 )

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentTesterBaseWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentTesterBaseWriter.scala
@@ -810,7 +810,7 @@ case class ComponentTesterBaseWriter(
           event.aNode._2.data.params.flatMap(aNode => {
             val data = aNode._2.data
             val name = data.name
-            val tn = writeEventParamType(data)
+            val tn = writeEventParamType(data, "Fw::LogStringArg")
             val paramType = s.a.typeMap(data.typeName.id)
             val serializedSizeExpr = s.getSerializedSizeExpr(paramType, tn)
 
@@ -943,7 +943,7 @@ case class ComponentTesterBaseWriter(
         formalParamsCppWriter.write(
           event.aNode._2.data.params,
           Nil,
-          Some("Fw::LogStringArg"),
+          Some("Fw::StringBase"),
           FormalParamsCppWriter.Value
         ),
         CppDoc.Type("void"),

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.cpp
@@ -2541,8 +2541,8 @@ void ActiveEventsComponentBase ::
 
 void ActiveEventsComponentBase ::
   log_COMMAND_EventCommand(
-      const Fw::LogStringArg& str1,
-      const Fw::LogStringArg& str2
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
   )
 {
   // Get the time
@@ -2569,13 +2569,13 @@ void ActiveEventsComponentBase ::
     );
 #endif
 
-    _status = str1.serialize(_logBuff, 80);
+    _status = str1.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 80));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = str2.serialize(_logBuff, 100);
+    _status = str2.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 100));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.hpp
@@ -1056,8 +1056,8 @@ class ActiveEventsComponentBase :
     //!
     //! A command event with string params
     void log_COMMAND_EventCommand(
-        const Fw::LogStringArg& str1, //!< A string
-        const Fw::LogStringArg& str2 //!< Another string
+        const Fw::StringBase& str1, //!< A string
+        const Fw::StringBase& str2 //!< Another string
     );
 
     //! Log event EventDiagnostic

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
@@ -4804,8 +4804,8 @@ void ActiveSerialComponentBase ::
 
 void ActiveSerialComponentBase ::
   log_COMMAND_EventCommand(
-      const Fw::LogStringArg& str1,
-      const Fw::LogStringArg& str2
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
   )
 {
   // Get the time
@@ -4832,13 +4832,13 @@ void ActiveSerialComponentBase ::
     );
 #endif
 
-    _status = str1.serialize(_logBuff, 80);
+    _status = str1.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 80));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = str2.serialize(_logBuff, 100);
+    _status = str2.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 100));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
@@ -5360,7 +5360,7 @@ void ActiveSerialComponentBase ::
 
 void ActiveSerialComponentBase ::
   tlmWrite_ChannelStringFormat(
-      const Fw::TlmString& arg,
+      const Fw::StringBase& arg,
       Fw::Time _tlmTime
   )
 {
@@ -5373,7 +5373,7 @@ void ActiveSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = arg.serialize(_tlmBuff, 80);
+    Fw::SerializeStatus _stat = arg.serialize(_tlmBuff, FW_MIN(FW_TLM_STRING_MAX_SIZE, 80));
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.hpp
@@ -1866,8 +1866,8 @@ class ActiveSerialComponentBase :
     //!
     //! A command event with string params
     void log_COMMAND_EventCommand(
-        const Fw::LogStringArg& str1, //!< A string
-        const Fw::LogStringArg& str2 //!< Another string
+        const Fw::StringBase& str1, //!< A string
+        const Fw::StringBase& str2 //!< Another string
     );
 
     //! Log event EventDiagnostic

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.hpp
@@ -1937,7 +1937,7 @@ class ActiveSerialComponentBase :
     //!
     //! A telemetry channel with string data with format string
     void tlmWrite_ChannelStringFormat(
-        const Fw::TlmString& arg, //!< The telemetry value
+        const Fw::StringBase& arg, //!< The telemetry value
         Fw::Time _tlmTime = Fw::Time() //!< Timestamp. Default: unspecified, request from getTime port
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.cpp
@@ -2405,7 +2405,7 @@ void ActiveTelemetryComponentBase ::
 
 void ActiveTelemetryComponentBase ::
   tlmWrite_ChannelStringFormat(
-      const Fw::TlmString& arg,
+      const Fw::StringBase& arg,
       Fw::Time _tlmTime
   )
 {
@@ -2418,7 +2418,7 @@ void ActiveTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = arg.serialize(_tlmBuff, 80);
+    Fw::SerializeStatus _stat = arg.serialize(_tlmBuff, FW_MIN(FW_TLM_STRING_MAX_SIZE, 80));
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.hpp
@@ -1055,7 +1055,7 @@ class ActiveTelemetryComponentBase :
     //!
     //! A telemetry channel with string data with format string
     void tlmWrite_ChannelStringFormat(
-        const Fw::TlmString& arg, //!< The telemetry value
+        const Fw::StringBase& arg, //!< The telemetry value
         Fw::Time _tlmTime = Fw::Time() //!< Timestamp. Default: unspecified, request from getTime port
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
@@ -5240,7 +5240,7 @@ namespace M {
 
   void ActiveTestComponentBase ::
     tlmWrite_ChannelStringFormat(
-        const Fw::TlmString& arg,
+        const Fw::StringBase& arg,
         Fw::Time _tlmTime
     )
   {
@@ -5253,7 +5253,7 @@ namespace M {
       }
 
       Fw::TlmBuffer _tlmBuff;
-      Fw::SerializeStatus _stat = arg.serialize(_tlmBuff, 80);
+      Fw::SerializeStatus _stat = arg.serialize(_tlmBuff, FW_MIN(FW_TLM_STRING_MAX_SIZE, 80));
       FW_ASSERT(
         _stat == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_stat)

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
@@ -4684,8 +4684,8 @@ namespace M {
 
   void ActiveTestComponentBase ::
     log_COMMAND_EventCommand(
-        const Fw::LogStringArg& str1,
-        const Fw::LogStringArg& str2
+        const Fw::StringBase& str1,
+        const Fw::StringBase& str2
     )
   {
     // Get the time
@@ -4712,13 +4712,13 @@ namespace M {
       );
 #endif
 
-      _status = str1.serialize(_logBuff, 80);
+      _status = str1.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 80));
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
 
-      _status = str2.serialize(_logBuff, 100);
+      _status = str2.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 100));
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.hpp
@@ -1901,7 +1901,7 @@ namespace M {
       //!
       //! A telemetry channel with string data with format string
       void tlmWrite_ChannelStringFormat(
-          const Fw::TlmString& arg, //!< The telemetry value
+          const Fw::StringBase& arg, //!< The telemetry value
           Fw::Time _tlmTime = Fw::Time() //!< Timestamp. Default: unspecified, request from getTime port
       );
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.hpp
@@ -1830,8 +1830,8 @@ namespace M {
       //!
       //! A command event with string params
       void log_COMMAND_EventCommand(
-          const Fw::LogStringArg& str1, //!< A string
-          const Fw::LogStringArg& str2 //!< Another string
+          const Fw::StringBase& str1, //!< A string
+          const Fw::StringBase& str2 //!< Another string
       );
 
       //! Log event EventDiagnostic

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveEventsComponentAc.ref.cpp
@@ -1722,8 +1722,8 @@ void PassiveEventsComponentBase ::
 
 void PassiveEventsComponentBase ::
   log_COMMAND_EventCommand(
-      const Fw::LogStringArg& str1,
-      const Fw::LogStringArg& str2
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
   )
 {
   // Get the time
@@ -1750,13 +1750,13 @@ void PassiveEventsComponentBase ::
     );
 #endif
 
-    _status = str1.serialize(_logBuff, 80);
+    _status = str1.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 80));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = str2.serialize(_logBuff, 100);
+    _status = str2.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 100));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveEventsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveEventsComponentAc.ref.hpp
@@ -821,8 +821,8 @@ class PassiveEventsComponentBase :
     //!
     //! A command event with string params
     void log_COMMAND_EventCommand(
-        const Fw::LogStringArg& str1, //!< A string
-        const Fw::LogStringArg& str2 //!< Another string
+        const Fw::StringBase& str1, //!< A string
+        const Fw::StringBase& str2 //!< Another string
     );
 
     //! Log event EventDiagnostic

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
@@ -2891,8 +2891,8 @@ void PassiveSerialComponentBase ::
 
 void PassiveSerialComponentBase ::
   log_COMMAND_EventCommand(
-      const Fw::LogStringArg& str1,
-      const Fw::LogStringArg& str2
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
   )
 {
   // Get the time
@@ -2919,13 +2919,13 @@ void PassiveSerialComponentBase ::
     );
 #endif
 
-    _status = str1.serialize(_logBuff, 80);
+    _status = str1.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 80));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = str2.serialize(_logBuff, 100);
+    _status = str2.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 100));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
@@ -3447,7 +3447,7 @@ void PassiveSerialComponentBase ::
 
 void PassiveSerialComponentBase ::
   tlmWrite_ChannelStringFormat(
-      const Fw::TlmString& arg,
+      const Fw::StringBase& arg,
       Fw::Time _tlmTime
   )
 {
@@ -3460,7 +3460,7 @@ void PassiveSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = arg.serialize(_tlmBuff, 80);
+    Fw::SerializeStatus _stat = arg.serialize(_tlmBuff, FW_MIN(FW_TLM_STRING_MAX_SIZE, 80));
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.hpp
@@ -1360,7 +1360,7 @@ class PassiveSerialComponentBase :
     //!
     //! A telemetry channel with string data with format string
     void tlmWrite_ChannelStringFormat(
-        const Fw::TlmString& arg, //!< The telemetry value
+        const Fw::StringBase& arg, //!< The telemetry value
         Fw::Time _tlmTime = Fw::Time() //!< Timestamp. Default: unspecified, request from getTime port
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.hpp
@@ -1289,8 +1289,8 @@ class PassiveSerialComponentBase :
     //!
     //! A command event with string params
     void log_COMMAND_EventCommand(
-        const Fw::LogStringArg& str1, //!< A string
-        const Fw::LogStringArg& str2 //!< Another string
+        const Fw::StringBase& str1, //!< A string
+        const Fw::StringBase& str2 //!< Another string
     );
 
     //! Log event EventDiagnostic

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTelemetryComponentAc.ref.cpp
@@ -1586,7 +1586,7 @@ void PassiveTelemetryComponentBase ::
 
 void PassiveTelemetryComponentBase ::
   tlmWrite_ChannelStringFormat(
-      const Fw::TlmString& arg,
+      const Fw::StringBase& arg,
       Fw::Time _tlmTime
   )
 {
@@ -1599,7 +1599,7 @@ void PassiveTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = arg.serialize(_tlmBuff, 80);
+    Fw::SerializeStatus _stat = arg.serialize(_tlmBuff, FW_MIN(FW_TLM_STRING_MAX_SIZE, 80));
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTelemetryComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTelemetryComponentAc.ref.hpp
@@ -820,7 +820,7 @@ class PassiveTelemetryComponentBase :
     //!
     //! A telemetry channel with string data with format string
     void tlmWrite_ChannelStringFormat(
-        const Fw::TlmString& arg, //!< The telemetry value
+        const Fw::StringBase& arg, //!< The telemetry value
         Fw::Time _tlmTime = Fw::Time() //!< Timestamp. Default: unspecified, request from getTime port
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
@@ -3142,8 +3142,8 @@ void PassiveTestComponentBase ::
 
 void PassiveTestComponentBase ::
   log_COMMAND_EventCommand(
-      const Fw::LogStringArg& str1,
-      const Fw::LogStringArg& str2
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
   )
 {
   // Get the time
@@ -3170,13 +3170,13 @@ void PassiveTestComponentBase ::
     );
 #endif
 
-    _status = str1.serialize(_logBuff, 80);
+    _status = str1.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 80));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = str2.serialize(_logBuff, 100);
+    _status = str2.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 100));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
@@ -3698,7 +3698,7 @@ void PassiveTestComponentBase ::
 
 void PassiveTestComponentBase ::
   tlmWrite_ChannelStringFormat(
-      const Fw::TlmString& arg,
+      const Fw::StringBase& arg,
       Fw::Time _tlmTime
   )
 {
@@ -3711,7 +3711,7 @@ void PassiveTestComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = arg.serialize(_tlmBuff, 80);
+    Fw::SerializeStatus _stat = arg.serialize(_tlmBuff, FW_MIN(FW_TLM_STRING_MAX_SIZE, 80));
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.hpp
@@ -1386,8 +1386,8 @@ class PassiveTestComponentBase :
     //!
     //! A command event with string params
     void log_COMMAND_EventCommand(
-        const Fw::LogStringArg& str1, //!< A string
-        const Fw::LogStringArg& str2 //!< Another string
+        const Fw::StringBase& str1, //!< A string
+        const Fw::StringBase& str2 //!< Another string
     );
 
     //! Log event EventDiagnostic

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.hpp
@@ -1457,7 +1457,7 @@ class PassiveTestComponentBase :
     //!
     //! A telemetry channel with string data with format string
     void tlmWrite_ChannelStringFormat(
-        const Fw::TlmString& arg, //!< The telemetry value
+        const Fw::StringBase& arg, //!< The telemetry value
         Fw::Time _tlmTime = Fw::Time() //!< Timestamp. Default: unspecified, request from getTime port
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.cpp
@@ -2541,8 +2541,8 @@ void QueuedEventsComponentBase ::
 
 void QueuedEventsComponentBase ::
   log_COMMAND_EventCommand(
-      const Fw::LogStringArg& str1,
-      const Fw::LogStringArg& str2
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
   )
 {
   // Get the time
@@ -2569,13 +2569,13 @@ void QueuedEventsComponentBase ::
     );
 #endif
 
-    _status = str1.serialize(_logBuff, 80);
+    _status = str1.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 80));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = str2.serialize(_logBuff, 100);
+    _status = str2.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 100));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.hpp
@@ -1056,8 +1056,8 @@ class QueuedEventsComponentBase :
     //!
     //! A command event with string params
     void log_COMMAND_EventCommand(
-        const Fw::LogStringArg& str1, //!< A string
-        const Fw::LogStringArg& str2 //!< Another string
+        const Fw::StringBase& str1, //!< A string
+        const Fw::StringBase& str2 //!< Another string
     );
 
     //! Log event EventDiagnostic

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
@@ -4804,8 +4804,8 @@ void QueuedSerialComponentBase ::
 
 void QueuedSerialComponentBase ::
   log_COMMAND_EventCommand(
-      const Fw::LogStringArg& str1,
-      const Fw::LogStringArg& str2
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
   )
 {
   // Get the time
@@ -4832,13 +4832,13 @@ void QueuedSerialComponentBase ::
     );
 #endif
 
-    _status = str1.serialize(_logBuff, 80);
+    _status = str1.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 80));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = str2.serialize(_logBuff, 100);
+    _status = str2.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 100));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
@@ -5360,7 +5360,7 @@ void QueuedSerialComponentBase ::
 
 void QueuedSerialComponentBase ::
   tlmWrite_ChannelStringFormat(
-      const Fw::TlmString& arg,
+      const Fw::StringBase& arg,
       Fw::Time _tlmTime
   )
 {
@@ -5373,7 +5373,7 @@ void QueuedSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = arg.serialize(_tlmBuff, 80);
+    Fw::SerializeStatus _stat = arg.serialize(_tlmBuff, FW_MIN(FW_TLM_STRING_MAX_SIZE, 80));
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.hpp
@@ -1937,7 +1937,7 @@ class QueuedSerialComponentBase :
     //!
     //! A telemetry channel with string data with format string
     void tlmWrite_ChannelStringFormat(
-        const Fw::TlmString& arg, //!< The telemetry value
+        const Fw::StringBase& arg, //!< The telemetry value
         Fw::Time _tlmTime = Fw::Time() //!< Timestamp. Default: unspecified, request from getTime port
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.hpp
@@ -1866,8 +1866,8 @@ class QueuedSerialComponentBase :
     //!
     //! A command event with string params
     void log_COMMAND_EventCommand(
-        const Fw::LogStringArg& str1, //!< A string
-        const Fw::LogStringArg& str2 //!< Another string
+        const Fw::StringBase& str1, //!< A string
+        const Fw::StringBase& str2 //!< Another string
     );
 
     //! Log event EventDiagnostic

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.cpp
@@ -2405,7 +2405,7 @@ void QueuedTelemetryComponentBase ::
 
 void QueuedTelemetryComponentBase ::
   tlmWrite_ChannelStringFormat(
-      const Fw::TlmString& arg,
+      const Fw::StringBase& arg,
       Fw::Time _tlmTime
   )
 {
@@ -2418,7 +2418,7 @@ void QueuedTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = arg.serialize(_tlmBuff, 80);
+    Fw::SerializeStatus _stat = arg.serialize(_tlmBuff, FW_MIN(FW_TLM_STRING_MAX_SIZE, 80));
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.hpp
@@ -1055,7 +1055,7 @@ class QueuedTelemetryComponentBase :
     //!
     //! A telemetry channel with string data with format string
     void tlmWrite_ChannelStringFormat(
-        const Fw::TlmString& arg, //!< The telemetry value
+        const Fw::StringBase& arg, //!< The telemetry value
         Fw::Time _tlmTime = Fw::Time() //!< Timestamp. Default: unspecified, request from getTime port
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
@@ -5238,7 +5238,7 @@ void QueuedTestComponentBase ::
 
 void QueuedTestComponentBase ::
   tlmWrite_ChannelStringFormat(
-      const Fw::TlmString& arg,
+      const Fw::StringBase& arg,
       Fw::Time _tlmTime
   )
 {
@@ -5251,7 +5251,7 @@ void QueuedTestComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = arg.serialize(_tlmBuff, 80);
+    Fw::SerializeStatus _stat = arg.serialize(_tlmBuff, FW_MIN(FW_TLM_STRING_MAX_SIZE, 80));
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
@@ -4682,8 +4682,8 @@ void QueuedTestComponentBase ::
 
 void QueuedTestComponentBase ::
   log_COMMAND_EventCommand(
-      const Fw::LogStringArg& str1,
-      const Fw::LogStringArg& str2
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
   )
 {
   // Get the time
@@ -4710,13 +4710,13 @@ void QueuedTestComponentBase ::
     );
 #endif
 
-    _status = str1.serialize(_logBuff, 80);
+    _status = str1.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 80));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = str2.serialize(_logBuff, 100);
+    _status = str2.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 100));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.hpp
@@ -1828,8 +1828,8 @@ class QueuedTestComponentBase :
     //!
     //! A command event with string params
     void log_COMMAND_EventCommand(
-        const Fw::LogStringArg& str1, //!< A string
-        const Fw::LogStringArg& str2 //!< Another string
+        const Fw::StringBase& str1, //!< A string
+        const Fw::StringBase& str2 //!< Another string
     );
 
     //! Log event EventDiagnostic

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.hpp
@@ -1899,7 +1899,7 @@ class QueuedTestComponentBase :
     //!
     //! A telemetry channel with string data with format string
     void tlmWrite_ChannelStringFormat(
-        const Fw::TlmString& arg, //!< The telemetry value
+        const Fw::StringBase& arg, //!< The telemetry value
         Fw::Time _tlmTime = Fw::Time() //!< Timestamp. Default: unspecified, request from getTime port
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsTesterBase.ref.cpp
@@ -1678,8 +1678,8 @@ void ActiveCommandsTesterBase ::
   sendCmd_CMD_SYNC_STRING(
       const FwEnumStoreType instance,
       U32 cmdSeq,
-      const Fw::CmdStringArg& str1,
-      const Fw::CmdStringArg& str2
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
   )
 {
   // Serialize arguments
@@ -1894,8 +1894,8 @@ void ActiveCommandsTesterBase ::
   sendCmd_CMD_GUARDED_STRING(
       const FwEnumStoreType instance,
       U32 cmdSeq,
-      const Fw::CmdStringArg& str1,
-      const Fw::CmdStringArg& str2
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
   )
 {
   // Serialize arguments

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsTesterBase.ref.cpp
@@ -1686,13 +1686,13 @@ void ActiveCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(str1);
+  _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(str2);
+  _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -1902,13 +1902,13 @@ void ActiveCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(str1);
+  _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(str2);
+  _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsTesterBase.ref.hpp
@@ -836,8 +836,8 @@ class ActiveCommandsTesterBase :
     void sendCmd_CMD_SYNC_STRING(
         const FwEnumStoreType instance, //!< The instance number
         U32 cmdSeq, //!< The command sequence number
-        const Fw::CmdStringArg& str1, //!< A string
-        const Fw::CmdStringArg& str2 //!< Another string
+        const Fw::StringBase& str1, //!< A string
+        const Fw::StringBase& str2 //!< Another string
     );
 
     //! Send a CMD_SYNC_ENUM command
@@ -880,8 +880,8 @@ class ActiveCommandsTesterBase :
     void sendCmd_CMD_GUARDED_STRING(
         const FwEnumStoreType instance, //!< The instance number
         U32 cmdSeq, //!< The command sequence number
-        const Fw::CmdStringArg& str1, //!< A string
-        const Fw::CmdStringArg& str2 //!< Another string
+        const Fw::StringBase& str1, //!< A string
+        const Fw::StringBase& str2 //!< Another string
     );
 
     //! Send a CMD_GUARDED_ENUM command

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsTesterBase.ref.cpp
@@ -1917,8 +1917,8 @@ void ActiveEventsTesterBase ::
 
 void ActiveEventsTesterBase ::
   logIn_COMMAND_EventCommand(
-      const Fw::LogStringArg& str1,
-      const Fw::LogStringArg& str2
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
   )
 {
   EventEntry_EventCommand _e = {

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsTesterBase.ref.hpp
@@ -868,8 +868,8 @@ class ActiveEventsTesterBase :
 
     //! Handle event EventCommand
     virtual void logIn_COMMAND_EventCommand(
-        const Fw::LogStringArg& str1, //!< A string
-        const Fw::LogStringArg& str2 //!< Another string
+        const Fw::StringBase& str1, //!< A string
+        const Fw::StringBase& str2 //!< Another string
     );
 
     //! Handle event EventDiagnostic

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsTesterBase.ref.cpp
@@ -1779,7 +1779,7 @@ void ActiveParamsTesterBase ::
 
 void ActiveParamsTesterBase ::
   paramSet_ParamString(
-      const Fw::ParamString& val,
+      const Fw::StringBase& val,
       Fw::ParamValid valid
   )
 {

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsTesterBase.ref.hpp
@@ -861,7 +861,7 @@ class ActiveParamsTesterBase :
 
     //! Set parameter ParamString
     void paramSet_ParamString(
-        const Fw::ParamString& val, //!< The parameter value
+        const Fw::StringBase& val, //!< The parameter value
         Fw::ParamValid valid //!< The parameter valid flag
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.cpp
@@ -2320,8 +2320,8 @@ void ActiveSerialTesterBase ::
   sendCmd_CMD_SYNC_STRING(
       const FwEnumStoreType instance,
       U32 cmdSeq,
-      const Fw::CmdStringArg& str1,
-      const Fw::CmdStringArg& str2
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
   )
 {
   // Serialize arguments
@@ -2536,8 +2536,8 @@ void ActiveSerialTesterBase ::
   sendCmd_CMD_GUARDED_STRING(
       const FwEnumStoreType instance,
       U32 cmdSeq,
-      const Fw::CmdStringArg& str1,
-      const Fw::CmdStringArg& str2
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
   )
 {
   // Serialize arguments

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.cpp
@@ -3392,7 +3392,7 @@ void ActiveSerialTesterBase ::
 void ActiveSerialTesterBase ::
   tlmInput_ChannelU32Format(
       const Fw::Time& timeTag,
-      const U32& val
+      const U32 val
   )
 {
   TlmEntry_ChannelU32Format e = { timeTag, val };
@@ -3403,7 +3403,7 @@ void ActiveSerialTesterBase ::
 void ActiveSerialTesterBase ::
   tlmInput_ChannelF32Format(
       const Fw::Time& timeTag,
-      const F32& val
+      const F32 val
   )
 {
   TlmEntry_ChannelF32Format e = { timeTag, val };
@@ -3414,7 +3414,7 @@ void ActiveSerialTesterBase ::
 void ActiveSerialTesterBase ::
   tlmInput_ChannelStringFormat(
       const Fw::Time& timeTag,
-      const Fw::TlmString& val
+      const Fw::StringBase& val
   )
 {
   TlmEntry_ChannelStringFormat e = { timeTag, val };
@@ -3458,7 +3458,7 @@ void ActiveSerialTesterBase ::
 void ActiveSerialTesterBase ::
   tlmInput_ChannelU32Limits(
       const Fw::Time& timeTag,
-      const U32& val
+      const U32 val
   )
 {
   TlmEntry_ChannelU32Limits e = { timeTag, val };
@@ -3469,7 +3469,7 @@ void ActiveSerialTesterBase ::
 void ActiveSerialTesterBase ::
   tlmInput_ChannelF32Limits(
       const Fw::Time& timeTag,
-      const F32& val
+      const F32 val
   )
 {
   TlmEntry_ChannelF32Limits e = { timeTag, val };
@@ -3480,7 +3480,7 @@ void ActiveSerialTesterBase ::
 void ActiveSerialTesterBase ::
   tlmInput_ChannelF64(
       const Fw::Time& timeTag,
-      const F64& val
+      const F64 val
   )
 {
   TlmEntry_ChannelF64 e = { timeTag, val };
@@ -3491,7 +3491,7 @@ void ActiveSerialTesterBase ::
 void ActiveSerialTesterBase ::
   tlmInput_ChannelU32OnChange(
       const Fw::Time& timeTag,
-      const U32& val
+      const U32 val
   )
 {
   TlmEntry_ChannelU32OnChange e = { timeTag, val };

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.cpp
@@ -2328,13 +2328,13 @@ void ActiveSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(str1);
+  _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(str2);
+  _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2544,13 +2544,13 @@ void ActiveSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(str1);
+  _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(str2);
+  _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.cpp
@@ -3173,8 +3173,8 @@ void ActiveSerialTesterBase ::
 
 void ActiveSerialTesterBase ::
   logIn_COMMAND_EventCommand(
-      const Fw::LogStringArg& str1,
-      const Fw::LogStringArg& str2
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
   )
 {
   EventEntry_EventCommand _e = {

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.cpp
@@ -3634,7 +3634,7 @@ void ActiveSerialTesterBase ::
 
 void ActiveSerialTesterBase ::
   paramSet_ParamString(
-      const Fw::ParamString& val,
+      const Fw::StringBase& val,
       Fw::ParamValid valid
   )
 {

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.hpp
@@ -1401,7 +1401,7 @@ class ActiveSerialTesterBase :
 
     //! Set parameter ParamString
     void paramSet_ParamString(
-        const Fw::ParamString& val, //!< The parameter value
+        const Fw::StringBase& val, //!< The parameter value
         Fw::ParamValid valid //!< The parameter valid flag
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.hpp
@@ -1294,19 +1294,19 @@ class ActiveSerialTesterBase :
     //! Handle channel ChannelU32Format
     void tlmInput_ChannelU32Format(
         const Fw::Time& timeTag, //!< The time
-        const U32& val //!< The channel value
+        const U32 val //!< The channel value
     );
 
     //! Handle channel ChannelF32Format
     void tlmInput_ChannelF32Format(
         const Fw::Time& timeTag, //!< The time
-        const F32& val //!< The channel value
+        const F32 val //!< The channel value
     );
 
     //! Handle channel ChannelStringFormat
     void tlmInput_ChannelStringFormat(
         const Fw::Time& timeTag, //!< The time
-        const Fw::TlmString& val //!< The channel value
+        const Fw::StringBase& val //!< The channel value
     );
 
     //! Handle channel ChannelEnum
@@ -1330,25 +1330,25 @@ class ActiveSerialTesterBase :
     //! Handle channel ChannelU32Limits
     void tlmInput_ChannelU32Limits(
         const Fw::Time& timeTag, //!< The time
-        const U32& val //!< The channel value
+        const U32 val //!< The channel value
     );
 
     //! Handle channel ChannelF32Limits
     void tlmInput_ChannelF32Limits(
         const Fw::Time& timeTag, //!< The time
-        const F32& val //!< The channel value
+        const F32 val //!< The channel value
     );
 
     //! Handle channel ChannelF64
     void tlmInput_ChannelF64(
         const Fw::Time& timeTag, //!< The time
-        const F64& val //!< The channel value
+        const F64 val //!< The channel value
     );
 
     //! Handle channel ChannelU32OnChange
     void tlmInput_ChannelU32OnChange(
         const Fw::Time& timeTag, //!< The time
-        const U32& val //!< The channel value
+        const U32 val //!< The channel value
     );
 
     //! Handle channel ChannelEnumOnChange

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.hpp
@@ -1117,8 +1117,8 @@ class ActiveSerialTesterBase :
     void sendCmd_CMD_SYNC_STRING(
         const FwEnumStoreType instance, //!< The instance number
         U32 cmdSeq, //!< The command sequence number
-        const Fw::CmdStringArg& str1, //!< A string
-        const Fw::CmdStringArg& str2 //!< Another string
+        const Fw::StringBase& str1, //!< A string
+        const Fw::StringBase& str2 //!< Another string
     );
 
     //! Send a CMD_SYNC_ENUM command
@@ -1161,8 +1161,8 @@ class ActiveSerialTesterBase :
     void sendCmd_CMD_GUARDED_STRING(
         const FwEnumStoreType instance, //!< The instance number
         U32 cmdSeq, //!< The command sequence number
-        const Fw::CmdStringArg& str1, //!< A string
-        const Fw::CmdStringArg& str2 //!< Another string
+        const Fw::StringBase& str1, //!< A string
+        const Fw::StringBase& str2 //!< Another string
     );
 
     //! Send a CMD_GUARDED_ENUM command

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.hpp
@@ -1256,8 +1256,8 @@ class ActiveSerialTesterBase :
 
     //! Handle event EventCommand
     virtual void logIn_COMMAND_EventCommand(
-        const Fw::LogStringArg& str1, //!< A string
-        const Fw::LogStringArg& str2 //!< Another string
+        const Fw::StringBase& str1, //!< A string
+        const Fw::StringBase& str2 //!< Another string
     );
 
     //! Handle event EventDiagnostic

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryTesterBase.ref.cpp
@@ -1712,7 +1712,7 @@ void ActiveTelemetryTesterBase ::
 void ActiveTelemetryTesterBase ::
   tlmInput_ChannelU32Format(
       const Fw::Time& timeTag,
-      const U32& val
+      const U32 val
   )
 {
   TlmEntry_ChannelU32Format e = { timeTag, val };
@@ -1723,7 +1723,7 @@ void ActiveTelemetryTesterBase ::
 void ActiveTelemetryTesterBase ::
   tlmInput_ChannelF32Format(
       const Fw::Time& timeTag,
-      const F32& val
+      const F32 val
   )
 {
   TlmEntry_ChannelF32Format e = { timeTag, val };
@@ -1734,7 +1734,7 @@ void ActiveTelemetryTesterBase ::
 void ActiveTelemetryTesterBase ::
   tlmInput_ChannelStringFormat(
       const Fw::Time& timeTag,
-      const Fw::TlmString& val
+      const Fw::StringBase& val
   )
 {
   TlmEntry_ChannelStringFormat e = { timeTag, val };
@@ -1778,7 +1778,7 @@ void ActiveTelemetryTesterBase ::
 void ActiveTelemetryTesterBase ::
   tlmInput_ChannelU32Limits(
       const Fw::Time& timeTag,
-      const U32& val
+      const U32 val
   )
 {
   TlmEntry_ChannelU32Limits e = { timeTag, val };
@@ -1789,7 +1789,7 @@ void ActiveTelemetryTesterBase ::
 void ActiveTelemetryTesterBase ::
   tlmInput_ChannelF32Limits(
       const Fw::Time& timeTag,
-      const F32& val
+      const F32 val
   )
 {
   TlmEntry_ChannelF32Limits e = { timeTag, val };
@@ -1800,7 +1800,7 @@ void ActiveTelemetryTesterBase ::
 void ActiveTelemetryTesterBase ::
   tlmInput_ChannelF64(
       const Fw::Time& timeTag,
-      const F64& val
+      const F64 val
   )
 {
   TlmEntry_ChannelF64 e = { timeTag, val };
@@ -1811,7 +1811,7 @@ void ActiveTelemetryTesterBase ::
 void ActiveTelemetryTesterBase ::
   tlmInput_ChannelU32OnChange(
       const Fw::Time& timeTag,
-      const U32& val
+      const U32 val
   )
 {
   TlmEntry_ChannelU32OnChange e = { timeTag, val };

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryTesterBase.ref.hpp
@@ -872,19 +872,19 @@ class ActiveTelemetryTesterBase :
     //! Handle channel ChannelU32Format
     void tlmInput_ChannelU32Format(
         const Fw::Time& timeTag, //!< The time
-        const U32& val //!< The channel value
+        const U32 val //!< The channel value
     );
 
     //! Handle channel ChannelF32Format
     void tlmInput_ChannelF32Format(
         const Fw::Time& timeTag, //!< The time
-        const F32& val //!< The channel value
+        const F32 val //!< The channel value
     );
 
     //! Handle channel ChannelStringFormat
     void tlmInput_ChannelStringFormat(
         const Fw::Time& timeTag, //!< The time
-        const Fw::TlmString& val //!< The channel value
+        const Fw::StringBase& val //!< The channel value
     );
 
     //! Handle channel ChannelEnum
@@ -908,25 +908,25 @@ class ActiveTelemetryTesterBase :
     //! Handle channel ChannelU32Limits
     void tlmInput_ChannelU32Limits(
         const Fw::Time& timeTag, //!< The time
-        const U32& val //!< The channel value
+        const U32 val //!< The channel value
     );
 
     //! Handle channel ChannelF32Limits
     void tlmInput_ChannelF32Limits(
         const Fw::Time& timeTag, //!< The time
-        const F32& val //!< The channel value
+        const F32 val //!< The channel value
     );
 
     //! Handle channel ChannelF64
     void tlmInput_ChannelF64(
         const Fw::Time& timeTag, //!< The time
-        const F64& val //!< The channel value
+        const F64 val //!< The channel value
     );
 
     //! Handle channel ChannelU32OnChange
     void tlmInput_ChannelU32OnChange(
         const Fw::Time& timeTag, //!< The time
-        const U32& val //!< The channel value
+        const U32 val //!< The channel value
     );
 
     //! Handle channel ChannelEnumOnChange

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.cpp
@@ -3066,7 +3066,7 @@ namespace M {
   void ActiveTestTesterBase ::
     tlmInput_ChannelU32Format(
         const Fw::Time& timeTag,
-        const U32& val
+        const U32 val
     )
   {
     TlmEntry_ChannelU32Format e = { timeTag, val };
@@ -3077,7 +3077,7 @@ namespace M {
   void ActiveTestTesterBase ::
     tlmInput_ChannelF32Format(
         const Fw::Time& timeTag,
-        const F32& val
+        const F32 val
     )
   {
     TlmEntry_ChannelF32Format e = { timeTag, val };
@@ -3088,7 +3088,7 @@ namespace M {
   void ActiveTestTesterBase ::
     tlmInput_ChannelStringFormat(
         const Fw::Time& timeTag,
-        const Fw::TlmString& val
+        const Fw::StringBase& val
     )
   {
     TlmEntry_ChannelStringFormat e = { timeTag, val };
@@ -3132,7 +3132,7 @@ namespace M {
   void ActiveTestTesterBase ::
     tlmInput_ChannelU32Limits(
         const Fw::Time& timeTag,
-        const U32& val
+        const U32 val
     )
   {
     TlmEntry_ChannelU32Limits e = { timeTag, val };
@@ -3143,7 +3143,7 @@ namespace M {
   void ActiveTestTesterBase ::
     tlmInput_ChannelF32Limits(
         const Fw::Time& timeTag,
-        const F32& val
+        const F32 val
     )
   {
     TlmEntry_ChannelF32Limits e = { timeTag, val };
@@ -3154,7 +3154,7 @@ namespace M {
   void ActiveTestTesterBase ::
     tlmInput_ChannelF64(
         const Fw::Time& timeTag,
-        const F64& val
+        const F64 val
     )
   {
     TlmEntry_ChannelF64 e = { timeTag, val };
@@ -3165,7 +3165,7 @@ namespace M {
   void ActiveTestTesterBase ::
     tlmInput_ChannelU32OnChange(
         const Fw::Time& timeTag,
-        const U32& val
+        const U32 val
     )
   {
     TlmEntry_ChannelU32OnChange e = { timeTag, val };

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.cpp
@@ -1994,8 +1994,8 @@ namespace M {
     sendCmd_CMD_SYNC_STRING(
         const FwEnumStoreType instance,
         U32 cmdSeq,
-        const Fw::CmdStringArg& str1,
-        const Fw::CmdStringArg& str2
+        const Fw::StringBase& str1,
+        const Fw::StringBase& str2
     )
   {
     // Serialize arguments
@@ -2210,8 +2210,8 @@ namespace M {
     sendCmd_CMD_GUARDED_STRING(
         const FwEnumStoreType instance,
         U32 cmdSeq,
-        const Fw::CmdStringArg& str1,
-        const Fw::CmdStringArg& str2
+        const Fw::StringBase& str1,
+        const Fw::StringBase& str2
     )
   {
     // Serialize arguments

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.cpp
@@ -2847,8 +2847,8 @@ namespace M {
 
   void ActiveTestTesterBase ::
     logIn_COMMAND_EventCommand(
-        const Fw::LogStringArg& str1,
-        const Fw::LogStringArg& str2
+        const Fw::StringBase& str1,
+        const Fw::StringBase& str2
     )
   {
     EventEntry_EventCommand _e = {

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.cpp
@@ -3308,7 +3308,7 @@ namespace M {
 
   void ActiveTestTesterBase ::
     paramSet_ParamString(
-        const Fw::ParamString& val,
+        const Fw::StringBase& val,
         Fw::ParamValid valid
     )
   {

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.cpp
@@ -2002,13 +2002,13 @@ namespace M {
     Fw::CmdArgBuffer buf;
     Fw::SerializeStatus _status;
 
-    _status = buf.serialize(str1);
+    _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = buf.serialize(str2);
+    _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -2218,13 +2218,13 @@ namespace M {
     Fw::CmdArgBuffer buf;
     Fw::SerializeStatus _status;
 
-    _status = buf.serialize(str1);
+    _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = buf.serialize(str2);
+    _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.hpp
@@ -1283,7 +1283,7 @@ namespace M {
 
       //! Set parameter ParamString
       void paramSet_ParamString(
-          const Fw::ParamString& val, //!< The parameter value
+          const Fw::StringBase& val, //!< The parameter value
           Fw::ParamValid valid //!< The parameter valid flag
       );
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.hpp
@@ -1176,19 +1176,19 @@ namespace M {
       //! Handle channel ChannelU32Format
       void tlmInput_ChannelU32Format(
           const Fw::Time& timeTag, //!< The time
-          const U32& val //!< The channel value
+          const U32 val //!< The channel value
       );
 
       //! Handle channel ChannelF32Format
       void tlmInput_ChannelF32Format(
           const Fw::Time& timeTag, //!< The time
-          const F32& val //!< The channel value
+          const F32 val //!< The channel value
       );
 
       //! Handle channel ChannelStringFormat
       void tlmInput_ChannelStringFormat(
           const Fw::Time& timeTag, //!< The time
-          const Fw::TlmString& val //!< The channel value
+          const Fw::StringBase& val //!< The channel value
       );
 
       //! Handle channel ChannelEnum
@@ -1212,25 +1212,25 @@ namespace M {
       //! Handle channel ChannelU32Limits
       void tlmInput_ChannelU32Limits(
           const Fw::Time& timeTag, //!< The time
-          const U32& val //!< The channel value
+          const U32 val //!< The channel value
       );
 
       //! Handle channel ChannelF32Limits
       void tlmInput_ChannelF32Limits(
           const Fw::Time& timeTag, //!< The time
-          const F32& val //!< The channel value
+          const F32 val //!< The channel value
       );
 
       //! Handle channel ChannelF64
       void tlmInput_ChannelF64(
           const Fw::Time& timeTag, //!< The time
-          const F64& val //!< The channel value
+          const F64 val //!< The channel value
       );
 
       //! Handle channel ChannelU32OnChange
       void tlmInput_ChannelU32OnChange(
           const Fw::Time& timeTag, //!< The time
-          const U32& val //!< The channel value
+          const U32 val //!< The channel value
       );
 
       //! Handle channel ChannelEnumOnChange

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.hpp
@@ -1138,8 +1138,8 @@ namespace M {
 
       //! Handle event EventCommand
       virtual void logIn_COMMAND_EventCommand(
-          const Fw::LogStringArg& str1, //!< A string
-          const Fw::LogStringArg& str2 //!< Another string
+          const Fw::StringBase& str1, //!< A string
+          const Fw::StringBase& str2 //!< Another string
       );
 
       //! Handle event EventDiagnostic

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.hpp
@@ -999,8 +999,8 @@ namespace M {
       void sendCmd_CMD_SYNC_STRING(
           const FwEnumStoreType instance, //!< The instance number
           U32 cmdSeq, //!< The command sequence number
-          const Fw::CmdStringArg& str1, //!< A string
-          const Fw::CmdStringArg& str2 //!< Another string
+          const Fw::StringBase& str1, //!< A string
+          const Fw::StringBase& str2 //!< Another string
       );
 
       //! Send a CMD_SYNC_ENUM command
@@ -1043,8 +1043,8 @@ namespace M {
       void sendCmd_CMD_GUARDED_STRING(
           const FwEnumStoreType instance, //!< The instance number
           U32 cmdSeq, //!< The command sequence number
-          const Fw::CmdStringArg& str1, //!< A string
-          const Fw::CmdStringArg& str2 //!< Another string
+          const Fw::StringBase& str1, //!< A string
+          const Fw::StringBase& str2 //!< Another string
       );
 
       //! Send a CMD_GUARDED_ENUM command

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsTesterBase.ref.cpp
@@ -1305,8 +1305,8 @@ void PassiveCommandsTesterBase ::
   sendCmd_CMD_SYNC_STRING(
       const FwEnumStoreType instance,
       U32 cmdSeq,
-      const Fw::CmdStringArg& str1,
-      const Fw::CmdStringArg& str2
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
   )
 {
   // Serialize arguments
@@ -1521,8 +1521,8 @@ void PassiveCommandsTesterBase ::
   sendCmd_CMD_GUARDED_STRING(
       const FwEnumStoreType instance,
       U32 cmdSeq,
-      const Fw::CmdStringArg& str1,
-      const Fw::CmdStringArg& str2
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
   )
 {
   // Serialize arguments

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsTesterBase.ref.cpp
@@ -1313,13 +1313,13 @@ void PassiveCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(str1);
+  _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(str2);
+  _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -1529,13 +1529,13 @@ void PassiveCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(str1);
+  _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(str2);
+  _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsTesterBase.ref.hpp
@@ -693,8 +693,8 @@ class PassiveCommandsTesterBase :
     void sendCmd_CMD_SYNC_STRING(
         const FwEnumStoreType instance, //!< The instance number
         U32 cmdSeq, //!< The command sequence number
-        const Fw::CmdStringArg& str1, //!< A string
-        const Fw::CmdStringArg& str2 //!< Another string
+        const Fw::StringBase& str1, //!< A string
+        const Fw::StringBase& str2 //!< Another string
     );
 
     //! Send a CMD_SYNC_ENUM command
@@ -737,8 +737,8 @@ class PassiveCommandsTesterBase :
     void sendCmd_CMD_GUARDED_STRING(
         const FwEnumStoreType instance, //!< The instance number
         U32 cmdSeq, //!< The command sequence number
-        const Fw::CmdStringArg& str1, //!< A string
-        const Fw::CmdStringArg& str2 //!< Another string
+        const Fw::StringBase& str1, //!< A string
+        const Fw::StringBase& str2 //!< Another string
     );
 
     //! Send a CMD_GUARDED_ENUM command

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsTesterBase.ref.cpp
@@ -1544,8 +1544,8 @@ void PassiveEventsTesterBase ::
 
 void PassiveEventsTesterBase ::
   logIn_COMMAND_EventCommand(
-      const Fw::LogStringArg& str1,
-      const Fw::LogStringArg& str2
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
   )
 {
   EventEntry_EventCommand _e = {

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsTesterBase.ref.hpp
@@ -725,8 +725,8 @@ class PassiveEventsTesterBase :
 
     //! Handle event EventCommand
     virtual void logIn_COMMAND_EventCommand(
-        const Fw::LogStringArg& str1, //!< A string
-        const Fw::LogStringArg& str2 //!< Another string
+        const Fw::StringBase& str1, //!< A string
+        const Fw::StringBase& str2 //!< Another string
     );
 
     //! Handle event EventDiagnostic

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsTesterBase.ref.cpp
@@ -1406,7 +1406,7 @@ void PassiveParamsTesterBase ::
 
 void PassiveParamsTesterBase ::
   paramSet_ParamString(
-      const Fw::ParamString& val,
+      const Fw::StringBase& val,
       Fw::ParamValid valid
   )
 {

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsTesterBase.ref.hpp
@@ -718,7 +718,7 @@ class PassiveParamsTesterBase :
 
     //! Set parameter ParamString
     void paramSet_ParamString(
-        const Fw::ParamString& val, //!< The parameter value
+        const Fw::StringBase& val, //!< The parameter value
         Fw::ParamValid valid //!< The parameter valid flag
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.cpp
@@ -1683,8 +1683,8 @@ void PassiveSerialTesterBase ::
   sendCmd_CMD_SYNC_STRING(
       const FwEnumStoreType instance,
       U32 cmdSeq,
-      const Fw::CmdStringArg& str1,
-      const Fw::CmdStringArg& str2
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
   )
 {
   // Serialize arguments
@@ -1899,8 +1899,8 @@ void PassiveSerialTesterBase ::
   sendCmd_CMD_GUARDED_STRING(
       const FwEnumStoreType instance,
       U32 cmdSeq,
-      const Fw::CmdStringArg& str1,
-      const Fw::CmdStringArg& str2
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
   )
 {
   // Serialize arguments

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.cpp
@@ -2612,7 +2612,7 @@ void PassiveSerialTesterBase ::
 void PassiveSerialTesterBase ::
   tlmInput_ChannelU32Format(
       const Fw::Time& timeTag,
-      const U32& val
+      const U32 val
   )
 {
   TlmEntry_ChannelU32Format e = { timeTag, val };
@@ -2623,7 +2623,7 @@ void PassiveSerialTesterBase ::
 void PassiveSerialTesterBase ::
   tlmInput_ChannelF32Format(
       const Fw::Time& timeTag,
-      const F32& val
+      const F32 val
   )
 {
   TlmEntry_ChannelF32Format e = { timeTag, val };
@@ -2634,7 +2634,7 @@ void PassiveSerialTesterBase ::
 void PassiveSerialTesterBase ::
   tlmInput_ChannelStringFormat(
       const Fw::Time& timeTag,
-      const Fw::TlmString& val
+      const Fw::StringBase& val
   )
 {
   TlmEntry_ChannelStringFormat e = { timeTag, val };
@@ -2678,7 +2678,7 @@ void PassiveSerialTesterBase ::
 void PassiveSerialTesterBase ::
   tlmInput_ChannelU32Limits(
       const Fw::Time& timeTag,
-      const U32& val
+      const U32 val
   )
 {
   TlmEntry_ChannelU32Limits e = { timeTag, val };
@@ -2689,7 +2689,7 @@ void PassiveSerialTesterBase ::
 void PassiveSerialTesterBase ::
   tlmInput_ChannelF32Limits(
       const Fw::Time& timeTag,
-      const F32& val
+      const F32 val
   )
 {
   TlmEntry_ChannelF32Limits e = { timeTag, val };
@@ -2700,7 +2700,7 @@ void PassiveSerialTesterBase ::
 void PassiveSerialTesterBase ::
   tlmInput_ChannelF64(
       const Fw::Time& timeTag,
-      const F64& val
+      const F64 val
   )
 {
   TlmEntry_ChannelF64 e = { timeTag, val };
@@ -2711,7 +2711,7 @@ void PassiveSerialTesterBase ::
 void PassiveSerialTesterBase ::
   tlmInput_ChannelU32OnChange(
       const Fw::Time& timeTag,
-      const U32& val
+      const U32 val
   )
 {
   TlmEntry_ChannelU32OnChange e = { timeTag, val };

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.cpp
@@ -2854,7 +2854,7 @@ void PassiveSerialTesterBase ::
 
 void PassiveSerialTesterBase ::
   paramSet_ParamString(
-      const Fw::ParamString& val,
+      const Fw::StringBase& val,
       Fw::ParamValid valid
   )
 {

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.cpp
@@ -2393,8 +2393,8 @@ void PassiveSerialTesterBase ::
 
 void PassiveSerialTesterBase ::
   logIn_COMMAND_EventCommand(
-      const Fw::LogStringArg& str1,
-      const Fw::LogStringArg& str2
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
   )
 {
   EventEntry_EventCommand _e = {

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.cpp
@@ -1691,13 +1691,13 @@ void PassiveSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(str1);
+  _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(str2);
+  _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -1907,13 +1907,13 @@ void PassiveSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(str1);
+  _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(str2);
+  _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.hpp
@@ -985,8 +985,8 @@ class PassiveSerialTesterBase :
 
     //! Handle event EventCommand
     virtual void logIn_COMMAND_EventCommand(
-        const Fw::LogStringArg& str1, //!< A string
-        const Fw::LogStringArg& str2 //!< Another string
+        const Fw::StringBase& str1, //!< A string
+        const Fw::StringBase& str2 //!< Another string
     );
 
     //! Handle event EventDiagnostic

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.hpp
@@ -1023,19 +1023,19 @@ class PassiveSerialTesterBase :
     //! Handle channel ChannelU32Format
     void tlmInput_ChannelU32Format(
         const Fw::Time& timeTag, //!< The time
-        const U32& val //!< The channel value
+        const U32 val //!< The channel value
     );
 
     //! Handle channel ChannelF32Format
     void tlmInput_ChannelF32Format(
         const Fw::Time& timeTag, //!< The time
-        const F32& val //!< The channel value
+        const F32 val //!< The channel value
     );
 
     //! Handle channel ChannelStringFormat
     void tlmInput_ChannelStringFormat(
         const Fw::Time& timeTag, //!< The time
-        const Fw::TlmString& val //!< The channel value
+        const Fw::StringBase& val //!< The channel value
     );
 
     //! Handle channel ChannelEnum
@@ -1059,25 +1059,25 @@ class PassiveSerialTesterBase :
     //! Handle channel ChannelU32Limits
     void tlmInput_ChannelU32Limits(
         const Fw::Time& timeTag, //!< The time
-        const U32& val //!< The channel value
+        const U32 val //!< The channel value
     );
 
     //! Handle channel ChannelF32Limits
     void tlmInput_ChannelF32Limits(
         const Fw::Time& timeTag, //!< The time
-        const F32& val //!< The channel value
+        const F32 val //!< The channel value
     );
 
     //! Handle channel ChannelF64
     void tlmInput_ChannelF64(
         const Fw::Time& timeTag, //!< The time
-        const F64& val //!< The channel value
+        const F64 val //!< The channel value
     );
 
     //! Handle channel ChannelU32OnChange
     void tlmInput_ChannelU32OnChange(
         const Fw::Time& timeTag, //!< The time
-        const U32& val //!< The channel value
+        const U32 val //!< The channel value
     );
 
     //! Handle channel ChannelEnumOnChange

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.hpp
@@ -1130,7 +1130,7 @@ class PassiveSerialTesterBase :
 
     //! Set parameter ParamString
     void paramSet_ParamString(
-        const Fw::ParamString& val, //!< The parameter value
+        const Fw::StringBase& val, //!< The parameter value
         Fw::ParamValid valid //!< The parameter valid flag
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.hpp
@@ -878,8 +878,8 @@ class PassiveSerialTesterBase :
     void sendCmd_CMD_SYNC_STRING(
         const FwEnumStoreType instance, //!< The instance number
         U32 cmdSeq, //!< The command sequence number
-        const Fw::CmdStringArg& str1, //!< A string
-        const Fw::CmdStringArg& str2 //!< Another string
+        const Fw::StringBase& str1, //!< A string
+        const Fw::StringBase& str2 //!< Another string
     );
 
     //! Send a CMD_SYNC_ENUM command
@@ -922,8 +922,8 @@ class PassiveSerialTesterBase :
     void sendCmd_CMD_GUARDED_STRING(
         const FwEnumStoreType instance, //!< The instance number
         U32 cmdSeq, //!< The command sequence number
-        const Fw::CmdStringArg& str1, //!< A string
-        const Fw::CmdStringArg& str2 //!< Another string
+        const Fw::StringBase& str1, //!< A string
+        const Fw::StringBase& str2 //!< Another string
     );
 
     //! Send a CMD_GUARDED_ENUM command

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryTesterBase.ref.cpp
@@ -1339,7 +1339,7 @@ void PassiveTelemetryTesterBase ::
 void PassiveTelemetryTesterBase ::
   tlmInput_ChannelU32Format(
       const Fw::Time& timeTag,
-      const U32& val
+      const U32 val
   )
 {
   TlmEntry_ChannelU32Format e = { timeTag, val };
@@ -1350,7 +1350,7 @@ void PassiveTelemetryTesterBase ::
 void PassiveTelemetryTesterBase ::
   tlmInput_ChannelF32Format(
       const Fw::Time& timeTag,
-      const F32& val
+      const F32 val
   )
 {
   TlmEntry_ChannelF32Format e = { timeTag, val };
@@ -1361,7 +1361,7 @@ void PassiveTelemetryTesterBase ::
 void PassiveTelemetryTesterBase ::
   tlmInput_ChannelStringFormat(
       const Fw::Time& timeTag,
-      const Fw::TlmString& val
+      const Fw::StringBase& val
   )
 {
   TlmEntry_ChannelStringFormat e = { timeTag, val };
@@ -1405,7 +1405,7 @@ void PassiveTelemetryTesterBase ::
 void PassiveTelemetryTesterBase ::
   tlmInput_ChannelU32Limits(
       const Fw::Time& timeTag,
-      const U32& val
+      const U32 val
   )
 {
   TlmEntry_ChannelU32Limits e = { timeTag, val };
@@ -1416,7 +1416,7 @@ void PassiveTelemetryTesterBase ::
 void PassiveTelemetryTesterBase ::
   tlmInput_ChannelF32Limits(
       const Fw::Time& timeTag,
-      const F32& val
+      const F32 val
   )
 {
   TlmEntry_ChannelF32Limits e = { timeTag, val };
@@ -1427,7 +1427,7 @@ void PassiveTelemetryTesterBase ::
 void PassiveTelemetryTesterBase ::
   tlmInput_ChannelF64(
       const Fw::Time& timeTag,
-      const F64& val
+      const F64 val
   )
 {
   TlmEntry_ChannelF64 e = { timeTag, val };
@@ -1438,7 +1438,7 @@ void PassiveTelemetryTesterBase ::
 void PassiveTelemetryTesterBase ::
   tlmInput_ChannelU32OnChange(
       const Fw::Time& timeTag,
-      const U32& val
+      const U32 val
   )
 {
   TlmEntry_ChannelU32OnChange e = { timeTag, val };

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryTesterBase.ref.hpp
@@ -729,19 +729,19 @@ class PassiveTelemetryTesterBase :
     //! Handle channel ChannelU32Format
     void tlmInput_ChannelU32Format(
         const Fw::Time& timeTag, //!< The time
-        const U32& val //!< The channel value
+        const U32 val //!< The channel value
     );
 
     //! Handle channel ChannelF32Format
     void tlmInput_ChannelF32Format(
         const Fw::Time& timeTag, //!< The time
-        const F32& val //!< The channel value
+        const F32 val //!< The channel value
     );
 
     //! Handle channel ChannelStringFormat
     void tlmInput_ChannelStringFormat(
         const Fw::Time& timeTag, //!< The time
-        const Fw::TlmString& val //!< The channel value
+        const Fw::StringBase& val //!< The channel value
     );
 
     //! Handle channel ChannelEnum
@@ -765,25 +765,25 @@ class PassiveTelemetryTesterBase :
     //! Handle channel ChannelU32Limits
     void tlmInput_ChannelU32Limits(
         const Fw::Time& timeTag, //!< The time
-        const U32& val //!< The channel value
+        const U32 val //!< The channel value
     );
 
     //! Handle channel ChannelF32Limits
     void tlmInput_ChannelF32Limits(
         const Fw::Time& timeTag, //!< The time
-        const F32& val //!< The channel value
+        const F32 val //!< The channel value
     );
 
     //! Handle channel ChannelF64
     void tlmInput_ChannelF64(
         const Fw::Time& timeTag, //!< The time
-        const F64& val //!< The channel value
+        const F64 val //!< The channel value
     );
 
     //! Handle channel ChannelU32OnChange
     void tlmInput_ChannelU32OnChange(
         const Fw::Time& timeTag, //!< The time
-        const U32& val //!< The channel value
+        const U32 val //!< The channel value
     );
 
     //! Handle channel ChannelEnumOnChange

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.cpp
@@ -1627,13 +1627,13 @@ void PassiveTestTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(str1);
+  _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(str2);
+  _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -1843,13 +1843,13 @@ void PassiveTestTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(str1);
+  _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(str2);
+  _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.cpp
@@ -1619,8 +1619,8 @@ void PassiveTestTesterBase ::
   sendCmd_CMD_SYNC_STRING(
       const FwEnumStoreType instance,
       U32 cmdSeq,
-      const Fw::CmdStringArg& str1,
-      const Fw::CmdStringArg& str2
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
   )
 {
   // Serialize arguments
@@ -1835,8 +1835,8 @@ void PassiveTestTesterBase ::
   sendCmd_CMD_GUARDED_STRING(
       const FwEnumStoreType instance,
       U32 cmdSeq,
-      const Fw::CmdStringArg& str1,
-      const Fw::CmdStringArg& str2
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
   )
 {
   // Serialize arguments

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.cpp
@@ -2548,7 +2548,7 @@ void PassiveTestTesterBase ::
 void PassiveTestTesterBase ::
   tlmInput_ChannelU32Format(
       const Fw::Time& timeTag,
-      const U32& val
+      const U32 val
   )
 {
   TlmEntry_ChannelU32Format e = { timeTag, val };
@@ -2559,7 +2559,7 @@ void PassiveTestTesterBase ::
 void PassiveTestTesterBase ::
   tlmInput_ChannelF32Format(
       const Fw::Time& timeTag,
-      const F32& val
+      const F32 val
   )
 {
   TlmEntry_ChannelF32Format e = { timeTag, val };
@@ -2570,7 +2570,7 @@ void PassiveTestTesterBase ::
 void PassiveTestTesterBase ::
   tlmInput_ChannelStringFormat(
       const Fw::Time& timeTag,
-      const Fw::TlmString& val
+      const Fw::StringBase& val
   )
 {
   TlmEntry_ChannelStringFormat e = { timeTag, val };
@@ -2614,7 +2614,7 @@ void PassiveTestTesterBase ::
 void PassiveTestTesterBase ::
   tlmInput_ChannelU32Limits(
       const Fw::Time& timeTag,
-      const U32& val
+      const U32 val
   )
 {
   TlmEntry_ChannelU32Limits e = { timeTag, val };
@@ -2625,7 +2625,7 @@ void PassiveTestTesterBase ::
 void PassiveTestTesterBase ::
   tlmInput_ChannelF32Limits(
       const Fw::Time& timeTag,
-      const F32& val
+      const F32 val
   )
 {
   TlmEntry_ChannelF32Limits e = { timeTag, val };
@@ -2636,7 +2636,7 @@ void PassiveTestTesterBase ::
 void PassiveTestTesterBase ::
   tlmInput_ChannelF64(
       const Fw::Time& timeTag,
-      const F64& val
+      const F64 val
   )
 {
   TlmEntry_ChannelF64 e = { timeTag, val };
@@ -2647,7 +2647,7 @@ void PassiveTestTesterBase ::
 void PassiveTestTesterBase ::
   tlmInput_ChannelU32OnChange(
       const Fw::Time& timeTag,
-      const U32& val
+      const U32 val
   )
 {
   TlmEntry_ChannelU32OnChange e = { timeTag, val };

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.cpp
@@ -2329,8 +2329,8 @@ void PassiveTestTesterBase ::
 
 void PassiveTestTesterBase ::
   logIn_COMMAND_EventCommand(
-      const Fw::LogStringArg& str1,
-      const Fw::LogStringArg& str2
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
   )
 {
   EventEntry_EventCommand _e = {

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.cpp
@@ -2790,7 +2790,7 @@ void PassiveTestTesterBase ::
 
 void PassiveTestTesterBase ::
   paramSet_ParamString(
-      const Fw::ParamString& val,
+      const Fw::StringBase& val,
       Fw::ParamValid valid
   )
 {

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.hpp
@@ -999,19 +999,19 @@ class PassiveTestTesterBase :
     //! Handle channel ChannelU32Format
     void tlmInput_ChannelU32Format(
         const Fw::Time& timeTag, //!< The time
-        const U32& val //!< The channel value
+        const U32 val //!< The channel value
     );
 
     //! Handle channel ChannelF32Format
     void tlmInput_ChannelF32Format(
         const Fw::Time& timeTag, //!< The time
-        const F32& val //!< The channel value
+        const F32 val //!< The channel value
     );
 
     //! Handle channel ChannelStringFormat
     void tlmInput_ChannelStringFormat(
         const Fw::Time& timeTag, //!< The time
-        const Fw::TlmString& val //!< The channel value
+        const Fw::StringBase& val //!< The channel value
     );
 
     //! Handle channel ChannelEnum
@@ -1035,25 +1035,25 @@ class PassiveTestTesterBase :
     //! Handle channel ChannelU32Limits
     void tlmInput_ChannelU32Limits(
         const Fw::Time& timeTag, //!< The time
-        const U32& val //!< The channel value
+        const U32 val //!< The channel value
     );
 
     //! Handle channel ChannelF32Limits
     void tlmInput_ChannelF32Limits(
         const Fw::Time& timeTag, //!< The time
-        const F32& val //!< The channel value
+        const F32 val //!< The channel value
     );
 
     //! Handle channel ChannelF64
     void tlmInput_ChannelF64(
         const Fw::Time& timeTag, //!< The time
-        const F64& val //!< The channel value
+        const F64 val //!< The channel value
     );
 
     //! Handle channel ChannelU32OnChange
     void tlmInput_ChannelU32OnChange(
         const Fw::Time& timeTag, //!< The time
-        const U32& val //!< The channel value
+        const U32 val //!< The channel value
     );
 
     //! Handle channel ChannelEnumOnChange

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.hpp
@@ -854,8 +854,8 @@ class PassiveTestTesterBase :
     void sendCmd_CMD_SYNC_STRING(
         const FwEnumStoreType instance, //!< The instance number
         U32 cmdSeq, //!< The command sequence number
-        const Fw::CmdStringArg& str1, //!< A string
-        const Fw::CmdStringArg& str2 //!< Another string
+        const Fw::StringBase& str1, //!< A string
+        const Fw::StringBase& str2 //!< Another string
     );
 
     //! Send a CMD_SYNC_ENUM command
@@ -898,8 +898,8 @@ class PassiveTestTesterBase :
     void sendCmd_CMD_GUARDED_STRING(
         const FwEnumStoreType instance, //!< The instance number
         U32 cmdSeq, //!< The command sequence number
-        const Fw::CmdStringArg& str1, //!< A string
-        const Fw::CmdStringArg& str2 //!< Another string
+        const Fw::StringBase& str1, //!< A string
+        const Fw::StringBase& str2 //!< Another string
     );
 
     //! Send a CMD_GUARDED_ENUM command

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.hpp
@@ -1106,7 +1106,7 @@ class PassiveTestTesterBase :
 
     //! Set parameter ParamString
     void paramSet_ParamString(
-        const Fw::ParamString& val, //!< The parameter value
+        const Fw::StringBase& val, //!< The parameter value
         Fw::ParamValid valid //!< The parameter valid flag
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.hpp
@@ -961,8 +961,8 @@ class PassiveTestTesterBase :
 
     //! Handle event EventCommand
     virtual void logIn_COMMAND_EventCommand(
-        const Fw::LogStringArg& str1, //!< A string
-        const Fw::LogStringArg& str2 //!< Another string
+        const Fw::StringBase& str1, //!< A string
+        const Fw::StringBase& str2 //!< Another string
     );
 
     //! Handle event EventDiagnostic

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsTesterBase.ref.cpp
@@ -1686,13 +1686,13 @@ void QueuedCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(str1);
+  _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(str2);
+  _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -1902,13 +1902,13 @@ void QueuedCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(str1);
+  _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(str2);
+  _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsTesterBase.ref.cpp
@@ -1678,8 +1678,8 @@ void QueuedCommandsTesterBase ::
   sendCmd_CMD_SYNC_STRING(
       const FwEnumStoreType instance,
       U32 cmdSeq,
-      const Fw::CmdStringArg& str1,
-      const Fw::CmdStringArg& str2
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
   )
 {
   // Serialize arguments
@@ -1894,8 +1894,8 @@ void QueuedCommandsTesterBase ::
   sendCmd_CMD_GUARDED_STRING(
       const FwEnumStoreType instance,
       U32 cmdSeq,
-      const Fw::CmdStringArg& str1,
-      const Fw::CmdStringArg& str2
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
   )
 {
   // Serialize arguments

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsTesterBase.ref.hpp
@@ -836,8 +836,8 @@ class QueuedCommandsTesterBase :
     void sendCmd_CMD_SYNC_STRING(
         const FwEnumStoreType instance, //!< The instance number
         U32 cmdSeq, //!< The command sequence number
-        const Fw::CmdStringArg& str1, //!< A string
-        const Fw::CmdStringArg& str2 //!< Another string
+        const Fw::StringBase& str1, //!< A string
+        const Fw::StringBase& str2 //!< Another string
     );
 
     //! Send a CMD_SYNC_ENUM command
@@ -880,8 +880,8 @@ class QueuedCommandsTesterBase :
     void sendCmd_CMD_GUARDED_STRING(
         const FwEnumStoreType instance, //!< The instance number
         U32 cmdSeq, //!< The command sequence number
-        const Fw::CmdStringArg& str1, //!< A string
-        const Fw::CmdStringArg& str2 //!< Another string
+        const Fw::StringBase& str1, //!< A string
+        const Fw::StringBase& str2 //!< Another string
     );
 
     //! Send a CMD_GUARDED_ENUM command

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsTesterBase.ref.cpp
@@ -1917,8 +1917,8 @@ void QueuedEventsTesterBase ::
 
 void QueuedEventsTesterBase ::
   logIn_COMMAND_EventCommand(
-      const Fw::LogStringArg& str1,
-      const Fw::LogStringArg& str2
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
   )
 {
   EventEntry_EventCommand _e = {

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsTesterBase.ref.hpp
@@ -868,8 +868,8 @@ class QueuedEventsTesterBase :
 
     //! Handle event EventCommand
     virtual void logIn_COMMAND_EventCommand(
-        const Fw::LogStringArg& str1, //!< A string
-        const Fw::LogStringArg& str2 //!< Another string
+        const Fw::StringBase& str1, //!< A string
+        const Fw::StringBase& str2 //!< Another string
     );
 
     //! Handle event EventDiagnostic

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsTesterBase.ref.cpp
@@ -1779,7 +1779,7 @@ void QueuedParamsTesterBase ::
 
 void QueuedParamsTesterBase ::
   paramSet_ParamString(
-      const Fw::ParamString& val,
+      const Fw::StringBase& val,
       Fw::ParamValid valid
   )
 {

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsTesterBase.ref.hpp
@@ -861,7 +861,7 @@ class QueuedParamsTesterBase :
 
     //! Set parameter ParamString
     void paramSet_ParamString(
-        const Fw::ParamString& val, //!< The parameter value
+        const Fw::StringBase& val, //!< The parameter value
         Fw::ParamValid valid //!< The parameter valid flag
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.cpp
@@ -2328,13 +2328,13 @@ void QueuedSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(str1);
+  _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(str2);
+  _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2544,13 +2544,13 @@ void QueuedSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(str1);
+  _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(str2);
+  _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.cpp
@@ -3634,7 +3634,7 @@ void QueuedSerialTesterBase ::
 
 void QueuedSerialTesterBase ::
   paramSet_ParamString(
-      const Fw::ParamString& val,
+      const Fw::StringBase& val,
       Fw::ParamValid valid
   )
 {

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.cpp
@@ -3392,7 +3392,7 @@ void QueuedSerialTesterBase ::
 void QueuedSerialTesterBase ::
   tlmInput_ChannelU32Format(
       const Fw::Time& timeTag,
-      const U32& val
+      const U32 val
   )
 {
   TlmEntry_ChannelU32Format e = { timeTag, val };
@@ -3403,7 +3403,7 @@ void QueuedSerialTesterBase ::
 void QueuedSerialTesterBase ::
   tlmInput_ChannelF32Format(
       const Fw::Time& timeTag,
-      const F32& val
+      const F32 val
   )
 {
   TlmEntry_ChannelF32Format e = { timeTag, val };
@@ -3414,7 +3414,7 @@ void QueuedSerialTesterBase ::
 void QueuedSerialTesterBase ::
   tlmInput_ChannelStringFormat(
       const Fw::Time& timeTag,
-      const Fw::TlmString& val
+      const Fw::StringBase& val
   )
 {
   TlmEntry_ChannelStringFormat e = { timeTag, val };
@@ -3458,7 +3458,7 @@ void QueuedSerialTesterBase ::
 void QueuedSerialTesterBase ::
   tlmInput_ChannelU32Limits(
       const Fw::Time& timeTag,
-      const U32& val
+      const U32 val
   )
 {
   TlmEntry_ChannelU32Limits e = { timeTag, val };
@@ -3469,7 +3469,7 @@ void QueuedSerialTesterBase ::
 void QueuedSerialTesterBase ::
   tlmInput_ChannelF32Limits(
       const Fw::Time& timeTag,
-      const F32& val
+      const F32 val
   )
 {
   TlmEntry_ChannelF32Limits e = { timeTag, val };
@@ -3480,7 +3480,7 @@ void QueuedSerialTesterBase ::
 void QueuedSerialTesterBase ::
   tlmInput_ChannelF64(
       const Fw::Time& timeTag,
-      const F64& val
+      const F64 val
   )
 {
   TlmEntry_ChannelF64 e = { timeTag, val };
@@ -3491,7 +3491,7 @@ void QueuedSerialTesterBase ::
 void QueuedSerialTesterBase ::
   tlmInput_ChannelU32OnChange(
       const Fw::Time& timeTag,
-      const U32& val
+      const U32 val
   )
 {
   TlmEntry_ChannelU32OnChange e = { timeTag, val };

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.cpp
@@ -2320,8 +2320,8 @@ void QueuedSerialTesterBase ::
   sendCmd_CMD_SYNC_STRING(
       const FwEnumStoreType instance,
       U32 cmdSeq,
-      const Fw::CmdStringArg& str1,
-      const Fw::CmdStringArg& str2
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
   )
 {
   // Serialize arguments
@@ -2536,8 +2536,8 @@ void QueuedSerialTesterBase ::
   sendCmd_CMD_GUARDED_STRING(
       const FwEnumStoreType instance,
       U32 cmdSeq,
-      const Fw::CmdStringArg& str1,
-      const Fw::CmdStringArg& str2
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
   )
 {
   // Serialize arguments

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.cpp
@@ -3173,8 +3173,8 @@ void QueuedSerialTesterBase ::
 
 void QueuedSerialTesterBase ::
   logIn_COMMAND_EventCommand(
-      const Fw::LogStringArg& str1,
-      const Fw::LogStringArg& str2
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
   )
 {
   EventEntry_EventCommand _e = {

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.hpp
@@ -1256,8 +1256,8 @@ class QueuedSerialTesterBase :
 
     //! Handle event EventCommand
     virtual void logIn_COMMAND_EventCommand(
-        const Fw::LogStringArg& str1, //!< A string
-        const Fw::LogStringArg& str2 //!< Another string
+        const Fw::StringBase& str1, //!< A string
+        const Fw::StringBase& str2 //!< Another string
     );
 
     //! Handle event EventDiagnostic

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.hpp
@@ -1401,7 +1401,7 @@ class QueuedSerialTesterBase :
 
     //! Set parameter ParamString
     void paramSet_ParamString(
-        const Fw::ParamString& val, //!< The parameter value
+        const Fw::StringBase& val, //!< The parameter value
         Fw::ParamValid valid //!< The parameter valid flag
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.hpp
@@ -1117,8 +1117,8 @@ class QueuedSerialTesterBase :
     void sendCmd_CMD_SYNC_STRING(
         const FwEnumStoreType instance, //!< The instance number
         U32 cmdSeq, //!< The command sequence number
-        const Fw::CmdStringArg& str1, //!< A string
-        const Fw::CmdStringArg& str2 //!< Another string
+        const Fw::StringBase& str1, //!< A string
+        const Fw::StringBase& str2 //!< Another string
     );
 
     //! Send a CMD_SYNC_ENUM command
@@ -1161,8 +1161,8 @@ class QueuedSerialTesterBase :
     void sendCmd_CMD_GUARDED_STRING(
         const FwEnumStoreType instance, //!< The instance number
         U32 cmdSeq, //!< The command sequence number
-        const Fw::CmdStringArg& str1, //!< A string
-        const Fw::CmdStringArg& str2 //!< Another string
+        const Fw::StringBase& str1, //!< A string
+        const Fw::StringBase& str2 //!< Another string
     );
 
     //! Send a CMD_GUARDED_ENUM command

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.hpp
@@ -1294,19 +1294,19 @@ class QueuedSerialTesterBase :
     //! Handle channel ChannelU32Format
     void tlmInput_ChannelU32Format(
         const Fw::Time& timeTag, //!< The time
-        const U32& val //!< The channel value
+        const U32 val //!< The channel value
     );
 
     //! Handle channel ChannelF32Format
     void tlmInput_ChannelF32Format(
         const Fw::Time& timeTag, //!< The time
-        const F32& val //!< The channel value
+        const F32 val //!< The channel value
     );
 
     //! Handle channel ChannelStringFormat
     void tlmInput_ChannelStringFormat(
         const Fw::Time& timeTag, //!< The time
-        const Fw::TlmString& val //!< The channel value
+        const Fw::StringBase& val //!< The channel value
     );
 
     //! Handle channel ChannelEnum
@@ -1330,25 +1330,25 @@ class QueuedSerialTesterBase :
     //! Handle channel ChannelU32Limits
     void tlmInput_ChannelU32Limits(
         const Fw::Time& timeTag, //!< The time
-        const U32& val //!< The channel value
+        const U32 val //!< The channel value
     );
 
     //! Handle channel ChannelF32Limits
     void tlmInput_ChannelF32Limits(
         const Fw::Time& timeTag, //!< The time
-        const F32& val //!< The channel value
+        const F32 val //!< The channel value
     );
 
     //! Handle channel ChannelF64
     void tlmInput_ChannelF64(
         const Fw::Time& timeTag, //!< The time
-        const F64& val //!< The channel value
+        const F64 val //!< The channel value
     );
 
     //! Handle channel ChannelU32OnChange
     void tlmInput_ChannelU32OnChange(
         const Fw::Time& timeTag, //!< The time
-        const U32& val //!< The channel value
+        const U32 val //!< The channel value
     );
 
     //! Handle channel ChannelEnumOnChange

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryTesterBase.ref.cpp
@@ -1712,7 +1712,7 @@ void QueuedTelemetryTesterBase ::
 void QueuedTelemetryTesterBase ::
   tlmInput_ChannelU32Format(
       const Fw::Time& timeTag,
-      const U32& val
+      const U32 val
   )
 {
   TlmEntry_ChannelU32Format e = { timeTag, val };
@@ -1723,7 +1723,7 @@ void QueuedTelemetryTesterBase ::
 void QueuedTelemetryTesterBase ::
   tlmInput_ChannelF32Format(
       const Fw::Time& timeTag,
-      const F32& val
+      const F32 val
   )
 {
   TlmEntry_ChannelF32Format e = { timeTag, val };
@@ -1734,7 +1734,7 @@ void QueuedTelemetryTesterBase ::
 void QueuedTelemetryTesterBase ::
   tlmInput_ChannelStringFormat(
       const Fw::Time& timeTag,
-      const Fw::TlmString& val
+      const Fw::StringBase& val
   )
 {
   TlmEntry_ChannelStringFormat e = { timeTag, val };
@@ -1778,7 +1778,7 @@ void QueuedTelemetryTesterBase ::
 void QueuedTelemetryTesterBase ::
   tlmInput_ChannelU32Limits(
       const Fw::Time& timeTag,
-      const U32& val
+      const U32 val
   )
 {
   TlmEntry_ChannelU32Limits e = { timeTag, val };
@@ -1789,7 +1789,7 @@ void QueuedTelemetryTesterBase ::
 void QueuedTelemetryTesterBase ::
   tlmInput_ChannelF32Limits(
       const Fw::Time& timeTag,
-      const F32& val
+      const F32 val
   )
 {
   TlmEntry_ChannelF32Limits e = { timeTag, val };
@@ -1800,7 +1800,7 @@ void QueuedTelemetryTesterBase ::
 void QueuedTelemetryTesterBase ::
   tlmInput_ChannelF64(
       const Fw::Time& timeTag,
-      const F64& val
+      const F64 val
   )
 {
   TlmEntry_ChannelF64 e = { timeTag, val };
@@ -1811,7 +1811,7 @@ void QueuedTelemetryTesterBase ::
 void QueuedTelemetryTesterBase ::
   tlmInput_ChannelU32OnChange(
       const Fw::Time& timeTag,
-      const U32& val
+      const U32 val
   )
 {
   TlmEntry_ChannelU32OnChange e = { timeTag, val };

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryTesterBase.ref.hpp
@@ -872,19 +872,19 @@ class QueuedTelemetryTesterBase :
     //! Handle channel ChannelU32Format
     void tlmInput_ChannelU32Format(
         const Fw::Time& timeTag, //!< The time
-        const U32& val //!< The channel value
+        const U32 val //!< The channel value
     );
 
     //! Handle channel ChannelF32Format
     void tlmInput_ChannelF32Format(
         const Fw::Time& timeTag, //!< The time
-        const F32& val //!< The channel value
+        const F32 val //!< The channel value
     );
 
     //! Handle channel ChannelStringFormat
     void tlmInput_ChannelStringFormat(
         const Fw::Time& timeTag, //!< The time
-        const Fw::TlmString& val //!< The channel value
+        const Fw::StringBase& val //!< The channel value
     );
 
     //! Handle channel ChannelEnum
@@ -908,25 +908,25 @@ class QueuedTelemetryTesterBase :
     //! Handle channel ChannelU32Limits
     void tlmInput_ChannelU32Limits(
         const Fw::Time& timeTag, //!< The time
-        const U32& val //!< The channel value
+        const U32 val //!< The channel value
     );
 
     //! Handle channel ChannelF32Limits
     void tlmInput_ChannelF32Limits(
         const Fw::Time& timeTag, //!< The time
-        const F32& val //!< The channel value
+        const F32 val //!< The channel value
     );
 
     //! Handle channel ChannelF64
     void tlmInput_ChannelF64(
         const Fw::Time& timeTag, //!< The time
-        const F64& val //!< The channel value
+        const F64 val //!< The channel value
     );
 
     //! Handle channel ChannelU32OnChange
     void tlmInput_ChannelU32OnChange(
         const Fw::Time& timeTag, //!< The time
-        const U32& val //!< The channel value
+        const U32 val //!< The channel value
     );
 
     //! Handle channel ChannelEnumOnChange

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.cpp
@@ -2845,8 +2845,8 @@ void QueuedTestTesterBase ::
 
 void QueuedTestTesterBase ::
   logIn_COMMAND_EventCommand(
-      const Fw::LogStringArg& str1,
-      const Fw::LogStringArg& str2
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
   )
 {
   EventEntry_EventCommand _e = {

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.cpp
@@ -1992,8 +1992,8 @@ void QueuedTestTesterBase ::
   sendCmd_CMD_SYNC_STRING(
       const FwEnumStoreType instance,
       U32 cmdSeq,
-      const Fw::CmdStringArg& str1,
-      const Fw::CmdStringArg& str2
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
   )
 {
   // Serialize arguments
@@ -2208,8 +2208,8 @@ void QueuedTestTesterBase ::
   sendCmd_CMD_GUARDED_STRING(
       const FwEnumStoreType instance,
       U32 cmdSeq,
-      const Fw::CmdStringArg& str1,
-      const Fw::CmdStringArg& str2
+      const Fw::StringBase& str1,
+      const Fw::StringBase& str2
   )
 {
   // Serialize arguments

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.cpp
@@ -3306,7 +3306,7 @@ void QueuedTestTesterBase ::
 
 void QueuedTestTesterBase ::
   paramSet_ParamString(
-      const Fw::ParamString& val,
+      const Fw::StringBase& val,
       Fw::ParamValid valid
   )
 {

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.cpp
@@ -2000,13 +2000,13 @@ void QueuedTestTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(str1);
+  _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(str2);
+  _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2216,13 +2216,13 @@ void QueuedTestTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(str1);
+  _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(str2);
+  _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.cpp
@@ -3064,7 +3064,7 @@ void QueuedTestTesterBase ::
 void QueuedTestTesterBase ::
   tlmInput_ChannelU32Format(
       const Fw::Time& timeTag,
-      const U32& val
+      const U32 val
   )
 {
   TlmEntry_ChannelU32Format e = { timeTag, val };
@@ -3075,7 +3075,7 @@ void QueuedTestTesterBase ::
 void QueuedTestTesterBase ::
   tlmInput_ChannelF32Format(
       const Fw::Time& timeTag,
-      const F32& val
+      const F32 val
   )
 {
   TlmEntry_ChannelF32Format e = { timeTag, val };
@@ -3086,7 +3086,7 @@ void QueuedTestTesterBase ::
 void QueuedTestTesterBase ::
   tlmInput_ChannelStringFormat(
       const Fw::Time& timeTag,
-      const Fw::TlmString& val
+      const Fw::StringBase& val
   )
 {
   TlmEntry_ChannelStringFormat e = { timeTag, val };
@@ -3130,7 +3130,7 @@ void QueuedTestTesterBase ::
 void QueuedTestTesterBase ::
   tlmInput_ChannelU32Limits(
       const Fw::Time& timeTag,
-      const U32& val
+      const U32 val
   )
 {
   TlmEntry_ChannelU32Limits e = { timeTag, val };
@@ -3141,7 +3141,7 @@ void QueuedTestTesterBase ::
 void QueuedTestTesterBase ::
   tlmInput_ChannelF32Limits(
       const Fw::Time& timeTag,
-      const F32& val
+      const F32 val
   )
 {
   TlmEntry_ChannelF32Limits e = { timeTag, val };
@@ -3152,7 +3152,7 @@ void QueuedTestTesterBase ::
 void QueuedTestTesterBase ::
   tlmInput_ChannelF64(
       const Fw::Time& timeTag,
-      const F64& val
+      const F64 val
   )
 {
   TlmEntry_ChannelF64 e = { timeTag, val };
@@ -3163,7 +3163,7 @@ void QueuedTestTesterBase ::
 void QueuedTestTesterBase ::
   tlmInput_ChannelU32OnChange(
       const Fw::Time& timeTag,
-      const U32& val
+      const U32 val
   )
 {
   TlmEntry_ChannelU32OnChange e = { timeTag, val };

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.hpp
@@ -1174,19 +1174,19 @@ class QueuedTestTesterBase :
     //! Handle channel ChannelU32Format
     void tlmInput_ChannelU32Format(
         const Fw::Time& timeTag, //!< The time
-        const U32& val //!< The channel value
+        const U32 val //!< The channel value
     );
 
     //! Handle channel ChannelF32Format
     void tlmInput_ChannelF32Format(
         const Fw::Time& timeTag, //!< The time
-        const F32& val //!< The channel value
+        const F32 val //!< The channel value
     );
 
     //! Handle channel ChannelStringFormat
     void tlmInput_ChannelStringFormat(
         const Fw::Time& timeTag, //!< The time
-        const Fw::TlmString& val //!< The channel value
+        const Fw::StringBase& val //!< The channel value
     );
 
     //! Handle channel ChannelEnum
@@ -1210,25 +1210,25 @@ class QueuedTestTesterBase :
     //! Handle channel ChannelU32Limits
     void tlmInput_ChannelU32Limits(
         const Fw::Time& timeTag, //!< The time
-        const U32& val //!< The channel value
+        const U32 val //!< The channel value
     );
 
     //! Handle channel ChannelF32Limits
     void tlmInput_ChannelF32Limits(
         const Fw::Time& timeTag, //!< The time
-        const F32& val //!< The channel value
+        const F32 val //!< The channel value
     );
 
     //! Handle channel ChannelF64
     void tlmInput_ChannelF64(
         const Fw::Time& timeTag, //!< The time
-        const F64& val //!< The channel value
+        const F64 val //!< The channel value
     );
 
     //! Handle channel ChannelU32OnChange
     void tlmInput_ChannelU32OnChange(
         const Fw::Time& timeTag, //!< The time
-        const U32& val //!< The channel value
+        const U32 val //!< The channel value
     );
 
     //! Handle channel ChannelEnumOnChange

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.hpp
@@ -997,8 +997,8 @@ class QueuedTestTesterBase :
     void sendCmd_CMD_SYNC_STRING(
         const FwEnumStoreType instance, //!< The instance number
         U32 cmdSeq, //!< The command sequence number
-        const Fw::CmdStringArg& str1, //!< A string
-        const Fw::CmdStringArg& str2 //!< Another string
+        const Fw::StringBase& str1, //!< A string
+        const Fw::StringBase& str2 //!< Another string
     );
 
     //! Send a CMD_SYNC_ENUM command
@@ -1041,8 +1041,8 @@ class QueuedTestTesterBase :
     void sendCmd_CMD_GUARDED_STRING(
         const FwEnumStoreType instance, //!< The instance number
         U32 cmdSeq, //!< The command sequence number
-        const Fw::CmdStringArg& str1, //!< A string
-        const Fw::CmdStringArg& str2 //!< Another string
+        const Fw::StringBase& str1, //!< A string
+        const Fw::StringBase& str2 //!< Another string
     );
 
     //! Send a CMD_GUARDED_ENUM command

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.hpp
@@ -1136,8 +1136,8 @@ class QueuedTestTesterBase :
 
     //! Handle event EventCommand
     virtual void logIn_COMMAND_EventCommand(
-        const Fw::LogStringArg& str1, //!< A string
-        const Fw::LogStringArg& str2 //!< Another string
+        const Fw::StringBase& str1, //!< A string
+        const Fw::StringBase& str2 //!< Another string
     );
 
     //! Handle event EventDiagnostic

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.hpp
@@ -1281,7 +1281,7 @@ class QueuedTestTesterBase :
 
     //! Set parameter ParamString
     void paramSet_ParamString(
-        const Fw::ParamString& val, //!< The parameter value
+        const Fw::StringBase& val, //!< The parameter value
         Fw::ParamValid valid //!< The parameter valid flag
     );
 


### PR DESCRIPTION
Closes #407. See that issue for the rationale.

Notes:
* This PR incorporates changes from #408. Merge that one before reviewing.
* This PR will require some minor changes to user test code. For example, you can no longer pass a bare `char*` to the `sendCmd` interface; you have to wrap your `char*` in an F Prime string constructor. However, I think we want to go in this direction. We should avoid implicit conversions, e.g., implicitly converting `char*` to an F Prime string type. Eventually, if possible, we should make single-argument constructors explicit.