### PR TITLE
Updated XML and GDS limitations #402

### DIFF
--- a/docs/fpp-spec.html
+++ b/docs/fpp-spec.html
@@ -5,7 +5,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="Asciidoctor 2.0.20">
-<title>The F Prime Prime (FPP) Language Specification, Unreleased, after v2.0.2</title>
+<title>The F Prime Prime (FPP) Language Specification, v2.1.0</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
 /*! Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
@@ -436,7 +436,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </head>
 <body class="article toc2 toc-left">
 <div id="header">
-<h1>The F Prime Prime (FPP) Language Specification, Unreleased, after v2.0.2</h1>
+<h1>The F Prime Prime (FPP) Language Specification, v2.1.0</h1>
 <div id="toc" class="toc2">
 <div id="toctitle">Table of Contents</div>
 <ul class="sectlevel1">
@@ -8551,7 +8551,7 @@ equivalent.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2024-06-25 11:50:06 -0700
+Last updated 2024-06-25 13:02:44 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-spec.html
+++ b/docs/fpp-spec.html
@@ -8551,7 +8551,7 @@ equivalent.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2024-06-20 11:07:32 -0700
+Last updated 2024-06-25 11:50:06 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-users-guide.html
+++ b/docs/fpp-users-guide.html
@@ -1945,32 +1945,6 @@ module M {
 }</code></pre>
 </div>
 </div>
-<div class="paragraph">
-<p><strong>XML limitation:</strong> The F Prime XML format supports
-only one level of C&#43;&#43; namespaces.
-Therefore nested modules are not translated properly to C&#43;&#43;.
-As a workaround, you can use an underscore prefix.
-For example, instead of writing</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="prettyprint highlight"><code data-lang="fpp">module A {
-  module B {
-
-  }
-}</code></pre>
-</div>
-</div>
-<div class="paragraph">
-<p>you can write</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="prettyprint highlight"><code data-lang="fpp">module A_B {
-
-}</code></pre>
-</div>
-</div>
 </div>
 </div>
 <div class="sect1">
@@ -2576,13 +2550,6 @@ For example, this code is accepted:</p>
 <p>The member <code>x</code> of the struct <code>S</code> gets three copies of the value
 10 specified for <code>x</code> in the default value expression.</p>
 </div>
-<div class="paragraph">
-<p><strong>GDS limitation:</strong> The F Prime GDS does not properly handle
-member arrays.
-Therefore, if you plan to use the F Prime GDS, then you should avoid
-using a struct type with a member array in the flight-ground interface (i.e.,
-commands, events, telemetry, and parameters).</p>
-</div>
 </div>
 <div class="sect3">
 <h4 id="Defining-Types_Struct-Type-Definitions_Member-Format-Strings">6.2.5. Member Format Strings</h4>
@@ -2996,15 +2963,6 @@ the enum name, separated from the name by a colon, like this:</p>
 <code>Small.A</code>, <code>Small.B</code>, and <code>Small.C</code>.
 Each of the enumerated constants is represented as a <code>U8</code> value
 in C&#43;&#43;.</p>
-</div>
-<div class="paragraph">
-<p><strong>GDS limitation:</strong>
-The F Prime GDS currently assumes that all enums use the default representation
-size of <code>I32</code>.
-Therefore, if you plan to use the F Prime GDS, then
-you should not use any enum with a specified representation
-type other than <code>I32</code> in the flight-ground interface (i.e., commands, events, telemetry,
-and parameters).</p>
 </div>
 </div>
 <div class="sect2">
@@ -5685,11 +5643,6 @@ has a numeric type; or (3) an array or struct type
 each of whose members satisfies condition (1) or
 condition (2).</p>
 </div>
-<div class="paragraph">
-<p><strong>XML limitation:</strong> The F Prime XML representation does
-not allow limits for telemetry channels
-of array or struct type.</p>
-</div>
 </div>
 </div>
 <div class="sect2">
@@ -6397,34 +6350,6 @@ active component Switch {
 when the definition logically belongs to the component.
 The name scoping mechanism emphasizes the hierarchical relationship
 and prevents name clashes.</p>
-</div>
-<div class="paragraph">
-<p><strong>XML limitation:</strong> In most cases, a qualified name such as <code>Switch.State</code>
-in FPP becomes a qualified name such as <code>Switch::State</code> when translating
-to C&#43;&#43;.
-However, the F Prime XML format does not support the definition
-of constants and types as members of C&#43;&#43; components.
-Therefore, when translating the previous example through XML to C&#43;&#43;,
-the following occurs:</p>
-</div>
-<div class="olist arabic">
-<ol class="arabic">
-<li>
-<p>The component <code>Switch</code> becomes an auto-generated C&#43;&#43; class
-<code>SwitchComponentBase</code>.</p>
-</li>
-<li>
-<p>The type <code>State</code> becomes a C&#43;&#43; class <code>Switch_State</code>.</p>
-</li>
-</ol>
-</div>
-<div class="paragraph">
-<p>Similarly, the FPP constant <code>SerialSplitter.splitFactor</code>
-becomes a C&#43;&#43; constant <code>SerialSplitter_SplitFactor</code>.
-We will have more to say about this issue in the sections on
-<a href="#Analyzing-and-Translating-Models_Generating-XML">generating XML</a>
-and
-<a href="#Analyzing-and-Translating-Models_Generating-C-Plus-Plus">generating C&#43;&#43;</a>.</p>
 </div>
 </div>
 <div class="sect2">

--- a/docs/fpp-users-guide.html
+++ b/docs/fpp-users-guide.html
@@ -739,7 +739,7 @@ well-tailored to its purpose.</p>
 </li>
 <li>
 <p>To generate code in the various languages that F Prime uses, e.g.,
-C&#43;&#43;, Python, XML.
+C&#43;&#43;, JSON, and XML.
 In this document, we will call these languages the <strong>target languages</strong>.</p>
 </li>
 </ul>
@@ -764,23 +764,6 @@ A more detailed and precise description is available in
 <a href="https://fprime-community.github.io/fpp/fpp-spec.html"><em>The FPP Language
 Specification</em></a>.
 We recommend that you read this document before consulting that one.</p>
-</div>
-<div class="paragraph">
-<p><strong>XML limitations:</strong>
-As of this writing, F Prime still uses an older XML format, e.g.,
-to support the Ground Data System (GDS).
-Some features of FPP are not supported in the XML representation.
-Where a feature is not supported in XML, we will call out this fact in a
-note marked <strong>XML limitation</strong>.
-As we phase out the XML code generation, we will phase in support
-for all the features described here.</p>
-</div>
-<div class="paragraph">
-<p><strong>GDS limitations:</strong>
-It is currently possible to construct FPP models that are not
-fully supported by the F Prime Ground Data System (GDS).
-Where an FPP feature is not supported in the GDS, we will call out this
-fact in a note marked <strong>GDS limitation.</strong></p>
 </div>
 <div class="paragraph">
 <p><strong>Overview:</strong> The rest of this document proceeds as follows.
@@ -6351,6 +6334,34 @@ when the definition logically belongs to the component.
 The name scoping mechanism emphasizes the hierarchical relationship
 and prevents name clashes.</p>
 </div>
+<div class="paragraph">
+<p>In most cases, a qualified name such as <code>Switch.State</code>
+in FPP becomes a qualified name such as <code>Switch::State</code> when translating
+to C&#43;&#43;.
+However, the F Prime XML format does not support the definition
+of constants and types as members of C&#43;&#43; components.
+Therefore, when translating the previous example to C&#43;&#43;,
+the following occurs:</p>
+</div>
+<div class="olist arabic">
+<ol class="arabic">
+<li>
+<p>The component <code>Switch</code> becomes an auto-generated C&#43;&#43; class
+<code>SwitchComponentBase</code>.</p>
+</li>
+<li>
+<p>The type <code>State</code> becomes a C&#43;&#43; class <code>Switch_State</code>.</p>
+</li>
+</ol>
+</div>
+<div class="paragraph">
+<p>Similarly, the FPP constant <code>SerialSplitter.splitFactor</code>
+becomes a C&#43;&#43; constant <code>SerialSplitter_SplitFactor</code>.
+We will have more to say about this issue in the sections on
+<a href="#Analyzing-and-Translating-Models_Generating-XML">generating XML</a>
+and
+<a href="#Analyzing-and-Translating-Models_Generating-C-Plus-Plus">generating C&#43;&#43;</a>.</p>
+</div>
 </div>
 <div class="sect2">
 <h3 id="Defining-Components_Include-Specifiers">9.11. Include Specifiers</h3>
@@ -7458,7 +7469,7 @@ named <code>C1</code> and <code>C2</code>.</p>
 <p>As shown, to write an instance specifier, you write the
 keyword <code>instance</code> and the name of a component instance
 definition.
-In general the name may be a qualified name such as <code>A.B</code>
+In general the name may be a qualified name such as <code>A.B</code>.
 if the instance is defined inside a
 <a href="#Defining-Modules">module</a>; in this simple
 example it is not.
@@ -9947,7 +9958,11 @@ even though <code>c.Out</code> has two ports and only one of them is connected.<
 <div class="sect2">
 <h3 id="Analyzing-and-Translating-Models_Generating-XML">13.2. Generating XML</h3>
 <div class="paragraph">
-<p>This section describes how to generate XML from FPP.</p>
+<p>The use of XML in F Prime is being phased out in favor of generating
+JSON and directly generating C&#43;&#43;.
+However, the F Prime XML representation is still used, e.g., in
+for specifying the layout of telemetry packets.
+This section describes how to generate XML from FPP.</p>
 </div>
 <div class="paragraph">
 <p><strong>XML file names:</strong> The table <a href="#xml-file-names">XML File Names</a> shows how FPP definitions are
@@ -10254,12 +10269,6 @@ an automatic default of 80.</p>
 you can provide FPP source on standard input, as described
 for <a href="#Analyzing-and-Translating-Models_Checking-Models"><code>fpp-check</code></a>.</p>
 </div>
-<div class="paragraph">
-<p><strong>XML limitations:</strong> The XML translation has several
-limitations.
-For more information, see the text marked <strong>XML limitations</strong> elsewhere
-in this manual.</p>
-</div>
 </div>
 <div class="sect2">
 <h3 id="Analyzing-and-Translating-Models_Generating-C-Plus-Plus">13.3. Generating C Plus Plus</h3>
@@ -10536,7 +10545,7 @@ This is similar to the <code>-d</code> option for
 <a href="#Analyzing-and-Translating-Models_Generating-XML"><code>fpp-to-xml</code></a>.</p>
 </li>
 <li>
-<p><code>-n</code> <em>file</em> : Write the names of the generated XML files
+<p><code>-n</code> <em>file</em> : Write the names of the generated C&#43;&#43; files
 to <em>file</em>.
 This is similar to the <code>-n</code> option for
 <a href="#Analyzing-and-Translating-Models_Generating-XML"><code>fpp-to-xml</code></a>.</p>
@@ -12285,7 +12294,7 @@ function, you may.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2024-06-20 11:08:28 -0700
+Last updated 2024-06-25 11:58:28 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-users-guide.html
+++ b/docs/fpp-users-guide.html
@@ -9958,7 +9958,7 @@ even though <code>c.Out</code> has two ports and only one of them is connected.<
 <div class="sect2">
 <h3 id="Analyzing-and-Translating-Models_Generating-XML">13.2. Generating XML</h3>
 <div class="paragraph">
-<p>The use of XML in F Prime is being phased out in favor of generating
+<p>We are phasing out The use of XML in favor of generating
 JSON and directly generating C&#43;&#43;.
 However, the F Prime XML representation is still used, e.g., in
 for specifying the layout of telemetry packets.
@@ -12294,7 +12294,7 @@ function, you may.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2024-06-25 13:03:19 -0700
+Last updated 2024-06-25 13:05:06 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-users-guide.html
+++ b/docs/fpp-users-guide.html
@@ -5,7 +5,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="Asciidoctor 2.0.20">
-<title>The F Prime Prime (FPP) User&#8217;s Guide, Unreleased, after v2.0.2</title>
+<title>The F Prime Prime (FPP) User&#8217;s Guide, v2.1.0</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
 /*! Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
@@ -436,7 +436,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </head>
 <body class="article toc2 toc-left">
 <div id="header">
-<h1>The F Prime Prime (FPP) User&#8217;s Guide, Unreleased, after v2.0.2</h1>
+<h1>The F Prime Prime (FPP) User&#8217;s Guide, v2.1.0</h1>
 <div id="toc" class="toc2">
 <div id="toctitle">Table of Contents</div>
 <ul class="sectlevel1">
@@ -12294,7 +12294,7 @@ function, you may.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2024-06-25 11:58:28 -0700
+Last updated 2024-06-25 13:03:19 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-users-guide.html
+++ b/docs/fpp-users-guide.html
@@ -1938,7 +1938,7 @@ module M {
 These definitions describe named types that may be used elsewhere in the
 model and that may generate code in the target language.
 For example,
-an FPP type definition may become a class definition in C&#43;&#43; or Python.</p>
+an FPP type definition may become a class definition in C&#43;&#43;.</p>
 </div>
 <div class="paragraph">
 <p>There are three kinds of type definitions:</p>
@@ -12294,7 +12294,7 @@ function, you may.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2024-06-25 13:13:18 -0700
+Last updated 2024-06-25 13:29:47 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-users-guide.html
+++ b/docs/fpp-users-guide.html
@@ -776,7 +776,7 @@ Section 12 explains how to specify a model as a collection
 of files: for example, it covers the management of dependencies
 between files.
 Section 13 explains how to analyze FPP models and how
-to translate FPP models to XML, to C&#43;&#43;, and from XML.
+to translate FPP models to and from XML, to C&#43;&#43;, and to JSON.
 Section 14 explains how to write a C&#43;&#43; implementation
 against the code generated from an FPP model.</p>
 </div>
@@ -12294,7 +12294,7 @@ function, you may.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2024-06-25 13:05:06 -0700
+Last updated 2024-06-25 13:13:18 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-users-guide.html
+++ b/docs/fpp-users-guide.html
@@ -9958,7 +9958,7 @@ even though <code>c.Out</code> has two ports and only one of them is connected.<
 <div class="sect2">
 <h3 id="Analyzing-and-Translating-Models_Generating-XML">13.2. Generating XML</h3>
 <div class="paragraph">
-<p>We are phasing out The use of XML in favor of generating
+<p>We are phasing out the use of XML in favor of generating
 JSON and directly generating C&#43;&#43;.
 However, the F Prime XML representation is still used, e.g., in
 for specifying the layout of telemetry packets.
@@ -12294,7 +12294,7 @@ function, you may.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2024-06-25 13:29:47 -0700
+Last updated 2024-06-26 08:38:10 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -453,17 +453,17 @@ generated code.</p>
 <div class="ulist">
 <ul>
 <li>
-<p><a href="https://github.com/fprime-community/fpp">The FPP repository on GitHub</a>.</p>
+<p><a href="https://github.com/nasa/fpp">The FPP repository on GitHub</a>.</p>
 </li>
 <li>
-<p><a href="https://github.com/fprime-community/fpp/wiki">The FPP wiki</a>.</p>
+<p><a href="https://github.com/nasa/fpp/wiki">The FPP wiki</a>.</p>
 </li>
 </ul>
 </div>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2024-03-19 08:19:11 -0700
+Last updated 2024-06-25 13:07:03 -0700
 </div>
 </div>
 </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -463,7 +463,7 @@ generated code.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2021-10-04 10:03:10 -0700
+Last updated 2024-03-19 08:19:11 -0700
 </div>
 </div>
 </body>

--- a/docs/index/index.adoc
+++ b/docs/index/index.adoc
@@ -10,6 +10,6 @@ generated code.
 
 For more information on FPP, see the following resources:
 
-* https://github.com/fprime-community/fpp[The FPP repository on GitHub].
+* https://github.com/nasa/fpp[The FPP repository on GitHub].
 
-* https://github.com/fprime-community/fpp/wiki[The FPP wiki].
+* https://github.com/nasa/fpp/wiki[The FPP wiki].

--- a/docs/users-guide/Analyzing-and-Translating-Models.adoc
+++ b/docs/users-guide/Analyzing-and-Translating-Models.adoc
@@ -138,6 +138,10 @@ even though `c.Out` has two ports and only one of them is connected.
 
 === Generating XML
 
+The use of XML in F Prime is being phased out in favor of generating
+JSON and directly generating {cpp}.
+However, the F Prime XML representation is still used, e.g., in
+for specifying the layout of telemetry packets.
 This section describes how to generate XML from FPP.
 
 *XML file names:* The table <<xml-file-names>> shows how FPP definitions are
@@ -348,11 +352,6 @@ an automatic default of 80.
 you can provide FPP source on standard input, as described
 for <<Analyzing-and-Translating-Models_Checking-Models,`fpp-check`>>.
 
-*XML limitations:* The XML translation has several
-limitations.
-For more information, see the text marked *XML limitations* elsewhere
-in this manual.
-
 === Generating C Plus Plus
 
 This section describes how to generate {cpp} from FPP.
@@ -542,7 +541,7 @@ the output directory for writing files.
 This is similar to the `-d` option for
 <<Analyzing-and-Translating-Models_Generating-XML, `fpp-to-xml`>>.
 
-* `-n` _file_ : Write the names of the generated XML files
+* `-n` _file_ : Write the names of the generated {cpp} files
 to _file_.
 This is similar to the `-n` option for
 <<Analyzing-and-Translating-Models_Generating-XML, `fpp-to-xml`>>.

--- a/docs/users-guide/Analyzing-and-Translating-Models.adoc
+++ b/docs/users-guide/Analyzing-and-Translating-Models.adoc
@@ -138,7 +138,7 @@ even though `c.Out` has two ports and only one of them is connected.
 
 === Generating XML
 
-We are phasing out The use of XML in favor of generating
+We are phasing out the use of XML in favor of generating
 JSON and directly generating {cpp}.
 However, the F Prime XML representation is still used, e.g., in
 for specifying the layout of telemetry packets.

--- a/docs/users-guide/Analyzing-and-Translating-Models.adoc
+++ b/docs/users-guide/Analyzing-and-Translating-Models.adoc
@@ -138,7 +138,7 @@ even though `c.Out` has two ports and only one of them is connected.
 
 === Generating XML
 
-The use of XML in F Prime is being phased out in favor of generating
+We are phasing out The use of XML in favor of generating
 JSON and directly generating {cpp}.
 However, the F Prime XML representation is still used, e.g., in
 for specifying the layout of telemetry packets.

--- a/docs/users-guide/Defining-Components.adoc
+++ b/docs/users-guide/Defining-Components.adoc
@@ -1850,10 +1850,6 @@ has a numeric type; or (3) an array or struct type
 each of whose members satisfies condition (1) or
 condition (2).
 
-*XML limitation:* The F Prime XML representation does
-not allow limits for telemetry channels
-of array or struct type.
-
 === Parameters
 
 When defining an F Prime component, you may specify one or more
@@ -2508,12 +2504,12 @@ when the definition logically belongs to the component.
 The name scoping mechanism emphasizes the hierarchical relationship
 and prevents name clashes.
 
-*XML limitation:* In most cases, a qualified name such as `Switch.State`
+In most cases, a qualified name such as `Switch.State`
 in FPP becomes a qualified name such as `Switch::State` when translating
 to {cpp}.
 However, the F Prime XML format does not support the definition
 of constants and types as members of {cpp} components.
-Therefore, when translating the previous example through XML to {cpp},
+Therefore, when translating the previous example to {cpp},
 the following occurs:
 
 . The component `Switch` becomes an auto-generated {cpp} class

--- a/docs/users-guide/Defining-Enums.adoc
+++ b/docs/users-guide/Defining-Enums.adoc
@@ -168,14 +168,6 @@ This code defines an enum `Small` with three enumerated constants
 Each of the enumerated constants is represented as a `U8` value
 in {cpp}.
 
-*GDS limitation:*
-The F Prime GDS currently assumes that all enums use the default representation
-size of `I32`.
-Therefore, if you plan to use the F Prime GDS, then
-you should not use any enum with a specified representation
-type other than `I32` in the flight-ground interface (i.e., commands, events, telemetry,
-and parameters).
-
 === The Default Value
 
 Every type in FPP has an associated default value.

--- a/docs/users-guide/Defining-Modules.adoc
+++ b/docs/users-guide/Defining-Modules.adoc
@@ -102,28 +102,3 @@ module M {
   constant a = 0
 }
 ----
-
-*XML limitation:* The F Prime XML format supports
-only one level of {cpp} namespaces.
-Therefore nested modules are not translated properly to {cpp}.
-As a workaround, you can use an underscore prefix.
-For example, instead of writing
-
-[source,fpp]
-----
-module A {
-  module B {
-
-  }
-}
-----
-
-you can write
-
-[source,fpp]
-
-----
-module A_B {
-
-}
-----

--- a/docs/users-guide/Defining-Topologies.adoc
+++ b/docs/users-guide/Defining-Topologies.adoc
@@ -76,7 +76,7 @@ named `C1` and `C2`.
 As shown, to write an instance specifier, you write the
 keyword `instance` and the name of a component instance
 definition.
-In general the name may be a qualified name such as `A.B`
+In general the name may be a qualified name such as `A.B`.
 if the instance is defined inside a
 <<Defining-Modules,module>>; in this simple
 example it is not.

--- a/docs/users-guide/Defining-Types.adoc
+++ b/docs/users-guide/Defining-Types.adoc
@@ -4,7 +4,7 @@ An FPP model may include one or more *type definitions*.
 These definitions describe named types that may be used elsewhere in the
 model and that may generate code in the target language.
 For example,
-an FPP type definition may become a class definition in {cpp} or Python.
+an FPP type definition may become a class definition in {cpp}.
 
 There are three kinds of type definitions:
 

--- a/docs/users-guide/Defining-Types.adoc
+++ b/docs/users-guide/Defining-Types.adoc
@@ -477,12 +477,6 @@ struct S {
 The member `x` of the struct `S` gets three copies of the value
 10 specified for `x` in the default value expression.
 
-*GDS limitation:* The F Prime GDS does not properly handle
-member arrays.
-Therefore, if you plan to use the F Prime GDS, then you should avoid
-using a struct type with a member array in the flight-ground interface (i.e.,
-commands, events, telemetry, and parameters).
-
 ==== Member Format Strings
 
 For any struct member, you can include an optional format.

--- a/docs/users-guide/Introduction.adoc
+++ b/docs/users-guide/Introduction.adoc
@@ -48,6 +48,6 @@ Section 12 explains how to specify a model as a collection
 of files: for example, it covers the management of dependencies
 between files.
 Section 13 explains how to analyze FPP models and how
-to translate FPP models to XML, to {cpp}, and from XML.
+to translate FPP models to and from XML, to {cpp}, and to JSON.
 Section 14 explains how to write a {cpp} implementation
 against the code generated from an FPP model.

--- a/docs/users-guide/Introduction.adoc
+++ b/docs/users-guide/Introduction.adoc
@@ -17,7 +17,7 @@ well-tailored to its purpose.
 * To provide semantic checking and error reporting for F Prime models.
 
 * To generate code in the various languages that F Prime uses, e.g.,
-{cpp}, Python, XML.
+{cpp}, JSON, and XML.
 In this document, we will call these languages the *target languages*.
 
 Developers may combine code generated from FPP with code written by hand to
@@ -37,21 +37,6 @@ A more detailed and precise description is available in
 https://fprime-community.github.io/fpp/fpp-spec.html[_The FPP Language
 Specification_].
 We recommend that you read this document before consulting that one.
-
-*XML limitations:*
-As of this writing, F Prime still uses an older XML format, e.g.,
-to support the Ground Data System (GDS).
-Some features of FPP are not supported in the XML representation.
-Where a feature is not supported in XML, we will call out this fact in a
-note marked *XML limitation*.
-As we phase out the XML code generation, we will phase in support
-for all the features described here.
-
-*GDS limitations:*
-It is currently possible to construct FPP models that are not
-fully supported by the F Prime Ground Data System (GDS).
-Where an FPP feature is not supported in the GDS, we will call out this
-fact in a note marked *GDS limitation.*
 
 *Overview:* The rest of this document proceeds as follows.
 Section 2 explains how to get up and running with FPP.

--- a/version.sh
+++ b/version.sh
@@ -2,4 +2,4 @@
 # The FPP version
 # ----------------------------------------------------------------------
 
-export VERSION="Unreleased, after v2.0.2"
+export VERSION="v2.1.0"


### PR DESCRIPTION
Removed XML and GDS limitations that are no longer relevant and/or fixed.

I removed any limitations that are related to XML to CPP since we no longer use the XML to generate CPP.

Also, for the XML limitation regarding limits for telemetry channels of array or struct types - I verified that the limits for these types are in the XML and JSON dictionary, however, the limits do not appears in the telemetry tab in the GDS. Based on [#2754](https://github.com/nasa/fprime/issues/2754), this appears to be a bug in the GDS, so I think we can change this to a GDS limitation or leave it out... @bocchino let me know what you think!

Closes #402.