### PR TITLE
Fix bug in handling of qualified names

### DIFF
--- a/compiler/lib/src/main/scala/analysis/Semantics/Name.scala
+++ b/compiler/lib/src/main/scala/analysis/Semantics/Name.scala
@@ -24,7 +24,7 @@ object Name {
     }
 
     /** Convert a qualified name to an identifier list */
-    def toIdentList: List[Unqualified] = (base :: qualifier).reverse
+    def toIdentList: List[Unqualified] = qualifier :+ base
 
     /** Computes a short qualified name
      *  Deletes the longest prefix provided by the enclosing scope */

--- a/compiler/tools/fpp-to-cpp/test/top/NestedNamespacesTopologyAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/top/NestedNamespacesTopologyAc.ref.cpp
@@ -6,80 +6,82 @@
 
 #include "NestedNamespacesTopologyAc.hpp"
 
-namespace A {
-
-  namespace B {
+namespace M {
 
 
-    // ----------------------------------------------------------------------
-    // Helper functions
-    // ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Component instances
+  // ----------------------------------------------------------------------
 
-    void initComponents(const TopologyState& state) {
-      // Nothing to do
-    }
+  N::O::C c(FW_OPTIONAL_NAME("c"));
 
-    void configComponents(const TopologyState& state) {
-      // Nothing to do
-    }
+  // ----------------------------------------------------------------------
+  // Helper functions
+  // ----------------------------------------------------------------------
 
-    void setBaseIds() {
-      // Nothing to do
-    }
+  void initComponents(const TopologyState& state) {
+    c.init(InstanceIds::c);
+  }
 
-    void connectComponents() {
-      // Nothing to do
-    }
+  void configComponents(const TopologyState& state) {
+    // Nothing to do
+  }
 
-    void regCommands() {
-      // Nothing to do
-    }
+  void setBaseIds() {
+    c.setIdBase(BaseIds::c);
+  }
 
-    void readParameters() {
-      // Nothing to do
-    }
+  void connectComponents() {
+    // Nothing to do
+  }
 
-    void loadParameters() {
-      // Nothing to do
-    }
+  void regCommands() {
+    // Nothing to do
+  }
 
-    void startTasks(const TopologyState& state) {
-      // Nothing to do
-    }
+  void readParameters() {
+    // Nothing to do
+  }
 
-    void stopTasks(const TopologyState& state) {
-      // Nothing to do
-    }
+  void loadParameters() {
+    // Nothing to do
+  }
 
-    void freeThreads(const TopologyState& state) {
-      // Nothing to do
-    }
+  void startTasks(const TopologyState& state) {
+    // Nothing to do
+  }
 
-    void tearDownComponents(const TopologyState& state) {
-      // Nothing to do
-    }
+  void stopTasks(const TopologyState& state) {
+    // Nothing to do
+  }
 
-    // ----------------------------------------------------------------------
-    // Setup and teardown functions
-    // ----------------------------------------------------------------------
+  void freeThreads(const TopologyState& state) {
+    // Nothing to do
+  }
 
-    void setup(const TopologyState& state) {
-      initComponents(state);
-      configComponents(state);
-      setBaseIds();
-      connectComponents();
-      regCommands();
-      readParameters();
-      loadParameters();
-      startTasks(state);
-    }
+  void tearDownComponents(const TopologyState& state) {
+    // Nothing to do
+  }
 
-    void teardown(const TopologyState& state) {
-      stopTasks(state);
-      freeThreads(state);
-      tearDownComponents(state);
-    }
+  // ----------------------------------------------------------------------
+  // Setup and teardown functions
+  // ----------------------------------------------------------------------
 
+  void setup(const TopologyState& state) {
+    initComponents(state);
+    configComponents(state);
+    setBaseIds();
+    connectComponents();
+    regCommands();
+    readParameters();
+    loadParameters();
+    startTasks(state);
+  }
+
+  void teardown(const TopologyState& state) {
+    stopTasks(state);
+    freeThreads(state);
+    tearDownComponents(state);
   }
 
 }

--- a/compiler/tools/fpp-to-cpp/test/top/NestedNamespacesTopologyAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/top/NestedNamespacesTopologyAc.ref.hpp
@@ -4,79 +4,99 @@
 // \brief  hpp file for NestedNamespaces topology
 // ======================================================================
 
-#ifndef A_B_NestedNamespacesTopologyAc_HPP
-#define A_B_NestedNamespacesTopologyAc_HPP
+#ifndef M_NestedNamespacesTopologyAc_HPP
+#define M_NestedNamespacesTopologyAc_HPP
 
+#include "C.hpp"
 #include "NestedNamespacesTopologyDefs.hpp"
 
-namespace A {
+namespace M {
 
-  namespace B {
+  // ----------------------------------------------------------------------
+  // Constants
+  // ----------------------------------------------------------------------
 
-    // ----------------------------------------------------------------------
-    // Helper functions
-    // ----------------------------------------------------------------------
-
-    //! Initialize components
-    void initComponents(
-        const TopologyState& state //!< The topology state
-    );
-
-    //! Configure components
-    void configComponents(
-        const TopologyState& state //!< The topology state
-    );
-
-    //! Set component base Ids
-    void setBaseIds();
-
-    //! Connect components
-    void connectComponents();
-
-    //! Register commands
-    void regCommands();
-
-    //! Read parameters
-    void readParameters();
-
-    //! Load parameters
-    void loadParameters();
-
-    //! Start tasks
-    void startTasks(
-        const TopologyState& state //!< The topology state
-    );
-
-    //! Stop tasks
-    void stopTasks(
-        const TopologyState& state //!< The topology state
-    );
-
-    //! Free threads
-    void freeThreads(
-        const TopologyState& state //!< The topology state
-    );
-
-    //! Tear down components
-    void tearDownComponents(
-        const TopologyState& state //!< The topology state
-    );
-
-    // ----------------------------------------------------------------------
-    // Setup and teardown functions
-    // ----------------------------------------------------------------------
-
-    //! Set up the topology
-    void setup(
-        const TopologyState& state //!< The topology state
-    );
-
-    //! Tear down the topology
-    void teardown(
-        const TopologyState& state //!< The topology state
-    );
-
+  namespace BaseIds {
+    enum {
+      c = 0x100,
+    };
   }
+
+  namespace InstanceIds {
+    enum {
+      c,
+    };
+  }
+
+  // ----------------------------------------------------------------------
+  // Component instances
+  // ----------------------------------------------------------------------
+
+  //! c
+  extern N::O::C c;
+
+  // ----------------------------------------------------------------------
+  // Helper functions
+  // ----------------------------------------------------------------------
+
+  //! Initialize components
+  void initComponents(
+      const TopologyState& state //!< The topology state
+  );
+
+  //! Configure components
+  void configComponents(
+      const TopologyState& state //!< The topology state
+  );
+
+  //! Set component base Ids
+  void setBaseIds();
+
+  //! Connect components
+  void connectComponents();
+
+  //! Register commands
+  void regCommands();
+
+  //! Read parameters
+  void readParameters();
+
+  //! Load parameters
+  void loadParameters();
+
+  //! Start tasks
+  void startTasks(
+      const TopologyState& state //!< The topology state
+  );
+
+  //! Stop tasks
+  void stopTasks(
+      const TopologyState& state //!< The topology state
+  );
+
+  //! Free threads
+  void freeThreads(
+      const TopologyState& state //!< The topology state
+  );
+
+  //! Tear down components
+  void tearDownComponents(
+      const TopologyState& state //!< The topology state
+  );
+
+  // ----------------------------------------------------------------------
+  // Setup and teardown functions
+  // ----------------------------------------------------------------------
+
+  //! Set up the topology
+  void setup(
+      const TopologyState& state //!< The topology state
+  );
+
+  //! Tear down the topology
+  void teardown(
+      const TopologyState& state //!< The topology state
+  );
 
 }
 

--- a/compiler/tools/fpp-to-cpp/test/top/nested_namespaces.fpp
+++ b/compiler/tools/fpp-to-cpp/test/top/nested_namespaces.fpp
@@ -1,10 +1,26 @@
-module A {
+module M {
 
-  module B {
+  module N {
 
-    topology NestedNamespaces {
+    module O {
+
+      passive component C {
+
+      }
 
     }
+
+  }
+
+}
+
+instance c: M.N.O.C base id 0x100
+
+module M {
+
+  topology NestedNamespaces {
+
+    instance c
 
   }
 


### PR DESCRIPTION
When computing a short name, the system was reversing the list of qualifiers in the prefix.

* Fix bug
* Update unit tests to exercise the correct behavior

Closes #453.