### PR TITLE
Add .gitignore file for fpp-to-dict tests

### DIFF
--- a/compiler/tools/fpp-to-dict/test/.gitignore
+++ b/compiler/tools/fpp-to-dict/test/.gitignore
@@ -1,0 +1,3 @@
+*Dictionary.json
+default-tests.sh
+default-update-ref.sh


### PR DESCRIPTION
Some generated artifacts are showing up as untracked files.