### PR TITLE
fpp-to-json Patterned Connection Graph test case

### DIFF
--- a/compiler/lib/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/compiler/lib/src/main/resources/META-INF/native-image/reflect-config.json
@@ -447,8 +447,52 @@
   "fields":[{"name":"0bitmap$166"}]
 },
 {
+  "name":"fpp.compiler.codegen.AnalysisJsonEncoder$$anon$1340",
+  "fields":[{"name":"0bitmap$1248"}]
+},
+{
+  "name":"fpp.compiler.codegen.AnalysisJsonEncoder$$anon$1341",
+  "fields":[{"name":"0bitmap$1238"}]
+},
+{
   "name":"fpp.compiler.codegen.AnalysisJsonEncoder$$anon$135",
   "fields":[{"name":"0bitmap$152"}]
+},
+{
+  "name":"fpp.compiler.codegen.AnalysisJsonEncoder$$anon$1356",
+  "fields":[{"name":"0bitmap$1247"}]
+},
+{
+  "name":"fpp.compiler.codegen.AnalysisJsonEncoder$$anon$1357",
+  "fields":[{"name":"0bitmap$1246"}]
+},
+{
+  "name":"fpp.compiler.codegen.AnalysisJsonEncoder$$anon$1358",
+  "fields":[{"name":"0bitmap$1239"}]
+},
+{
+  "name":"fpp.compiler.codegen.AnalysisJsonEncoder$$anon$1359",
+  "fields":[{"name":"0bitmap$1240"}]
+},
+{
+  "name":"fpp.compiler.codegen.AnalysisJsonEncoder$$anon$1360",
+  "fields":[{"name":"0bitmap$1241"}]
+},
+{
+  "name":"fpp.compiler.codegen.AnalysisJsonEncoder$$anon$1361",
+  "fields":[{"name":"0bitmap$1242"}]
+},
+{
+  "name":"fpp.compiler.codegen.AnalysisJsonEncoder$$anon$1362",
+  "fields":[{"name":"0bitmap$1243"}]
+},
+{
+  "name":"fpp.compiler.codegen.AnalysisJsonEncoder$$anon$1363",
+  "fields":[{"name":"0bitmap$1244"}]
+},
+{
+  "name":"fpp.compiler.codegen.AnalysisJsonEncoder$$anon$1364",
+  "fields":[{"name":"0bitmap$1245"}]
 },
 {
   "name":"fpp.compiler.codegen.AnalysisJsonEncoder$$anon$1368",

--- a/compiler/tools/fpp-to-json/test/Fw/symbols.fpp
+++ b/compiler/tools/fpp-to-json/test/Fw/symbols.fpp
@@ -1,0 +1,18 @@
+# Symbols to be used in test cases that require some symbols to be defined
+
+module Fw {
+  port Time
+  port CmdReg
+  port Cmd
+  port CmdResponse
+  port Log
+  port LogText
+  port PrmGet
+  port PrmSet
+  port Tlm
+  port TlmGet
+}
+
+module Svc {
+  port Ping
+}

--- a/compiler/tools/fpp-to-json/test/fprime/defs.fpp
+++ b/compiler/tools/fpp-to-json/test/fprime/defs.fpp
@@ -1,14 +1,14 @@
-# Symbols to be used in test cases that require some symbols to be defined
+# Placeholders for definitions provided by F Prime
 
 module Fw {
-  port Time
-  port CmdReg
   port Cmd
+  port CmdReg
   port CmdResponse
   port Log
   port LogText
   port PrmGet
   port PrmSet
+  port Time
   port Tlm
   port TlmGet
 }

--- a/compiler/tools/fpp-to-json/test/patternedConnections.fpp
+++ b/compiler/tools/fpp-to-json/test/patternedConnections.fpp
@@ -1,0 +1,58 @@
+passive component Time {
+    sync input port timeGetPort: Fw.Time
+}
+
+passive component Command {
+    sync input port cmdIn: Fw.Cmd
+    sync input port cmdRegOut: Fw.CmdReg
+    sync input port cmdResponseOut: Fw.CmdResponse
+    output port cmdSend: Fw.Cmd
+}
+
+passive component Event {
+    sync input port eventLog: Fw.Log
+}
+
+passive component Health {
+    output port PingSend: Svc.Ping
+    sync input port PingReturn: Svc.Ping
+}
+
+passive component Param {
+    sync input port paramGet: Fw.PrmGet
+    sync input port paramSet: Fw.PrmSet
+}
+
+passive component Telemetry {
+    sync input port tlm: Fw.Tlm
+}
+
+passive component TextEvent {
+    sync input port textEventLog: Fw.LogText
+}
+
+instance c1: Time base id 0x100
+instance c2: Command base id 0x200
+instance c3: Event base id 0x300
+instance c4: Health base id 0x400
+instance c5: Param base id 0x500
+instance c6: Telemetry base id 0x600
+instance c7: TextEvent base id 0x700
+
+topology T {
+    instance c1
+    instance c2
+    instance c3
+    instance c4
+    instance c5
+    instance c6
+    instance c7
+
+    time connections instance c1
+    command connections instance c2
+    event connections instance c3
+    health connections instance c4
+    param connections instance c5
+    telemetry connections instance c6
+    text event connections instance c7
+}

--- a/compiler/tools/fpp-to-json/test/patternedConnections.ref.txt
+++ b/compiler/tools/fpp-to-json/test/patternedConnections.ref.txt
@@ -1676,7 +1676,7 @@
                           "node" : {
                             "AstNode" : {
                               "data" : {
-                                "name" : "Time",
+                                "name" : "Cmd",
                                 "params" : [
                                 ],
                                 "returnType" : "None"
@@ -1718,7 +1718,7 @@
                           "node" : {
                             "AstNode" : {
                               "data" : {
-                                "name" : "Cmd",
+                                "name" : "CmdResponse",
                                 "params" : [
                                 ],
                                 "returnType" : "None"
@@ -1739,7 +1739,7 @@
                           "node" : {
                             "AstNode" : {
                               "data" : {
-                                "name" : "CmdResponse",
+                                "name" : "Log",
                                 "params" : [
                                 ],
                                 "returnType" : "None"
@@ -1760,7 +1760,7 @@
                           "node" : {
                             "AstNode" : {
                               "data" : {
-                                "name" : "Log",
+                                "name" : "LogText",
                                 "params" : [
                                 ],
                                 "returnType" : "None"
@@ -1781,7 +1781,7 @@
                           "node" : {
                             "AstNode" : {
                               "data" : {
-                                "name" : "LogText",
+                                "name" : "PrmGet",
                                 "params" : [
                                 ],
                                 "returnType" : "None"
@@ -1802,7 +1802,7 @@
                           "node" : {
                             "AstNode" : {
                               "data" : {
-                                "name" : "PrmGet",
+                                "name" : "PrmSet",
                                 "params" : [
                                 ],
                                 "returnType" : "None"
@@ -1823,7 +1823,7 @@
                           "node" : {
                             "AstNode" : {
                               "data" : {
-                                "name" : "PrmSet",
+                                "name" : "Time",
                                 "params" : [
                                 ],
                                 "returnType" : "None"
@@ -1911,7 +1911,7 @@
                                 ],
                                 "returnType" : "None"
                               },
-                              "id" : 309
+                              "id" : 301
                             }
                           }
                         }
@@ -1921,7 +1921,7 @@
                     ]
                   ]
                 },
-                "id" : 310
+                "id" : 302
               }
             }
           }
@@ -3364,127 +3364,87 @@
     "includingLoc" : "None"
   },
   "286" : {
-    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
     "pos" : "4.3",
     "includingLoc" : "None"
   },
   "287" : {
-    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
     "pos" : "5.3",
     "includingLoc" : "None"
   },
   "288" : {
-    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
     "pos" : "6.3",
     "includingLoc" : "None"
   },
   "289" : {
-    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
     "pos" : "7.3",
     "includingLoc" : "None"
   },
   "290" : {
-    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
     "pos" : "8.3",
     "includingLoc" : "None"
   },
   "291" : {
-    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
     "pos" : "9.3",
     "includingLoc" : "None"
   },
   "292" : {
-    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
     "pos" : "10.3",
     "includingLoc" : "None"
   },
   "293" : {
-    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
     "pos" : "11.3",
     "includingLoc" : "None"
   },
   "294" : {
-    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
     "pos" : "12.3",
     "includingLoc" : "None"
   },
   "295" : {
-    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
     "pos" : "13.3",
     "includingLoc" : "None"
   },
   "296" : {
-    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
     "pos" : "13.3",
     "includingLoc" : "None"
   },
   "297" : {
-    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
     "pos" : "13.3",
     "includingLoc" : "None"
   },
   "298" : {
-    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
     "pos" : "3.1",
     "includingLoc" : "None"
   },
   "299" : {
-    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
     "pos" : "17.3",
     "includingLoc" : "None"
   },
   "300" : {
-    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
     "pos" : "17.3",
     "includingLoc" : "None"
   },
   "301" : {
-    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
     "pos" : "17.3",
     "includingLoc" : "None"
   },
   "302" : {
-    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
-    "pos" : "16.1",
-    "includingLoc" : "None"
-  },
-  "303" : {
-    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
-    "pos" : "17.3",
-    "includingLoc" : "None"
-  },
-  "304" : {
-    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
-    "pos" : "17.3",
-    "includingLoc" : "None"
-  },
-  "305" : {
-    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
-    "pos" : "17.3",
-    "includingLoc" : "None"
-  },
-  "306" : {
-    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
-    "pos" : "16.1",
-    "includingLoc" : "None"
-  },
-  "307" : {
-    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
-    "pos" : "17.3",
-    "includingLoc" : "None"
-  },
-  "308" : {
-    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
-    "pos" : "17.3",
-    "includingLoc" : "None"
-  },
-  "309" : {
-    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
-    "pos" : "17.3",
-    "includingLoc" : "None"
-  },
-  "310" : {
-    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
     "pos" : "16.1",
     "includingLoc" : "None"
   }
@@ -3686,7 +3646,7 @@
               "DefPort" : {
                 "symbol" : {
                   "Port" : {
-                    "nodeId" : 309,
+                    "nodeId" : 301,
                     "unqualifiedName" : "Ping"
                   }
                 }
@@ -3721,7 +3681,7 @@
               "DefPort" : {
                 "symbol" : {
                   "Port" : {
-                    "nodeId" : 309,
+                    "nodeId" : 301,
                     "unqualifiedName" : "Ping"
                   }
                 }
@@ -3794,7 +3754,7 @@
               "DefPort" : {
                 "symbol" : {
                   "Port" : {
-                    "nodeId" : 286,
+                    "nodeId" : 293,
                     "unqualifiedName" : "Time"
                   }
                 }
@@ -3867,7 +3827,7 @@
               "DefPort" : {
                 "symbol" : {
                   "Port" : {
-                    "nodeId" : 292,
+                    "nodeId" : 291,
                     "unqualifiedName" : "PrmGet"
                   }
                 }
@@ -3902,7 +3862,7 @@
               "DefPort" : {
                 "symbol" : {
                   "Port" : {
-                    "nodeId" : 293,
+                    "nodeId" : 292,
                     "unqualifiedName" : "PrmSet"
                   }
                 }
@@ -3975,7 +3935,7 @@
               "DefPort" : {
                 "symbol" : {
                   "Port" : {
-                    "nodeId" : 291,
+                    "nodeId" : 290,
                     "unqualifiedName" : "LogText"
                   }
                 }
@@ -4121,7 +4081,7 @@
               "DefPort" : {
                 "symbol" : {
                   "Port" : {
-                    "nodeId" : 290,
+                    "nodeId" : 289,
                     "unqualifiedName" : "Log"
                   }
                 }
@@ -4194,7 +4154,7 @@
               "DefPort" : {
                 "symbol" : {
                   "Port" : {
-                    "nodeId" : 288,
+                    "nodeId" : 286,
                     "unqualifiedName" : "Cmd"
                   }
                 }
@@ -4264,7 +4224,7 @@
               "DefPort" : {
                 "symbol" : {
                   "Port" : {
-                    "nodeId" : 289,
+                    "nodeId" : 288,
                     "unqualifiedName" : "CmdResponse"
                   }
                 }
@@ -4299,7 +4259,7 @@
               "DefPort" : {
                 "symbol" : {
                   "Port" : {
-                    "nodeId" : 288,
+                    "nodeId" : 286,
                     "unqualifiedName" : "Cmd"
                   }
                 }
@@ -4344,7 +4304,7 @@
   "includedFileSet" : [
   ],
   "inputFileSet" : [
-    "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
     "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp"
   ],
   "locationSpecifierMap" : [
@@ -4380,12 +4340,6 @@
         "unqualifiedName" : "Fw"
       }
     },
-    "309" : {
-      "Module" : {
-        "nodeId" : 310,
-        "unqualifiedName" : "Svc"
-      }
-    },
     "293" : {
       "Module" : {
         "nodeId" : 298,
@@ -4402,6 +4356,12 @@
       "Module" : {
         "nodeId" : 298,
         "unqualifiedName" : "Fw"
+      }
+    },
+    "301" : {
+      "Module" : {
+        "nodeId" : 302,
+        "unqualifiedName" : "Svc"
       }
     },
     "286" : {
@@ -4459,43 +4419,43 @@
                 },
                 "PrmGet" : {
                   "Port" : {
-                    "nodeId" : 292,
+                    "nodeId" : 291,
                     "unqualifiedName" : "PrmGet"
                   }
                 },
                 "LogText" : {
                   "Port" : {
-                    "nodeId" : 291,
+                    "nodeId" : 290,
                     "unqualifiedName" : "LogText"
                   }
                 },
                 "Cmd" : {
                   "Port" : {
-                    "nodeId" : 288,
+                    "nodeId" : 286,
                     "unqualifiedName" : "Cmd"
                   }
                 },
                 "Log" : {
                   "Port" : {
-                    "nodeId" : 290,
+                    "nodeId" : 289,
                     "unqualifiedName" : "Log"
                   }
                 },
                 "CmdResponse" : {
                   "Port" : {
-                    "nodeId" : 289,
+                    "nodeId" : 288,
                     "unqualifiedName" : "CmdResponse"
                   }
                 },
                 "Time" : {
                   "Port" : {
-                    "nodeId" : 286,
+                    "nodeId" : 293,
                     "unqualifiedName" : "Time"
                   }
                 },
                 "PrmSet" : {
                   "Port" : {
-                    "nodeId" : 293,
+                    "nodeId" : 292,
                     "unqualifiedName" : "PrmSet"
                   }
                 },
@@ -4525,7 +4485,7 @@
         }
       }
     },
-    "310" : {
+    "302" : {
       "ScopeImpl" : {
         "map" : {
           "Port" : {
@@ -4533,7 +4493,7 @@
               "map" : {
                 "Ping" : {
                   "Port" : {
-                    "nodeId" : 309,
+                    "nodeId" : 301,
                     "unqualifiedName" : "Ping"
                   }
                 }
@@ -4646,18 +4606,18 @@
         [
           {
             "aNode" : {
-              "astNodeId" : 138
+              "astNodeId" : 130
             },
             "qualifiedName" : {
               "qualifier" : [
               ],
-              "base" : "c7"
+              "base" : "c5"
             },
             "component" : {
-              "astNodeId" : 110
+              "astNodeId" : 84
             },
-            "baseId" : 1792,
-            "maxId" : 1791,
+            "baseId" : 1280,
+            "maxId" : 1279,
             "file" : "None",
             "queueSize" : "None",
             "stackSize" : "None",
@@ -4675,7 +4635,44 @@
             },
             {
               "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-              "pos" : "49.5",
+              "pos" : "47.5",
+              "includingLoc" : "None"
+            }
+          ]
+        ],
+        [
+          {
+            "aNode" : {
+              "astNodeId" : 122
+            },
+            "qualifiedName" : {
+              "qualifier" : [
+              ],
+              "base" : "c3"
+            },
+            "component" : {
+              "astNodeId" : 50
+            },
+            "baseId" : 768,
+            "maxId" : 767,
+            "file" : "None",
+            "queueSize" : "None",
+            "stackSize" : "None",
+            "priority" : "None",
+            "cpu" : "None",
+            "initSpecifierMap" : {
+              
+            }
+          },
+          [
+            {
+              "Public" : {
+                
+              }
+            },
+            {
+              "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+              "pos" : "45.5",
               "includingLoc" : "None"
             }
           ]
@@ -4720,43 +4717,6 @@
         [
           {
             "aNode" : {
-              "astNodeId" : 130
-            },
-            "qualifiedName" : {
-              "qualifier" : [
-              ],
-              "base" : "c5"
-            },
-            "component" : {
-              "astNodeId" : 84
-            },
-            "baseId" : 1280,
-            "maxId" : 1279,
-            "file" : "None",
-            "queueSize" : "None",
-            "stackSize" : "None",
-            "priority" : "None",
-            "cpu" : "None",
-            "initSpecifierMap" : {
-              
-            }
-          },
-          [
-            {
-              "Public" : {
-                
-              }
-            },
-            {
-              "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-              "pos" : "47.5",
-              "includingLoc" : "None"
-            }
-          ]
-        ],
-        [
-          {
-            "aNode" : {
               "astNodeId" : 126
             },
             "qualifiedName" : {
@@ -4794,18 +4754,18 @@
         [
           {
             "aNode" : {
-              "astNodeId" : 122
+              "astNodeId" : 138
             },
             "qualifiedName" : {
               "qualifier" : [
               ],
-              "base" : "c3"
+              "base" : "c7"
             },
             "component" : {
-              "astNodeId" : 50
+              "astNodeId" : 110
             },
-            "baseId" : 768,
-            "maxId" : 767,
+            "baseId" : 1792,
+            "maxId" : 1791,
             "file" : "None",
             "queueSize" : "None",
             "stackSize" : "None",
@@ -4823,7 +4783,7 @@
             },
             {
               "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-              "pos" : "45.5",
+              "pos" : "49.5",
               "includingLoc" : "None"
             }
           ]
@@ -5192,246 +5152,6 @@
         {
           "componentInstance" : {
             "aNode" : {
-              "astNodeId" : 118
-            },
-            "qualifiedName" : {
-              "qualifier" : [
-              ],
-              "base" : "c2"
-            },
-            "component" : {
-              "astNodeId" : 37
-            },
-            "baseId" : 512,
-            "maxId" : 511,
-            "file" : "None",
-            "queueSize" : "None",
-            "stackSize" : "None",
-            "priority" : "None",
-            "cpu" : "None",
-            "initSpecifierMap" : {
-              
-            }
-          },
-          "portInstance" : {
-            "General" : {
-              "aNode" : {
-                "astNodeId" : 36
-              },
-              "specifier" : {
-                "kind" : {
-                  "Output" : {
-                    
-                  }
-                },
-                "name" : "cmdSend",
-                "size" : "None",
-                "port" : {
-                  "Some" : {
-                    "astNodeId" : 35
-                  }
-                },
-                "priority" : "None",
-                "queueFull" : "None"
-              },
-              "kind" : "Output",
-              "size" : 1,
-              "ty" : {
-                "DefPort" : {
-                  "symbol" : {
-                    "Port" : {
-                      "nodeId" : 288,
-                      "unqualifiedName" : "Cmd"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "componentInstance" : {
-            "aNode" : {
-              "astNodeId" : 130
-            },
-            "qualifiedName" : {
-              "qualifier" : [
-              ],
-              "base" : "c5"
-            },
-            "component" : {
-              "astNodeId" : 84
-            },
-            "baseId" : 1280,
-            "maxId" : 1279,
-            "file" : "None",
-            "queueSize" : "None",
-            "stackSize" : "None",
-            "priority" : "None",
-            "cpu" : "None",
-            "initSpecifierMap" : {
-              
-            }
-          },
-          "portInstance" : {
-            "General" : {
-              "aNode" : {
-                "astNodeId" : 83
-              },
-              "specifier" : {
-                "kind" : {
-                  "SyncInput" : {
-                    
-                  }
-                },
-                "name" : "paramSet",
-                "size" : "None",
-                "port" : {
-                  "Some" : {
-                    "astNodeId" : 82
-                  }
-                },
-                "priority" : "None",
-                "queueFull" : "None"
-              },
-              "kind" : "SyncInput",
-              "size" : 1,
-              "ty" : {
-                "DefPort" : {
-                  "symbol" : {
-                    "Port" : {
-                      "nodeId" : 293,
-                      "unqualifiedName" : "PrmSet"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "componentInstance" : {
-            "aNode" : {
-              "astNodeId" : 130
-            },
-            "qualifiedName" : {
-              "qualifier" : [
-              ],
-              "base" : "c5"
-            },
-            "component" : {
-              "astNodeId" : 84
-            },
-            "baseId" : 1280,
-            "maxId" : 1279,
-            "file" : "None",
-            "queueSize" : "None",
-            "stackSize" : "None",
-            "priority" : "None",
-            "cpu" : "None",
-            "initSpecifierMap" : {
-              
-            }
-          },
-          "portInstance" : {
-            "General" : {
-              "aNode" : {
-                "astNodeId" : 71
-              },
-              "specifier" : {
-                "kind" : {
-                  "SyncInput" : {
-                    
-                  }
-                },
-                "name" : "paramGet",
-                "size" : "None",
-                "port" : {
-                  "Some" : {
-                    "astNodeId" : 70
-                  }
-                },
-                "priority" : "None",
-                "queueFull" : "None"
-              },
-              "kind" : "SyncInput",
-              "size" : 1,
-              "ty" : {
-                "DefPort" : {
-                  "symbol" : {
-                    "Port" : {
-                      "nodeId" : 292,
-                      "unqualifiedName" : "PrmGet"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "componentInstance" : {
-            "aNode" : {
-              "astNodeId" : 118
-            },
-            "qualifiedName" : {
-              "qualifier" : [
-              ],
-              "base" : "c2"
-            },
-            "component" : {
-              "astNodeId" : 37
-            },
-            "baseId" : 512,
-            "maxId" : 511,
-            "file" : "None",
-            "queueSize" : "None",
-            "stackSize" : "None",
-            "priority" : "None",
-            "cpu" : "None",
-            "initSpecifierMap" : {
-              
-            }
-          },
-          "portInstance" : {
-            "General" : {
-              "aNode" : {
-                "astNodeId" : 24
-              },
-              "specifier" : {
-                "kind" : {
-                  "SyncInput" : {
-                    
-                  }
-                },
-                "name" : "cmdResponseOut",
-                "size" : "None",
-                "port" : {
-                  "Some" : {
-                    "astNodeId" : 23
-                  }
-                },
-                "priority" : "None",
-                "queueFull" : "None"
-              },
-              "kind" : "SyncInput",
-              "size" : 1,
-              "ty" : {
-                "DefPort" : {
-                  "symbol" : {
-                    "Port" : {
-                      "nodeId" : 289,
-                      "unqualifiedName" : "CmdResponse"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "componentInstance" : {
-            "aNode" : {
               "astNodeId" : 126
             },
             "qualifiedName" : {
@@ -5480,67 +5200,7 @@
                 "DefPort" : {
                   "symbol" : {
                     "Port" : {
-                      "nodeId" : 309,
-                      "unqualifiedName" : "Ping"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "componentInstance" : {
-            "aNode" : {
-              "astNodeId" : 126
-            },
-            "qualifiedName" : {
-              "qualifier" : [
-              ],
-              "base" : "c4"
-            },
-            "component" : {
-              "astNodeId" : 67
-            },
-            "baseId" : 1024,
-            "maxId" : 1023,
-            "file" : "None",
-            "queueSize" : "None",
-            "stackSize" : "None",
-            "priority" : "None",
-            "cpu" : "None",
-            "initSpecifierMap" : {
-              
-            }
-          },
-          "portInstance" : {
-            "General" : {
-              "aNode" : {
-                "astNodeId" : 54
-              },
-              "specifier" : {
-                "kind" : {
-                  "Output" : {
-                    
-                  }
-                },
-                "name" : "PingSend",
-                "size" : "None",
-                "port" : {
-                  "Some" : {
-                    "astNodeId" : 53
-                  }
-                },
-                "priority" : "None",
-                "queueFull" : "None"
-              },
-              "kind" : "Output",
-              "size" : 1,
-              "ty" : {
-                "DefPort" : {
-                  "symbol" : {
-                    "Port" : {
-                      "nodeId" : 309,
+                      "nodeId" : 301,
                       "unqualifiedName" : "Ping"
                     }
                   }
@@ -5600,8 +5260,248 @@
                 "DefPort" : {
                   "symbol" : {
                     "Port" : {
-                      "nodeId" : 286,
+                      "nodeId" : 293,
                       "unqualifiedName" : "Time"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "componentInstance" : {
+            "aNode" : {
+              "astNodeId" : 118
+            },
+            "qualifiedName" : {
+              "qualifier" : [
+              ],
+              "base" : "c2"
+            },
+            "component" : {
+              "astNodeId" : 37
+            },
+            "baseId" : 512,
+            "maxId" : 511,
+            "file" : "None",
+            "queueSize" : "None",
+            "stackSize" : "None",
+            "priority" : "None",
+            "cpu" : "None",
+            "initSpecifierMap" : {
+              
+            }
+          },
+          "portInstance" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 24
+              },
+              "specifier" : {
+                "kind" : {
+                  "SyncInput" : {
+                    
+                  }
+                },
+                "name" : "cmdResponseOut",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 23
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "kind" : "SyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 288,
+                      "unqualifiedName" : "CmdResponse"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "componentInstance" : {
+            "aNode" : {
+              "astNodeId" : 118
+            },
+            "qualifiedName" : {
+              "qualifier" : [
+              ],
+              "base" : "c2"
+            },
+            "component" : {
+              "astNodeId" : 37
+            },
+            "baseId" : 512,
+            "maxId" : 511,
+            "file" : "None",
+            "queueSize" : "None",
+            "stackSize" : "None",
+            "priority" : "None",
+            "cpu" : "None",
+            "initSpecifierMap" : {
+              
+            }
+          },
+          "portInstance" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 16
+              },
+              "specifier" : {
+                "kind" : {
+                  "SyncInput" : {
+                    
+                  }
+                },
+                "name" : "cmdIn",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 15
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "kind" : "SyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 286,
+                      "unqualifiedName" : "Cmd"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "componentInstance" : {
+            "aNode" : {
+              "astNodeId" : 126
+            },
+            "qualifiedName" : {
+              "qualifier" : [
+              ],
+              "base" : "c4"
+            },
+            "component" : {
+              "astNodeId" : 67
+            },
+            "baseId" : 1024,
+            "maxId" : 1023,
+            "file" : "None",
+            "queueSize" : "None",
+            "stackSize" : "None",
+            "priority" : "None",
+            "cpu" : "None",
+            "initSpecifierMap" : {
+              
+            }
+          },
+          "portInstance" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 54
+              },
+              "specifier" : {
+                "kind" : {
+                  "Output" : {
+                    
+                  }
+                },
+                "name" : "PingSend",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 53
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "kind" : "Output",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 301,
+                      "unqualifiedName" : "Ping"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "componentInstance" : {
+            "aNode" : {
+              "astNodeId" : 130
+            },
+            "qualifiedName" : {
+              "qualifier" : [
+              ],
+              "base" : "c5"
+            },
+            "component" : {
+              "astNodeId" : 84
+            },
+            "baseId" : 1280,
+            "maxId" : 1279,
+            "file" : "None",
+            "queueSize" : "None",
+            "stackSize" : "None",
+            "priority" : "None",
+            "cpu" : "None",
+            "initSpecifierMap" : {
+              
+            }
+          },
+          "portInstance" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 71
+              },
+              "specifier" : {
+                "kind" : {
+                  "SyncInput" : {
+                    
+                  }
+                },
+                "name" : "paramGet",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 70
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "kind" : "SyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 291,
+                      "unqualifiedName" : "PrmGet"
                     }
                   }
                 }
@@ -5660,8 +5560,128 @@
                 "DefPort" : {
                   "symbol" : {
                     "Port" : {
-                      "nodeId" : 291,
+                      "nodeId" : 290,
                       "unqualifiedName" : "LogText"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "componentInstance" : {
+            "aNode" : {
+              "astNodeId" : 118
+            },
+            "qualifiedName" : {
+              "qualifier" : [
+              ],
+              "base" : "c2"
+            },
+            "component" : {
+              "astNodeId" : 37
+            },
+            "baseId" : 512,
+            "maxId" : 511,
+            "file" : "None",
+            "queueSize" : "None",
+            "stackSize" : "None",
+            "priority" : "None",
+            "cpu" : "None",
+            "initSpecifierMap" : {
+              
+            }
+          },
+          "portInstance" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 36
+              },
+              "specifier" : {
+                "kind" : {
+                  "Output" : {
+                    
+                  }
+                },
+                "name" : "cmdSend",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 35
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "kind" : "Output",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 286,
+                      "unqualifiedName" : "Cmd"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "componentInstance" : {
+            "aNode" : {
+              "astNodeId" : 122
+            },
+            "qualifiedName" : {
+              "qualifier" : [
+              ],
+              "base" : "c3"
+            },
+            "component" : {
+              "astNodeId" : 50
+            },
+            "baseId" : 768,
+            "maxId" : 767,
+            "file" : "None",
+            "queueSize" : "None",
+            "stackSize" : "None",
+            "priority" : "None",
+            "cpu" : "None",
+            "initSpecifierMap" : {
+              
+            }
+          },
+          "portInstance" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 49
+              },
+              "specifier" : {
+                "kind" : {
+                  "SyncInput" : {
+                    
+                  }
+                },
+                "name" : "eventLog",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 48
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "kind" : "SyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 289,
+                      "unqualifiedName" : "Log"
                     }
                   }
                 }
@@ -5732,18 +5752,18 @@
         {
           "componentInstance" : {
             "aNode" : {
-              "astNodeId" : 122
+              "astNodeId" : 130
             },
             "qualifiedName" : {
               "qualifier" : [
               ],
-              "base" : "c3"
+              "base" : "c5"
             },
             "component" : {
-              "astNodeId" : 50
+              "astNodeId" : 84
             },
-            "baseId" : 768,
-            "maxId" : 767,
+            "baseId" : 1280,
+            "maxId" : 1279,
             "file" : "None",
             "queueSize" : "None",
             "stackSize" : "None",
@@ -5756,7 +5776,7 @@
           "portInstance" : {
             "General" : {
               "aNode" : {
-                "astNodeId" : 49
+                "astNodeId" : 83
               },
               "specifier" : {
                 "kind" : {
@@ -5764,11 +5784,11 @@
                     
                   }
                 },
-                "name" : "eventLog",
+                "name" : "paramSet",
                 "size" : "None",
                 "port" : {
                   "Some" : {
-                    "astNodeId" : 48
+                    "astNodeId" : 82
                   }
                 },
                 "priority" : "None",
@@ -5780,8 +5800,8 @@
                 "DefPort" : {
                   "symbol" : {
                     "Port" : {
-                      "nodeId" : 290,
-                      "unqualifiedName" : "Log"
+                      "nodeId" : 292,
+                      "unqualifiedName" : "PrmSet"
                     }
                   }
                 }
@@ -5848,66 +5868,6 @@
               }
             }
           }
-        },
-        {
-          "componentInstance" : {
-            "aNode" : {
-              "astNodeId" : 118
-            },
-            "qualifiedName" : {
-              "qualifier" : [
-              ],
-              "base" : "c2"
-            },
-            "component" : {
-              "astNodeId" : 37
-            },
-            "baseId" : 512,
-            "maxId" : 511,
-            "file" : "None",
-            "queueSize" : "None",
-            "stackSize" : "None",
-            "priority" : "None",
-            "cpu" : "None",
-            "initSpecifierMap" : {
-              
-            }
-          },
-          "portInstance" : {
-            "General" : {
-              "aNode" : {
-                "astNodeId" : 16
-              },
-              "specifier" : {
-                "kind" : {
-                  "SyncInput" : {
-                    
-                  }
-                },
-                "name" : "cmdIn",
-                "size" : "None",
-                "port" : {
-                  "Some" : {
-                    "astNodeId" : 15
-                  }
-                },
-                "priority" : "None",
-                "queueFull" : "None"
-              },
-              "kind" : "SyncInput",
-              "size" : 1,
-              "ty" : {
-                "DefPort" : {
-                  "symbol" : {
-                    "Port" : {
-                      "nodeId" : 288,
-                      "unqualifiedName" : "Cmd"
-                    }
-                  }
-                }
-              }
-            }
-          }
         }
       ]
     }
@@ -5966,7 +5926,7 @@
   "useDefMap" : {
     "51" : {
       "Module" : {
-        "nodeId" : 310,
+        "nodeId" : 302,
         "unqualifiedName" : "Svc"
       }
     },
@@ -5996,13 +5956,13 @@
     },
     "53" : {
       "Port" : {
-        "nodeId" : 309,
+        "nodeId" : 301,
         "unqualifiedName" : "Ping"
       }
     },
     "70" : {
       "Port" : {
-        "nodeId" : 292,
+        "nodeId" : 291,
         "unqualifiedName" : "PrmGet"
       }
     },
@@ -6020,7 +5980,7 @@
     },
     "63" : {
       "Module" : {
-        "nodeId" : 310,
+        "nodeId" : 302,
         "unqualifiedName" : "Svc"
       }
     },
@@ -6068,13 +6028,13 @@
     },
     "23" : {
       "Port" : {
-        "nodeId" : 289,
+        "nodeId" : 288,
         "unqualifiedName" : "CmdResponse"
       }
     },
     "15" : {
       "Port" : {
-        "nodeId" : 288,
+        "nodeId" : 286,
         "unqualifiedName" : "Cmd"
       }
     },
@@ -6128,7 +6088,7 @@
     },
     "35" : {
       "Port" : {
-        "nodeId" : 288,
+        "nodeId" : 286,
         "unqualifiedName" : "Cmd"
       }
     },
@@ -6146,7 +6106,7 @@
     },
     "10" : {
       "Port" : {
-        "nodeId" : 286,
+        "nodeId" : 293,
         "unqualifiedName" : "Time"
       }
     },
@@ -6164,7 +6124,7 @@
     },
     "48" : {
       "Port" : {
-        "nodeId" : 290,
+        "nodeId" : 289,
         "unqualifiedName" : "Log"
       }
     },
@@ -6182,13 +6142,13 @@
     },
     "65" : {
       "Port" : {
-        "nodeId" : 309,
+        "nodeId" : 301,
         "unqualifiedName" : "Ping"
       }
     },
     "108" : {
       "Port" : {
-        "nodeId" : 291,
+        "nodeId" : 290,
         "unqualifiedName" : "LogText"
       }
     },
@@ -6212,7 +6172,7 @@
     },
     "82" : {
       "Port" : {
-        "nodeId" : 293,
+        "nodeId" : 292,
         "unqualifiedName" : "PrmSet"
       }
     },

--- a/compiler/tools/fpp-to-json/test/patternedConnections.ref.txt
+++ b/compiler/tools/fpp-to-json/test/patternedConnections.ref.txt
@@ -1,0 +1,6275 @@
+[
+  {
+    "members" : [
+      [
+        [
+        ],
+        {
+          "DefComponent" : {
+            "node" : {
+              "AstNode" : {
+                "data" : {
+                  "kind" : {
+                    "Passive" : {
+                      
+                    }
+                  },
+                  "name" : "Time",
+                  "members" : [
+                    [
+                      [
+                      ],
+                      {
+                        "SpecPortInstance" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "General" : {
+                                  "kind" : {
+                                    "SyncInput" : {
+                                      
+                                    }
+                                  },
+                                  "name" : "timeGetPort",
+                                  "size" : "None",
+                                  "port" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "Qualified" : {
+                                            "qualifier" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "Unqualified" : {
+                                                    "name" : "Fw"
+                                                  }
+                                                },
+                                                "id" : 8
+                                              }
+                                            },
+                                            "name" : {
+                                              "AstNode" : {
+                                                "data" : "Time",
+                                                "id" : 9
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "id" : 10
+                                      }
+                                    }
+                                  },
+                                  "priority" : "None",
+                                  "queueFull" : "None"
+                                }
+                              },
+                              "id" : 11
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ]
+                  ]
+                },
+                "id" : 12
+              }
+            }
+          }
+        },
+        [
+        ]
+      ],
+      [
+        [
+        ],
+        {
+          "DefComponent" : {
+            "node" : {
+              "AstNode" : {
+                "data" : {
+                  "kind" : {
+                    "Passive" : {
+                      
+                    }
+                  },
+                  "name" : "Command",
+                  "members" : [
+                    [
+                      [
+                      ],
+                      {
+                        "SpecPortInstance" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "General" : {
+                                  "kind" : {
+                                    "SyncInput" : {
+                                      
+                                    }
+                                  },
+                                  "name" : "cmdIn",
+                                  "size" : "None",
+                                  "port" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "Qualified" : {
+                                            "qualifier" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "Unqualified" : {
+                                                    "name" : "Fw"
+                                                  }
+                                                },
+                                                "id" : 13
+                                              }
+                                            },
+                                            "name" : {
+                                              "AstNode" : {
+                                                "data" : "Cmd",
+                                                "id" : 14
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "id" : 15
+                                      }
+                                    }
+                                  },
+                                  "priority" : "None",
+                                  "queueFull" : "None"
+                                }
+                              },
+                              "id" : 16
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ],
+                    [
+                      [
+                      ],
+                      {
+                        "SpecPortInstance" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "General" : {
+                                  "kind" : {
+                                    "SyncInput" : {
+                                      
+                                    }
+                                  },
+                                  "name" : "cmdRegOut",
+                                  "size" : "None",
+                                  "port" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "Qualified" : {
+                                            "qualifier" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "Unqualified" : {
+                                                    "name" : "Fw"
+                                                  }
+                                                },
+                                                "id" : 17
+                                              }
+                                            },
+                                            "name" : {
+                                              "AstNode" : {
+                                                "data" : "CmdReg",
+                                                "id" : 18
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "id" : 19
+                                      }
+                                    }
+                                  },
+                                  "priority" : "None",
+                                  "queueFull" : "None"
+                                }
+                              },
+                              "id" : 20
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ],
+                    [
+                      [
+                      ],
+                      {
+                        "SpecPortInstance" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "General" : {
+                                  "kind" : {
+                                    "SyncInput" : {
+                                      
+                                    }
+                                  },
+                                  "name" : "cmdResponseOut",
+                                  "size" : "None",
+                                  "port" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "Qualified" : {
+                                            "qualifier" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "Unqualified" : {
+                                                    "name" : "Fw"
+                                                  }
+                                                },
+                                                "id" : 21
+                                              }
+                                            },
+                                            "name" : {
+                                              "AstNode" : {
+                                                "data" : "CmdResponse",
+                                                "id" : 22
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "id" : 23
+                                      }
+                                    }
+                                  },
+                                  "priority" : "None",
+                                  "queueFull" : "None"
+                                }
+                              },
+                              "id" : 24
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ],
+                    [
+                      [
+                      ],
+                      {
+                        "SpecPortInstance" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "General" : {
+                                  "kind" : {
+                                    "Output" : {
+                                      
+                                    }
+                                  },
+                                  "name" : "cmdSend",
+                                  "size" : "None",
+                                  "port" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "Qualified" : {
+                                            "qualifier" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "Unqualified" : {
+                                                    "name" : "Fw"
+                                                  }
+                                                },
+                                                "id" : 33
+                                              }
+                                            },
+                                            "name" : {
+                                              "AstNode" : {
+                                                "data" : "Cmd",
+                                                "id" : 34
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "id" : 35
+                                      }
+                                    }
+                                  },
+                                  "priority" : "None",
+                                  "queueFull" : "None"
+                                }
+                              },
+                              "id" : 36
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ]
+                  ]
+                },
+                "id" : 37
+              }
+            }
+          }
+        },
+        [
+        ]
+      ],
+      [
+        [
+        ],
+        {
+          "DefComponent" : {
+            "node" : {
+              "AstNode" : {
+                "data" : {
+                  "kind" : {
+                    "Passive" : {
+                      
+                    }
+                  },
+                  "name" : "Event",
+                  "members" : [
+                    [
+                      [
+                      ],
+                      {
+                        "SpecPortInstance" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "General" : {
+                                  "kind" : {
+                                    "SyncInput" : {
+                                      
+                                    }
+                                  },
+                                  "name" : "eventLog",
+                                  "size" : "None",
+                                  "port" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "Qualified" : {
+                                            "qualifier" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "Unqualified" : {
+                                                    "name" : "Fw"
+                                                  }
+                                                },
+                                                "id" : 46
+                                              }
+                                            },
+                                            "name" : {
+                                              "AstNode" : {
+                                                "data" : "Log",
+                                                "id" : 47
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "id" : 48
+                                      }
+                                    }
+                                  },
+                                  "priority" : "None",
+                                  "queueFull" : "None"
+                                }
+                              },
+                              "id" : 49
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ]
+                  ]
+                },
+                "id" : 50
+              }
+            }
+          }
+        },
+        [
+        ]
+      ],
+      [
+        [
+        ],
+        {
+          "DefComponent" : {
+            "node" : {
+              "AstNode" : {
+                "data" : {
+                  "kind" : {
+                    "Passive" : {
+                      
+                    }
+                  },
+                  "name" : "Health",
+                  "members" : [
+                    [
+                      [
+                      ],
+                      {
+                        "SpecPortInstance" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "General" : {
+                                  "kind" : {
+                                    "Output" : {
+                                      
+                                    }
+                                  },
+                                  "name" : "PingSend",
+                                  "size" : "None",
+                                  "port" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "Qualified" : {
+                                            "qualifier" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "Unqualified" : {
+                                                    "name" : "Svc"
+                                                  }
+                                                },
+                                                "id" : 51
+                                              }
+                                            },
+                                            "name" : {
+                                              "AstNode" : {
+                                                "data" : "Ping",
+                                                "id" : 52
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "id" : 53
+                                      }
+                                    }
+                                  },
+                                  "priority" : "None",
+                                  "queueFull" : "None"
+                                }
+                              },
+                              "id" : 54
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ],
+                    [
+                      [
+                      ],
+                      {
+                        "SpecPortInstance" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "General" : {
+                                  "kind" : {
+                                    "SyncInput" : {
+                                      
+                                    }
+                                  },
+                                  "name" : "PingReturn",
+                                  "size" : "None",
+                                  "port" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "Qualified" : {
+                                            "qualifier" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "Unqualified" : {
+                                                    "name" : "Svc"
+                                                  }
+                                                },
+                                                "id" : 63
+                                              }
+                                            },
+                                            "name" : {
+                                              "AstNode" : {
+                                                "data" : "Ping",
+                                                "id" : 64
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "id" : 65
+                                      }
+                                    }
+                                  },
+                                  "priority" : "None",
+                                  "queueFull" : "None"
+                                }
+                              },
+                              "id" : 66
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ]
+                  ]
+                },
+                "id" : 67
+              }
+            }
+          }
+        },
+        [
+        ]
+      ],
+      [
+        [
+        ],
+        {
+          "DefComponent" : {
+            "node" : {
+              "AstNode" : {
+                "data" : {
+                  "kind" : {
+                    "Passive" : {
+                      
+                    }
+                  },
+                  "name" : "Param",
+                  "members" : [
+                    [
+                      [
+                      ],
+                      {
+                        "SpecPortInstance" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "General" : {
+                                  "kind" : {
+                                    "SyncInput" : {
+                                      
+                                    }
+                                  },
+                                  "name" : "paramGet",
+                                  "size" : "None",
+                                  "port" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "Qualified" : {
+                                            "qualifier" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "Unqualified" : {
+                                                    "name" : "Fw"
+                                                  }
+                                                },
+                                                "id" : 68
+                                              }
+                                            },
+                                            "name" : {
+                                              "AstNode" : {
+                                                "data" : "PrmGet",
+                                                "id" : 69
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "id" : 70
+                                      }
+                                    }
+                                  },
+                                  "priority" : "None",
+                                  "queueFull" : "None"
+                                }
+                              },
+                              "id" : 71
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ],
+                    [
+                      [
+                      ],
+                      {
+                        "SpecPortInstance" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "General" : {
+                                  "kind" : {
+                                    "SyncInput" : {
+                                      
+                                    }
+                                  },
+                                  "name" : "paramSet",
+                                  "size" : "None",
+                                  "port" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "Qualified" : {
+                                            "qualifier" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "Unqualified" : {
+                                                    "name" : "Fw"
+                                                  }
+                                                },
+                                                "id" : 80
+                                              }
+                                            },
+                                            "name" : {
+                                              "AstNode" : {
+                                                "data" : "PrmSet",
+                                                "id" : 81
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "id" : 82
+                                      }
+                                    }
+                                  },
+                                  "priority" : "None",
+                                  "queueFull" : "None"
+                                }
+                              },
+                              "id" : 83
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ]
+                  ]
+                },
+                "id" : 84
+              }
+            }
+          }
+        },
+        [
+        ]
+      ],
+      [
+        [
+        ],
+        {
+          "DefComponent" : {
+            "node" : {
+              "AstNode" : {
+                "data" : {
+                  "kind" : {
+                    "Passive" : {
+                      
+                    }
+                  },
+                  "name" : "Telemetry",
+                  "members" : [
+                    [
+                      [
+                      ],
+                      {
+                        "SpecPortInstance" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "General" : {
+                                  "kind" : {
+                                    "SyncInput" : {
+                                      
+                                    }
+                                  },
+                                  "name" : "tlm",
+                                  "size" : "None",
+                                  "port" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "Qualified" : {
+                                            "qualifier" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "Unqualified" : {
+                                                    "name" : "Fw"
+                                                  }
+                                                },
+                                                "id" : 93
+                                              }
+                                            },
+                                            "name" : {
+                                              "AstNode" : {
+                                                "data" : "Tlm",
+                                                "id" : 94
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "id" : 95
+                                      }
+                                    }
+                                  },
+                                  "priority" : "None",
+                                  "queueFull" : "None"
+                                }
+                              },
+                              "id" : 96
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ]
+                  ]
+                },
+                "id" : 97
+              }
+            }
+          }
+        },
+        [
+        ]
+      ],
+      [
+        [
+        ],
+        {
+          "DefComponent" : {
+            "node" : {
+              "AstNode" : {
+                "data" : {
+                  "kind" : {
+                    "Passive" : {
+                      
+                    }
+                  },
+                  "name" : "TextEvent",
+                  "members" : [
+                    [
+                      [
+                      ],
+                      {
+                        "SpecPortInstance" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "General" : {
+                                  "kind" : {
+                                    "SyncInput" : {
+                                      
+                                    }
+                                  },
+                                  "name" : "textEventLog",
+                                  "size" : "None",
+                                  "port" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "Qualified" : {
+                                            "qualifier" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "Unqualified" : {
+                                                    "name" : "Fw"
+                                                  }
+                                                },
+                                                "id" : 106
+                                              }
+                                            },
+                                            "name" : {
+                                              "AstNode" : {
+                                                "data" : "LogText",
+                                                "id" : 107
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "id" : 108
+                                      }
+                                    }
+                                  },
+                                  "priority" : "None",
+                                  "queueFull" : "None"
+                                }
+                              },
+                              "id" : 109
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ]
+                  ]
+                },
+                "id" : 110
+              }
+            }
+          }
+        },
+        [
+        ]
+      ],
+      [
+        [
+        ],
+        {
+          "DefComponentInstance" : {
+            "node" : {
+              "AstNode" : {
+                "data" : {
+                  "name" : "c1",
+                  "component" : {
+                    "AstNode" : {
+                      "data" : {
+                        "Unqualified" : {
+                          "name" : "Time"
+                        }
+                      },
+                      "id" : 112
+                    }
+                  },
+                  "baseId" : {
+                    "AstNode" : {
+                      "data" : {
+                        "ExprLiteralInt" : {
+                          "value" : "0x100"
+                        }
+                      },
+                      "id" : 113
+                    }
+                  },
+                  "implType" : "None",
+                  "file" : "None",
+                  "queueSize" : "None",
+                  "stackSize" : "None",
+                  "priority" : "None",
+                  "cpu" : "None",
+                  "initSpecs" : [
+                  ]
+                },
+                "id" : 114
+              }
+            }
+          }
+        },
+        [
+        ]
+      ],
+      [
+        [
+        ],
+        {
+          "DefComponentInstance" : {
+            "node" : {
+              "AstNode" : {
+                "data" : {
+                  "name" : "c2",
+                  "component" : {
+                    "AstNode" : {
+                      "data" : {
+                        "Unqualified" : {
+                          "name" : "Command"
+                        }
+                      },
+                      "id" : 116
+                    }
+                  },
+                  "baseId" : {
+                    "AstNode" : {
+                      "data" : {
+                        "ExprLiteralInt" : {
+                          "value" : "0x200"
+                        }
+                      },
+                      "id" : 117
+                    }
+                  },
+                  "implType" : "None",
+                  "file" : "None",
+                  "queueSize" : "None",
+                  "stackSize" : "None",
+                  "priority" : "None",
+                  "cpu" : "None",
+                  "initSpecs" : [
+                  ]
+                },
+                "id" : 118
+              }
+            }
+          }
+        },
+        [
+        ]
+      ],
+      [
+        [
+        ],
+        {
+          "DefComponentInstance" : {
+            "node" : {
+              "AstNode" : {
+                "data" : {
+                  "name" : "c3",
+                  "component" : {
+                    "AstNode" : {
+                      "data" : {
+                        "Unqualified" : {
+                          "name" : "Event"
+                        }
+                      },
+                      "id" : 120
+                    }
+                  },
+                  "baseId" : {
+                    "AstNode" : {
+                      "data" : {
+                        "ExprLiteralInt" : {
+                          "value" : "0x300"
+                        }
+                      },
+                      "id" : 121
+                    }
+                  },
+                  "implType" : "None",
+                  "file" : "None",
+                  "queueSize" : "None",
+                  "stackSize" : "None",
+                  "priority" : "None",
+                  "cpu" : "None",
+                  "initSpecs" : [
+                  ]
+                },
+                "id" : 122
+              }
+            }
+          }
+        },
+        [
+        ]
+      ],
+      [
+        [
+        ],
+        {
+          "DefComponentInstance" : {
+            "node" : {
+              "AstNode" : {
+                "data" : {
+                  "name" : "c4",
+                  "component" : {
+                    "AstNode" : {
+                      "data" : {
+                        "Unqualified" : {
+                          "name" : "Health"
+                        }
+                      },
+                      "id" : 124
+                    }
+                  },
+                  "baseId" : {
+                    "AstNode" : {
+                      "data" : {
+                        "ExprLiteralInt" : {
+                          "value" : "0x400"
+                        }
+                      },
+                      "id" : 125
+                    }
+                  },
+                  "implType" : "None",
+                  "file" : "None",
+                  "queueSize" : "None",
+                  "stackSize" : "None",
+                  "priority" : "None",
+                  "cpu" : "None",
+                  "initSpecs" : [
+                  ]
+                },
+                "id" : 126
+              }
+            }
+          }
+        },
+        [
+        ]
+      ],
+      [
+        [
+        ],
+        {
+          "DefComponentInstance" : {
+            "node" : {
+              "AstNode" : {
+                "data" : {
+                  "name" : "c5",
+                  "component" : {
+                    "AstNode" : {
+                      "data" : {
+                        "Unqualified" : {
+                          "name" : "Param"
+                        }
+                      },
+                      "id" : 128
+                    }
+                  },
+                  "baseId" : {
+                    "AstNode" : {
+                      "data" : {
+                        "ExprLiteralInt" : {
+                          "value" : "0x500"
+                        }
+                      },
+                      "id" : 129
+                    }
+                  },
+                  "implType" : "None",
+                  "file" : "None",
+                  "queueSize" : "None",
+                  "stackSize" : "None",
+                  "priority" : "None",
+                  "cpu" : "None",
+                  "initSpecs" : [
+                  ]
+                },
+                "id" : 130
+              }
+            }
+          }
+        },
+        [
+        ]
+      ],
+      [
+        [
+        ],
+        {
+          "DefComponentInstance" : {
+            "node" : {
+              "AstNode" : {
+                "data" : {
+                  "name" : "c6",
+                  "component" : {
+                    "AstNode" : {
+                      "data" : {
+                        "Unqualified" : {
+                          "name" : "Telemetry"
+                        }
+                      },
+                      "id" : 132
+                    }
+                  },
+                  "baseId" : {
+                    "AstNode" : {
+                      "data" : {
+                        "ExprLiteralInt" : {
+                          "value" : "0x600"
+                        }
+                      },
+                      "id" : 133
+                    }
+                  },
+                  "implType" : "None",
+                  "file" : "None",
+                  "queueSize" : "None",
+                  "stackSize" : "None",
+                  "priority" : "None",
+                  "cpu" : "None",
+                  "initSpecs" : [
+                  ]
+                },
+                "id" : 134
+              }
+            }
+          }
+        },
+        [
+        ]
+      ],
+      [
+        [
+        ],
+        {
+          "DefComponentInstance" : {
+            "node" : {
+              "AstNode" : {
+                "data" : {
+                  "name" : "c7",
+                  "component" : {
+                    "AstNode" : {
+                      "data" : {
+                        "Unqualified" : {
+                          "name" : "TextEvent"
+                        }
+                      },
+                      "id" : 136
+                    }
+                  },
+                  "baseId" : {
+                    "AstNode" : {
+                      "data" : {
+                        "ExprLiteralInt" : {
+                          "value" : "0x700"
+                        }
+                      },
+                      "id" : 137
+                    }
+                  },
+                  "implType" : "None",
+                  "file" : "None",
+                  "queueSize" : "None",
+                  "stackSize" : "None",
+                  "priority" : "None",
+                  "cpu" : "None",
+                  "initSpecs" : [
+                  ]
+                },
+                "id" : 138
+              }
+            }
+          }
+        },
+        [
+        ]
+      ],
+      [
+        [
+        ],
+        {
+          "DefTopology" : {
+            "node" : {
+              "AstNode" : {
+                "data" : {
+                  "name" : "T",
+                  "members" : [
+                    [
+                      [
+                      ],
+                      {
+                        "SpecCompInstance" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "visibility" : {
+                                  "Public" : {
+                                    
+                                  }
+                                },
+                                "instance" : {
+                                  "AstNode" : {
+                                    "data" : {
+                                      "Unqualified" : {
+                                        "name" : "c1"
+                                      }
+                                    },
+                                    "id" : 238
+                                  }
+                                }
+                              },
+                              "id" : 239
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ],
+                    [
+                      [
+                      ],
+                      {
+                        "SpecCompInstance" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "visibility" : {
+                                  "Public" : {
+                                    
+                                  }
+                                },
+                                "instance" : {
+                                  "AstNode" : {
+                                    "data" : {
+                                      "Unqualified" : {
+                                        "name" : "c2"
+                                      }
+                                    },
+                                    "id" : 241
+                                  }
+                                }
+                              },
+                              "id" : 242
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ],
+                    [
+                      [
+                      ],
+                      {
+                        "SpecCompInstance" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "visibility" : {
+                                  "Public" : {
+                                    
+                                  }
+                                },
+                                "instance" : {
+                                  "AstNode" : {
+                                    "data" : {
+                                      "Unqualified" : {
+                                        "name" : "c3"
+                                      }
+                                    },
+                                    "id" : 244
+                                  }
+                                }
+                              },
+                              "id" : 245
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ],
+                    [
+                      [
+                      ],
+                      {
+                        "SpecCompInstance" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "visibility" : {
+                                  "Public" : {
+                                    
+                                  }
+                                },
+                                "instance" : {
+                                  "AstNode" : {
+                                    "data" : {
+                                      "Unqualified" : {
+                                        "name" : "c4"
+                                      }
+                                    },
+                                    "id" : 247
+                                  }
+                                }
+                              },
+                              "id" : 248
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ],
+                    [
+                      [
+                      ],
+                      {
+                        "SpecCompInstance" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "visibility" : {
+                                  "Public" : {
+                                    
+                                  }
+                                },
+                                "instance" : {
+                                  "AstNode" : {
+                                    "data" : {
+                                      "Unqualified" : {
+                                        "name" : "c5"
+                                      }
+                                    },
+                                    "id" : 250
+                                  }
+                                }
+                              },
+                              "id" : 251
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ],
+                    [
+                      [
+                      ],
+                      {
+                        "SpecCompInstance" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "visibility" : {
+                                  "Public" : {
+                                    
+                                  }
+                                },
+                                "instance" : {
+                                  "AstNode" : {
+                                    "data" : {
+                                      "Unqualified" : {
+                                        "name" : "c6"
+                                      }
+                                    },
+                                    "id" : 253
+                                  }
+                                }
+                              },
+                              "id" : 254
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ],
+                    [
+                      [
+                      ],
+                      {
+                        "SpecCompInstance" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "visibility" : {
+                                  "Public" : {
+                                    
+                                  }
+                                },
+                                "instance" : {
+                                  "AstNode" : {
+                                    "data" : {
+                                      "Unqualified" : {
+                                        "name" : "c7"
+                                      }
+                                    },
+                                    "id" : 256
+                                  }
+                                }
+                              },
+                              "id" : 257
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ],
+                    [
+                      [
+                      ],
+                      {
+                        "SpecConnectionGraph" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "Pattern" : {
+                                  "kind" : {
+                                    "Time" : {
+                                      
+                                    }
+                                  },
+                                  "source" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "Unqualified" : {
+                                          "name" : "c1"
+                                        }
+                                      },
+                                      "id" : 259
+                                    }
+                                  },
+                                  "targets" : [
+                                  ]
+                                }
+                              },
+                              "id" : 260
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ],
+                    [
+                      [
+                      ],
+                      {
+                        "SpecConnectionGraph" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "Pattern" : {
+                                  "kind" : {
+                                    "Command" : {
+                                      
+                                    }
+                                  },
+                                  "source" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "Unqualified" : {
+                                          "name" : "c2"
+                                        }
+                                      },
+                                      "id" : 262
+                                    }
+                                  },
+                                  "targets" : [
+                                  ]
+                                }
+                              },
+                              "id" : 263
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ],
+                    [
+                      [
+                      ],
+                      {
+                        "SpecConnectionGraph" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "Pattern" : {
+                                  "kind" : {
+                                    "Event" : {
+                                      
+                                    }
+                                  },
+                                  "source" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "Unqualified" : {
+                                          "name" : "c3"
+                                        }
+                                      },
+                                      "id" : 265
+                                    }
+                                  },
+                                  "targets" : [
+                                  ]
+                                }
+                              },
+                              "id" : 266
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ],
+                    [
+                      [
+                      ],
+                      {
+                        "SpecConnectionGraph" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "Pattern" : {
+                                  "kind" : {
+                                    "Health" : {
+                                      
+                                    }
+                                  },
+                                  "source" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "Unqualified" : {
+                                          "name" : "c4"
+                                        }
+                                      },
+                                      "id" : 268
+                                    }
+                                  },
+                                  "targets" : [
+                                  ]
+                                }
+                              },
+                              "id" : 269
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ],
+                    [
+                      [
+                      ],
+                      {
+                        "SpecConnectionGraph" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "Pattern" : {
+                                  "kind" : {
+                                    "Param" : {
+                                      
+                                    }
+                                  },
+                                  "source" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "Unqualified" : {
+                                          "name" : "c5"
+                                        }
+                                      },
+                                      "id" : 271
+                                    }
+                                  },
+                                  "targets" : [
+                                  ]
+                                }
+                              },
+                              "id" : 272
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ],
+                    [
+                      [
+                      ],
+                      {
+                        "SpecConnectionGraph" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "Pattern" : {
+                                  "kind" : {
+                                    "Telemetry" : {
+                                      
+                                    }
+                                  },
+                                  "source" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "Unqualified" : {
+                                          "name" : "c6"
+                                        }
+                                      },
+                                      "id" : 274
+                                    }
+                                  },
+                                  "targets" : [
+                                  ]
+                                }
+                              },
+                              "id" : 275
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ],
+                    [
+                      [
+                      ],
+                      {
+                        "SpecConnectionGraph" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "Pattern" : {
+                                  "kind" : {
+                                    "TextEvent" : {
+                                      
+                                    }
+                                  },
+                                  "source" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "Unqualified" : {
+                                          "name" : "c7"
+                                        }
+                                      },
+                                      "id" : 283
+                                    }
+                                  },
+                                  "targets" : [
+                                  ]
+                                }
+                              },
+                              "id" : 284
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ]
+                  ]
+                },
+                "id" : 285
+              }
+            }
+          }
+        },
+        [
+        ]
+      ]
+    ]
+  },
+  {
+    "members" : [
+      [
+        [
+        ],
+        {
+          "DefModule" : {
+            "node" : {
+              "AstNode" : {
+                "data" : {
+                  "name" : "Fw",
+                  "members" : [
+                    [
+                      [
+                      ],
+                      {
+                        "DefPort" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "name" : "Time",
+                                "params" : [
+                                ],
+                                "returnType" : "None"
+                              },
+                              "id" : 286
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ],
+                    [
+                      [
+                      ],
+                      {
+                        "DefPort" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "name" : "CmdReg",
+                                "params" : [
+                                ],
+                                "returnType" : "None"
+                              },
+                              "id" : 287
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ],
+                    [
+                      [
+                      ],
+                      {
+                        "DefPort" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "name" : "Cmd",
+                                "params" : [
+                                ],
+                                "returnType" : "None"
+                              },
+                              "id" : 288
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ],
+                    [
+                      [
+                      ],
+                      {
+                        "DefPort" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "name" : "CmdResponse",
+                                "params" : [
+                                ],
+                                "returnType" : "None"
+                              },
+                              "id" : 289
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ],
+                    [
+                      [
+                      ],
+                      {
+                        "DefPort" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "name" : "Log",
+                                "params" : [
+                                ],
+                                "returnType" : "None"
+                              },
+                              "id" : 290
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ],
+                    [
+                      [
+                      ],
+                      {
+                        "DefPort" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "name" : "LogText",
+                                "params" : [
+                                ],
+                                "returnType" : "None"
+                              },
+                              "id" : 291
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ],
+                    [
+                      [
+                      ],
+                      {
+                        "DefPort" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "name" : "PrmGet",
+                                "params" : [
+                                ],
+                                "returnType" : "None"
+                              },
+                              "id" : 292
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ],
+                    [
+                      [
+                      ],
+                      {
+                        "DefPort" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "name" : "PrmSet",
+                                "params" : [
+                                ],
+                                "returnType" : "None"
+                              },
+                              "id" : 293
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ],
+                    [
+                      [
+                      ],
+                      {
+                        "DefPort" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "name" : "Tlm",
+                                "params" : [
+                                ],
+                                "returnType" : "None"
+                              },
+                              "id" : 294
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ],
+                    [
+                      [
+                      ],
+                      {
+                        "DefPort" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "name" : "TlmGet",
+                                "params" : [
+                                ],
+                                "returnType" : "None"
+                              },
+                              "id" : 297
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ]
+                  ]
+                },
+                "id" : 298
+              }
+            }
+          }
+        },
+        [
+        ]
+      ],
+      [
+        [
+        ],
+        {
+          "DefModule" : {
+            "node" : {
+              "AstNode" : {
+                "data" : {
+                  "name" : "Svc",
+                  "members" : [
+                    [
+                      [
+                      ],
+                      {
+                        "DefPort" : {
+                          "node" : {
+                            "AstNode" : {
+                              "data" : {
+                                "name" : "Ping",
+                                "params" : [
+                                ],
+                                "returnType" : "None"
+                              },
+                              "id" : 309
+                            }
+                          }
+                        }
+                      },
+                      [
+                      ]
+                    ]
+                  ]
+                },
+                "id" : 310
+              }
+            }
+          }
+        },
+        [
+        ]
+      ]
+    ]
+  }
+]
+{
+  "0" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "2.34",
+    "includingLoc" : "None"
+  },
+  "1" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "2.37",
+    "includingLoc" : "None"
+  },
+  "2" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "2.34",
+    "includingLoc" : "None"
+  },
+  "3" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "2.5",
+    "includingLoc" : "None"
+  },
+  "4" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "2.34",
+    "includingLoc" : "None"
+  },
+  "5" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "2.37",
+    "includingLoc" : "None"
+  },
+  "6" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "2.34",
+    "includingLoc" : "None"
+  },
+  "7" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "2.5",
+    "includingLoc" : "None"
+  },
+  "8" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "2.34",
+    "includingLoc" : "None"
+  },
+  "9" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "2.37",
+    "includingLoc" : "None"
+  },
+  "10" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "2.34",
+    "includingLoc" : "None"
+  },
+  "11" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "2.5",
+    "includingLoc" : "None"
+  },
+  "12" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "1.1",
+    "includingLoc" : "None"
+  },
+  "13" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "6.28",
+    "includingLoc" : "None"
+  },
+  "14" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "6.31",
+    "includingLoc" : "None"
+  },
+  "15" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "6.28",
+    "includingLoc" : "None"
+  },
+  "16" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "6.5",
+    "includingLoc" : "None"
+  },
+  "17" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "7.32",
+    "includingLoc" : "None"
+  },
+  "18" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "7.35",
+    "includingLoc" : "None"
+  },
+  "19" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "7.32",
+    "includingLoc" : "None"
+  },
+  "20" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "7.5",
+    "includingLoc" : "None"
+  },
+  "21" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "8.37",
+    "includingLoc" : "None"
+  },
+  "22" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "8.40",
+    "includingLoc" : "None"
+  },
+  "23" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "8.37",
+    "includingLoc" : "None"
+  },
+  "24" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "8.5",
+    "includingLoc" : "None"
+  },
+  "25" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "9.26",
+    "includingLoc" : "None"
+  },
+  "26" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "9.29",
+    "includingLoc" : "None"
+  },
+  "27" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "9.26",
+    "includingLoc" : "None"
+  },
+  "28" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "9.5",
+    "includingLoc" : "None"
+  },
+  "29" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "9.26",
+    "includingLoc" : "None"
+  },
+  "30" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "9.29",
+    "includingLoc" : "None"
+  },
+  "31" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "9.26",
+    "includingLoc" : "None"
+  },
+  "32" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "9.5",
+    "includingLoc" : "None"
+  },
+  "33" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "9.26",
+    "includingLoc" : "None"
+  },
+  "34" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "9.29",
+    "includingLoc" : "None"
+  },
+  "35" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "9.26",
+    "includingLoc" : "None"
+  },
+  "36" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "9.5",
+    "includingLoc" : "None"
+  },
+  "37" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "5.1",
+    "includingLoc" : "None"
+  },
+  "38" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "13.31",
+    "includingLoc" : "None"
+  },
+  "39" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "13.34",
+    "includingLoc" : "None"
+  },
+  "40" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "13.31",
+    "includingLoc" : "None"
+  },
+  "41" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "13.5",
+    "includingLoc" : "None"
+  },
+  "42" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "13.31",
+    "includingLoc" : "None"
+  },
+  "43" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "13.34",
+    "includingLoc" : "None"
+  },
+  "44" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "13.31",
+    "includingLoc" : "None"
+  },
+  "45" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "13.5",
+    "includingLoc" : "None"
+  },
+  "46" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "13.31",
+    "includingLoc" : "None"
+  },
+  "47" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "13.34",
+    "includingLoc" : "None"
+  },
+  "48" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "13.31",
+    "includingLoc" : "None"
+  },
+  "49" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "13.5",
+    "includingLoc" : "None"
+  },
+  "50" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "12.1",
+    "includingLoc" : "None"
+  },
+  "51" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "17.27",
+    "includingLoc" : "None"
+  },
+  "52" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "17.31",
+    "includingLoc" : "None"
+  },
+  "53" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "17.27",
+    "includingLoc" : "None"
+  },
+  "54" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "17.5",
+    "includingLoc" : "None"
+  },
+  "55" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "18.33",
+    "includingLoc" : "None"
+  },
+  "56" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "18.37",
+    "includingLoc" : "None"
+  },
+  "57" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "18.33",
+    "includingLoc" : "None"
+  },
+  "58" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "18.5",
+    "includingLoc" : "None"
+  },
+  "59" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "18.33",
+    "includingLoc" : "None"
+  },
+  "60" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "18.37",
+    "includingLoc" : "None"
+  },
+  "61" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "18.33",
+    "includingLoc" : "None"
+  },
+  "62" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "18.5",
+    "includingLoc" : "None"
+  },
+  "63" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "18.33",
+    "includingLoc" : "None"
+  },
+  "64" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "18.37",
+    "includingLoc" : "None"
+  },
+  "65" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "18.33",
+    "includingLoc" : "None"
+  },
+  "66" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "18.5",
+    "includingLoc" : "None"
+  },
+  "67" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "16.1",
+    "includingLoc" : "None"
+  },
+  "68" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "22.31",
+    "includingLoc" : "None"
+  },
+  "69" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "22.34",
+    "includingLoc" : "None"
+  },
+  "70" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "22.31",
+    "includingLoc" : "None"
+  },
+  "71" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "22.5",
+    "includingLoc" : "None"
+  },
+  "72" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "23.31",
+    "includingLoc" : "None"
+  },
+  "73" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "23.34",
+    "includingLoc" : "None"
+  },
+  "74" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "23.31",
+    "includingLoc" : "None"
+  },
+  "75" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "23.5",
+    "includingLoc" : "None"
+  },
+  "76" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "23.31",
+    "includingLoc" : "None"
+  },
+  "77" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "23.34",
+    "includingLoc" : "None"
+  },
+  "78" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "23.31",
+    "includingLoc" : "None"
+  },
+  "79" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "23.5",
+    "includingLoc" : "None"
+  },
+  "80" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "23.31",
+    "includingLoc" : "None"
+  },
+  "81" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "23.34",
+    "includingLoc" : "None"
+  },
+  "82" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "23.31",
+    "includingLoc" : "None"
+  },
+  "83" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "23.5",
+    "includingLoc" : "None"
+  },
+  "84" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "21.1",
+    "includingLoc" : "None"
+  },
+  "85" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "27.26",
+    "includingLoc" : "None"
+  },
+  "86" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "27.29",
+    "includingLoc" : "None"
+  },
+  "87" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "27.26",
+    "includingLoc" : "None"
+  },
+  "88" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "27.5",
+    "includingLoc" : "None"
+  },
+  "89" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "27.26",
+    "includingLoc" : "None"
+  },
+  "90" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "27.29",
+    "includingLoc" : "None"
+  },
+  "91" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "27.26",
+    "includingLoc" : "None"
+  },
+  "92" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "27.5",
+    "includingLoc" : "None"
+  },
+  "93" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "27.26",
+    "includingLoc" : "None"
+  },
+  "94" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "27.29",
+    "includingLoc" : "None"
+  },
+  "95" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "27.26",
+    "includingLoc" : "None"
+  },
+  "96" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "27.5",
+    "includingLoc" : "None"
+  },
+  "97" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "26.1",
+    "includingLoc" : "None"
+  },
+  "98" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "31.35",
+    "includingLoc" : "None"
+  },
+  "99" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "31.38",
+    "includingLoc" : "None"
+  },
+  "100" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "31.35",
+    "includingLoc" : "None"
+  },
+  "101" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "31.5",
+    "includingLoc" : "None"
+  },
+  "102" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "31.35",
+    "includingLoc" : "None"
+  },
+  "103" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "31.38",
+    "includingLoc" : "None"
+  },
+  "104" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "31.35",
+    "includingLoc" : "None"
+  },
+  "105" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "31.5",
+    "includingLoc" : "None"
+  },
+  "106" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "31.35",
+    "includingLoc" : "None"
+  },
+  "107" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "31.38",
+    "includingLoc" : "None"
+  },
+  "108" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "31.35",
+    "includingLoc" : "None"
+  },
+  "109" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "31.5",
+    "includingLoc" : "None"
+  },
+  "110" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "30.1",
+    "includingLoc" : "None"
+  },
+  "111" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "34.14",
+    "includingLoc" : "None"
+  },
+  "112" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "34.14",
+    "includingLoc" : "None"
+  },
+  "113" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "34.27",
+    "includingLoc" : "None"
+  },
+  "114" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "34.1",
+    "includingLoc" : "None"
+  },
+  "115" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "35.14",
+    "includingLoc" : "None"
+  },
+  "116" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "35.14",
+    "includingLoc" : "None"
+  },
+  "117" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "35.30",
+    "includingLoc" : "None"
+  },
+  "118" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "35.1",
+    "includingLoc" : "None"
+  },
+  "119" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "36.14",
+    "includingLoc" : "None"
+  },
+  "120" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "36.14",
+    "includingLoc" : "None"
+  },
+  "121" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "36.28",
+    "includingLoc" : "None"
+  },
+  "122" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "36.1",
+    "includingLoc" : "None"
+  },
+  "123" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "37.14",
+    "includingLoc" : "None"
+  },
+  "124" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "37.14",
+    "includingLoc" : "None"
+  },
+  "125" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "37.29",
+    "includingLoc" : "None"
+  },
+  "126" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "37.1",
+    "includingLoc" : "None"
+  },
+  "127" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "38.14",
+    "includingLoc" : "None"
+  },
+  "128" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "38.14",
+    "includingLoc" : "None"
+  },
+  "129" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "38.28",
+    "includingLoc" : "None"
+  },
+  "130" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "38.1",
+    "includingLoc" : "None"
+  },
+  "131" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "39.14",
+    "includingLoc" : "None"
+  },
+  "132" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "39.14",
+    "includingLoc" : "None"
+  },
+  "133" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "39.32",
+    "includingLoc" : "None"
+  },
+  "134" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "39.1",
+    "includingLoc" : "None"
+  },
+  "135" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "40.14",
+    "includingLoc" : "None"
+  },
+  "136" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "40.14",
+    "includingLoc" : "None"
+  },
+  "137" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "40.32",
+    "includingLoc" : "None"
+  },
+  "138" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "40.1",
+    "includingLoc" : "None"
+  },
+  "139" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "43.14",
+    "includingLoc" : "None"
+  },
+  "140" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "43.14",
+    "includingLoc" : "None"
+  },
+  "141" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "43.5",
+    "includingLoc" : "None"
+  },
+  "142" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "44.14",
+    "includingLoc" : "None"
+  },
+  "143" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "44.14",
+    "includingLoc" : "None"
+  },
+  "144" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "44.5",
+    "includingLoc" : "None"
+  },
+  "145" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "45.14",
+    "includingLoc" : "None"
+  },
+  "146" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "45.14",
+    "includingLoc" : "None"
+  },
+  "147" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "45.5",
+    "includingLoc" : "None"
+  },
+  "148" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "46.14",
+    "includingLoc" : "None"
+  },
+  "149" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "46.14",
+    "includingLoc" : "None"
+  },
+  "150" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "46.5",
+    "includingLoc" : "None"
+  },
+  "151" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "47.14",
+    "includingLoc" : "None"
+  },
+  "152" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "47.14",
+    "includingLoc" : "None"
+  },
+  "153" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "47.5",
+    "includingLoc" : "None"
+  },
+  "154" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "48.14",
+    "includingLoc" : "None"
+  },
+  "155" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "48.14",
+    "includingLoc" : "None"
+  },
+  "156" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "48.5",
+    "includingLoc" : "None"
+  },
+  "157" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "49.14",
+    "includingLoc" : "None"
+  },
+  "158" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "49.14",
+    "includingLoc" : "None"
+  },
+  "159" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "49.5",
+    "includingLoc" : "None"
+  },
+  "160" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "51.31",
+    "includingLoc" : "None"
+  },
+  "161" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "51.31",
+    "includingLoc" : "None"
+  },
+  "162" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "51.5",
+    "includingLoc" : "None"
+  },
+  "163" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "52.34",
+    "includingLoc" : "None"
+  },
+  "164" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "52.34",
+    "includingLoc" : "None"
+  },
+  "165" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "52.5",
+    "includingLoc" : "None"
+  },
+  "166" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "53.32",
+    "includingLoc" : "None"
+  },
+  "167" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "53.32",
+    "includingLoc" : "None"
+  },
+  "168" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "53.5",
+    "includingLoc" : "None"
+  },
+  "169" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "54.33",
+    "includingLoc" : "None"
+  },
+  "170" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "54.33",
+    "includingLoc" : "None"
+  },
+  "171" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "54.5",
+    "includingLoc" : "None"
+  },
+  "172" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "55.32",
+    "includingLoc" : "None"
+  },
+  "173" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "55.32",
+    "includingLoc" : "None"
+  },
+  "174" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "55.5",
+    "includingLoc" : "None"
+  },
+  "175" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "56.36",
+    "includingLoc" : "None"
+  },
+  "176" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "56.36",
+    "includingLoc" : "None"
+  },
+  "177" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "56.5",
+    "includingLoc" : "None"
+  },
+  "178" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "57.37",
+    "includingLoc" : "None"
+  },
+  "179" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "57.37",
+    "includingLoc" : "None"
+  },
+  "180" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "57.5",
+    "includingLoc" : "None"
+  },
+  "181" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "57.37",
+    "includingLoc" : "None"
+  },
+  "182" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "57.37",
+    "includingLoc" : "None"
+  },
+  "183" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "57.5",
+    "includingLoc" : "None"
+  },
+  "184" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "57.37",
+    "includingLoc" : "None"
+  },
+  "185" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "57.37",
+    "includingLoc" : "None"
+  },
+  "186" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "57.5",
+    "includingLoc" : "None"
+  },
+  "187" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "42.1",
+    "includingLoc" : "None"
+  },
+  "188" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "43.14",
+    "includingLoc" : "None"
+  },
+  "189" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "43.14",
+    "includingLoc" : "None"
+  },
+  "190" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "43.5",
+    "includingLoc" : "None"
+  },
+  "191" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "44.14",
+    "includingLoc" : "None"
+  },
+  "192" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "44.14",
+    "includingLoc" : "None"
+  },
+  "193" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "44.5",
+    "includingLoc" : "None"
+  },
+  "194" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "45.14",
+    "includingLoc" : "None"
+  },
+  "195" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "45.14",
+    "includingLoc" : "None"
+  },
+  "196" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "45.5",
+    "includingLoc" : "None"
+  },
+  "197" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "46.14",
+    "includingLoc" : "None"
+  },
+  "198" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "46.14",
+    "includingLoc" : "None"
+  },
+  "199" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "46.5",
+    "includingLoc" : "None"
+  },
+  "200" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "47.14",
+    "includingLoc" : "None"
+  },
+  "201" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "47.14",
+    "includingLoc" : "None"
+  },
+  "202" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "47.5",
+    "includingLoc" : "None"
+  },
+  "203" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "48.14",
+    "includingLoc" : "None"
+  },
+  "204" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "48.14",
+    "includingLoc" : "None"
+  },
+  "205" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "48.5",
+    "includingLoc" : "None"
+  },
+  "206" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "49.14",
+    "includingLoc" : "None"
+  },
+  "207" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "49.14",
+    "includingLoc" : "None"
+  },
+  "208" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "49.5",
+    "includingLoc" : "None"
+  },
+  "209" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "51.31",
+    "includingLoc" : "None"
+  },
+  "210" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "51.31",
+    "includingLoc" : "None"
+  },
+  "211" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "51.5",
+    "includingLoc" : "None"
+  },
+  "212" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "52.34",
+    "includingLoc" : "None"
+  },
+  "213" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "52.34",
+    "includingLoc" : "None"
+  },
+  "214" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "52.5",
+    "includingLoc" : "None"
+  },
+  "215" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "53.32",
+    "includingLoc" : "None"
+  },
+  "216" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "53.32",
+    "includingLoc" : "None"
+  },
+  "217" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "53.5",
+    "includingLoc" : "None"
+  },
+  "218" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "54.33",
+    "includingLoc" : "None"
+  },
+  "219" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "54.33",
+    "includingLoc" : "None"
+  },
+  "220" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "54.5",
+    "includingLoc" : "None"
+  },
+  "221" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "55.32",
+    "includingLoc" : "None"
+  },
+  "222" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "55.32",
+    "includingLoc" : "None"
+  },
+  "223" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "55.5",
+    "includingLoc" : "None"
+  },
+  "224" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "56.36",
+    "includingLoc" : "None"
+  },
+  "225" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "56.36",
+    "includingLoc" : "None"
+  },
+  "226" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "56.5",
+    "includingLoc" : "None"
+  },
+  "227" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "57.37",
+    "includingLoc" : "None"
+  },
+  "228" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "57.37",
+    "includingLoc" : "None"
+  },
+  "229" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "57.5",
+    "includingLoc" : "None"
+  },
+  "230" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "57.37",
+    "includingLoc" : "None"
+  },
+  "231" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "57.37",
+    "includingLoc" : "None"
+  },
+  "232" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "57.5",
+    "includingLoc" : "None"
+  },
+  "233" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "57.37",
+    "includingLoc" : "None"
+  },
+  "234" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "57.37",
+    "includingLoc" : "None"
+  },
+  "235" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "57.5",
+    "includingLoc" : "None"
+  },
+  "236" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "42.1",
+    "includingLoc" : "None"
+  },
+  "237" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "43.14",
+    "includingLoc" : "None"
+  },
+  "238" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "43.14",
+    "includingLoc" : "None"
+  },
+  "239" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "43.5",
+    "includingLoc" : "None"
+  },
+  "240" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "44.14",
+    "includingLoc" : "None"
+  },
+  "241" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "44.14",
+    "includingLoc" : "None"
+  },
+  "242" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "44.5",
+    "includingLoc" : "None"
+  },
+  "243" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "45.14",
+    "includingLoc" : "None"
+  },
+  "244" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "45.14",
+    "includingLoc" : "None"
+  },
+  "245" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "45.5",
+    "includingLoc" : "None"
+  },
+  "246" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "46.14",
+    "includingLoc" : "None"
+  },
+  "247" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "46.14",
+    "includingLoc" : "None"
+  },
+  "248" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "46.5",
+    "includingLoc" : "None"
+  },
+  "249" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "47.14",
+    "includingLoc" : "None"
+  },
+  "250" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "47.14",
+    "includingLoc" : "None"
+  },
+  "251" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "47.5",
+    "includingLoc" : "None"
+  },
+  "252" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "48.14",
+    "includingLoc" : "None"
+  },
+  "253" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "48.14",
+    "includingLoc" : "None"
+  },
+  "254" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "48.5",
+    "includingLoc" : "None"
+  },
+  "255" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "49.14",
+    "includingLoc" : "None"
+  },
+  "256" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "49.14",
+    "includingLoc" : "None"
+  },
+  "257" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "49.5",
+    "includingLoc" : "None"
+  },
+  "258" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "51.31",
+    "includingLoc" : "None"
+  },
+  "259" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "51.31",
+    "includingLoc" : "None"
+  },
+  "260" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "51.5",
+    "includingLoc" : "None"
+  },
+  "261" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "52.34",
+    "includingLoc" : "None"
+  },
+  "262" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "52.34",
+    "includingLoc" : "None"
+  },
+  "263" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "52.5",
+    "includingLoc" : "None"
+  },
+  "264" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "53.32",
+    "includingLoc" : "None"
+  },
+  "265" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "53.32",
+    "includingLoc" : "None"
+  },
+  "266" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "53.5",
+    "includingLoc" : "None"
+  },
+  "267" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "54.33",
+    "includingLoc" : "None"
+  },
+  "268" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "54.33",
+    "includingLoc" : "None"
+  },
+  "269" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "54.5",
+    "includingLoc" : "None"
+  },
+  "270" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "55.32",
+    "includingLoc" : "None"
+  },
+  "271" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "55.32",
+    "includingLoc" : "None"
+  },
+  "272" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "55.5",
+    "includingLoc" : "None"
+  },
+  "273" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "56.36",
+    "includingLoc" : "None"
+  },
+  "274" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "56.36",
+    "includingLoc" : "None"
+  },
+  "275" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "56.5",
+    "includingLoc" : "None"
+  },
+  "276" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "57.37",
+    "includingLoc" : "None"
+  },
+  "277" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "57.37",
+    "includingLoc" : "None"
+  },
+  "278" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "57.5",
+    "includingLoc" : "None"
+  },
+  "279" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "57.37",
+    "includingLoc" : "None"
+  },
+  "280" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "57.37",
+    "includingLoc" : "None"
+  },
+  "281" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "57.5",
+    "includingLoc" : "None"
+  },
+  "282" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "57.37",
+    "includingLoc" : "None"
+  },
+  "283" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "57.37",
+    "includingLoc" : "None"
+  },
+  "284" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "57.5",
+    "includingLoc" : "None"
+  },
+  "285" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+    "pos" : "42.1",
+    "includingLoc" : "None"
+  },
+  "286" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "pos" : "4.3",
+    "includingLoc" : "None"
+  },
+  "287" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "pos" : "5.3",
+    "includingLoc" : "None"
+  },
+  "288" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "pos" : "6.3",
+    "includingLoc" : "None"
+  },
+  "289" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "pos" : "7.3",
+    "includingLoc" : "None"
+  },
+  "290" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "pos" : "8.3",
+    "includingLoc" : "None"
+  },
+  "291" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "pos" : "9.3",
+    "includingLoc" : "None"
+  },
+  "292" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "pos" : "10.3",
+    "includingLoc" : "None"
+  },
+  "293" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "pos" : "11.3",
+    "includingLoc" : "None"
+  },
+  "294" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "pos" : "12.3",
+    "includingLoc" : "None"
+  },
+  "295" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "pos" : "13.3",
+    "includingLoc" : "None"
+  },
+  "296" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "pos" : "13.3",
+    "includingLoc" : "None"
+  },
+  "297" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "pos" : "13.3",
+    "includingLoc" : "None"
+  },
+  "298" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "pos" : "3.1",
+    "includingLoc" : "None"
+  },
+  "299" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "pos" : "17.3",
+    "includingLoc" : "None"
+  },
+  "300" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "pos" : "17.3",
+    "includingLoc" : "None"
+  },
+  "301" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "pos" : "17.3",
+    "includingLoc" : "None"
+  },
+  "302" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "pos" : "16.1",
+    "includingLoc" : "None"
+  },
+  "303" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "pos" : "17.3",
+    "includingLoc" : "None"
+  },
+  "304" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "pos" : "17.3",
+    "includingLoc" : "None"
+  },
+  "305" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "pos" : "17.3",
+    "includingLoc" : "None"
+  },
+  "306" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "pos" : "16.1",
+    "includingLoc" : "None"
+  },
+  "307" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "pos" : "17.3",
+    "includingLoc" : "None"
+  },
+  "308" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "pos" : "17.3",
+    "includingLoc" : "None"
+  },
+  "309" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "pos" : "17.3",
+    "includingLoc" : "None"
+  },
+  "310" : {
+    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "pos" : "16.1",
+    "includingLoc" : "None"
+  }
+}
+{
+  "componentInstanceMap" : {
+    "134" : {
+      "aNode" : {
+        "astNodeId" : 134
+      },
+      "qualifiedName" : {
+        "qualifier" : [
+        ],
+        "base" : "c6"
+      },
+      "component" : {
+        "astNodeId" : 97
+      },
+      "baseId" : 1536,
+      "maxId" : 1535,
+      "file" : "None",
+      "queueSize" : "None",
+      "stackSize" : "None",
+      "priority" : "None",
+      "cpu" : "None",
+      "initSpecifierMap" : {
+        
+      }
+    },
+    "138" : {
+      "aNode" : {
+        "astNodeId" : 138
+      },
+      "qualifiedName" : {
+        "qualifier" : [
+        ],
+        "base" : "c7"
+      },
+      "component" : {
+        "astNodeId" : 110
+      },
+      "baseId" : 1792,
+      "maxId" : 1791,
+      "file" : "None",
+      "queueSize" : "None",
+      "stackSize" : "None",
+      "priority" : "None",
+      "cpu" : "None",
+      "initSpecifierMap" : {
+        
+      }
+    },
+    "126" : {
+      "aNode" : {
+        "astNodeId" : 126
+      },
+      "qualifiedName" : {
+        "qualifier" : [
+        ],
+        "base" : "c4"
+      },
+      "component" : {
+        "astNodeId" : 67
+      },
+      "baseId" : 1024,
+      "maxId" : 1023,
+      "file" : "None",
+      "queueSize" : "None",
+      "stackSize" : "None",
+      "priority" : "None",
+      "cpu" : "None",
+      "initSpecifierMap" : {
+        
+      }
+    },
+    "122" : {
+      "aNode" : {
+        "astNodeId" : 122
+      },
+      "qualifiedName" : {
+        "qualifier" : [
+        ],
+        "base" : "c3"
+      },
+      "component" : {
+        "astNodeId" : 50
+      },
+      "baseId" : 768,
+      "maxId" : 767,
+      "file" : "None",
+      "queueSize" : "None",
+      "stackSize" : "None",
+      "priority" : "None",
+      "cpu" : "None",
+      "initSpecifierMap" : {
+        
+      }
+    },
+    "118" : {
+      "aNode" : {
+        "astNodeId" : 118
+      },
+      "qualifiedName" : {
+        "qualifier" : [
+        ],
+        "base" : "c2"
+      },
+      "component" : {
+        "astNodeId" : 37
+      },
+      "baseId" : 512,
+      "maxId" : 511,
+      "file" : "None",
+      "queueSize" : "None",
+      "stackSize" : "None",
+      "priority" : "None",
+      "cpu" : "None",
+      "initSpecifierMap" : {
+        
+      }
+    },
+    "130" : {
+      "aNode" : {
+        "astNodeId" : 130
+      },
+      "qualifiedName" : {
+        "qualifier" : [
+        ],
+        "base" : "c5"
+      },
+      "component" : {
+        "astNodeId" : 84
+      },
+      "baseId" : 1280,
+      "maxId" : 1279,
+      "file" : "None",
+      "queueSize" : "None",
+      "stackSize" : "None",
+      "priority" : "None",
+      "cpu" : "None",
+      "initSpecifierMap" : {
+        
+      }
+    },
+    "114" : {
+      "aNode" : {
+        "astNodeId" : 114
+      },
+      "qualifiedName" : {
+        "qualifier" : [
+        ],
+        "base" : "c1"
+      },
+      "component" : {
+        "astNodeId" : 12
+      },
+      "baseId" : 256,
+      "maxId" : 255,
+      "file" : "None",
+      "queueSize" : "None",
+      "stackSize" : "None",
+      "priority" : "None",
+      "cpu" : "None",
+      "initSpecifierMap" : {
+        
+      }
+    }
+  },
+  "componentMap" : {
+    "67" : {
+      "aNode" : {
+        "astNodeId" : 67
+      },
+      "portMap" : {
+        "PingSend" : {
+          "General" : {
+            "aNode" : {
+              "astNodeId" : 54
+            },
+            "specifier" : {
+              "kind" : {
+                "Output" : {
+                  
+                }
+              },
+              "name" : "PingSend",
+              "size" : "None",
+              "port" : {
+                "Some" : {
+                  "astNodeId" : 53
+                }
+              },
+              "priority" : "None",
+              "queueFull" : "None"
+            },
+            "kind" : "Output",
+            "size" : 1,
+            "ty" : {
+              "DefPort" : {
+                "symbol" : {
+                  "Port" : {
+                    "nodeId" : 309,
+                    "unqualifiedName" : "Ping"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "PingReturn" : {
+          "General" : {
+            "aNode" : {
+              "astNodeId" : 66
+            },
+            "specifier" : {
+              "kind" : {
+                "SyncInput" : {
+                  
+                }
+              },
+              "name" : "PingReturn",
+              "size" : "None",
+              "port" : {
+                "Some" : {
+                  "astNodeId" : 65
+                }
+              },
+              "priority" : "None",
+              "queueFull" : "None"
+            },
+            "kind" : "SyncInput",
+            "size" : 1,
+            "ty" : {
+              "DefPort" : {
+                "symbol" : {
+                  "Port" : {
+                    "nodeId" : 309,
+                    "unqualifiedName" : "Ping"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "specialPortMap" : {
+        
+      },
+      "commandMap" : {
+        
+      },
+      "defaultOpcode" : 0,
+      "tlmChannelMap" : {
+        
+      },
+      "defaultTlmChannelId" : 0,
+      "eventMap" : {
+        
+      },
+      "defaultEventId" : 0,
+      "paramMap" : {
+        
+      },
+      "specPortMatchingList" : [
+      ],
+      "portMatchingList" : [
+      ],
+      "defaultParamId" : 0,
+      "containerMap" : {
+        
+      },
+      "defaultContainerId" : 0,
+      "recordMap" : {
+        
+      },
+      "defaultRecordId" : 0
+    },
+    "12" : {
+      "aNode" : {
+        "astNodeId" : 12
+      },
+      "portMap" : {
+        "timeGetPort" : {
+          "General" : {
+            "aNode" : {
+              "astNodeId" : 11
+            },
+            "specifier" : {
+              "kind" : {
+                "SyncInput" : {
+                  
+                }
+              },
+              "name" : "timeGetPort",
+              "size" : "None",
+              "port" : {
+                "Some" : {
+                  "astNodeId" : 10
+                }
+              },
+              "priority" : "None",
+              "queueFull" : "None"
+            },
+            "kind" : "SyncInput",
+            "size" : 1,
+            "ty" : {
+              "DefPort" : {
+                "symbol" : {
+                  "Port" : {
+                    "nodeId" : 286,
+                    "unqualifiedName" : "Time"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "specialPortMap" : {
+        
+      },
+      "commandMap" : {
+        
+      },
+      "defaultOpcode" : 0,
+      "tlmChannelMap" : {
+        
+      },
+      "defaultTlmChannelId" : 0,
+      "eventMap" : {
+        
+      },
+      "defaultEventId" : 0,
+      "paramMap" : {
+        
+      },
+      "specPortMatchingList" : [
+      ],
+      "portMatchingList" : [
+      ],
+      "defaultParamId" : 0,
+      "containerMap" : {
+        
+      },
+      "defaultContainerId" : 0,
+      "recordMap" : {
+        
+      },
+      "defaultRecordId" : 0
+    },
+    "84" : {
+      "aNode" : {
+        "astNodeId" : 84
+      },
+      "portMap" : {
+        "paramGet" : {
+          "General" : {
+            "aNode" : {
+              "astNodeId" : 71
+            },
+            "specifier" : {
+              "kind" : {
+                "SyncInput" : {
+                  
+                }
+              },
+              "name" : "paramGet",
+              "size" : "None",
+              "port" : {
+                "Some" : {
+                  "astNodeId" : 70
+                }
+              },
+              "priority" : "None",
+              "queueFull" : "None"
+            },
+            "kind" : "SyncInput",
+            "size" : 1,
+            "ty" : {
+              "DefPort" : {
+                "symbol" : {
+                  "Port" : {
+                    "nodeId" : 292,
+                    "unqualifiedName" : "PrmGet"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "paramSet" : {
+          "General" : {
+            "aNode" : {
+              "astNodeId" : 83
+            },
+            "specifier" : {
+              "kind" : {
+                "SyncInput" : {
+                  
+                }
+              },
+              "name" : "paramSet",
+              "size" : "None",
+              "port" : {
+                "Some" : {
+                  "astNodeId" : 82
+                }
+              },
+              "priority" : "None",
+              "queueFull" : "None"
+            },
+            "kind" : "SyncInput",
+            "size" : 1,
+            "ty" : {
+              "DefPort" : {
+                "symbol" : {
+                  "Port" : {
+                    "nodeId" : 293,
+                    "unqualifiedName" : "PrmSet"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "specialPortMap" : {
+        
+      },
+      "commandMap" : {
+        
+      },
+      "defaultOpcode" : 0,
+      "tlmChannelMap" : {
+        
+      },
+      "defaultTlmChannelId" : 0,
+      "eventMap" : {
+        
+      },
+      "defaultEventId" : 0,
+      "paramMap" : {
+        
+      },
+      "specPortMatchingList" : [
+      ],
+      "portMatchingList" : [
+      ],
+      "defaultParamId" : 0,
+      "containerMap" : {
+        
+      },
+      "defaultContainerId" : 0,
+      "recordMap" : {
+        
+      },
+      "defaultRecordId" : 0
+    },
+    "110" : {
+      "aNode" : {
+        "astNodeId" : 110
+      },
+      "portMap" : {
+        "textEventLog" : {
+          "General" : {
+            "aNode" : {
+              "astNodeId" : 109
+            },
+            "specifier" : {
+              "kind" : {
+                "SyncInput" : {
+                  
+                }
+              },
+              "name" : "textEventLog",
+              "size" : "None",
+              "port" : {
+                "Some" : {
+                  "astNodeId" : 108
+                }
+              },
+              "priority" : "None",
+              "queueFull" : "None"
+            },
+            "kind" : "SyncInput",
+            "size" : 1,
+            "ty" : {
+              "DefPort" : {
+                "symbol" : {
+                  "Port" : {
+                    "nodeId" : 291,
+                    "unqualifiedName" : "LogText"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "specialPortMap" : {
+        
+      },
+      "commandMap" : {
+        
+      },
+      "defaultOpcode" : 0,
+      "tlmChannelMap" : {
+        
+      },
+      "defaultTlmChannelId" : 0,
+      "eventMap" : {
+        
+      },
+      "defaultEventId" : 0,
+      "paramMap" : {
+        
+      },
+      "specPortMatchingList" : [
+      ],
+      "portMatchingList" : [
+      ],
+      "defaultParamId" : 0,
+      "containerMap" : {
+        
+      },
+      "defaultContainerId" : 0,
+      "recordMap" : {
+        
+      },
+      "defaultRecordId" : 0
+    },
+    "97" : {
+      "aNode" : {
+        "astNodeId" : 97
+      },
+      "portMap" : {
+        "tlm" : {
+          "General" : {
+            "aNode" : {
+              "astNodeId" : 96
+            },
+            "specifier" : {
+              "kind" : {
+                "SyncInput" : {
+                  
+                }
+              },
+              "name" : "tlm",
+              "size" : "None",
+              "port" : {
+                "Some" : {
+                  "astNodeId" : 95
+                }
+              },
+              "priority" : "None",
+              "queueFull" : "None"
+            },
+            "kind" : "SyncInput",
+            "size" : 1,
+            "ty" : {
+              "DefPort" : {
+                "symbol" : {
+                  "Port" : {
+                    "nodeId" : 294,
+                    "unqualifiedName" : "Tlm"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "specialPortMap" : {
+        
+      },
+      "commandMap" : {
+        
+      },
+      "defaultOpcode" : 0,
+      "tlmChannelMap" : {
+        
+      },
+      "defaultTlmChannelId" : 0,
+      "eventMap" : {
+        
+      },
+      "defaultEventId" : 0,
+      "paramMap" : {
+        
+      },
+      "specPortMatchingList" : [
+      ],
+      "portMatchingList" : [
+      ],
+      "defaultParamId" : 0,
+      "containerMap" : {
+        
+      },
+      "defaultContainerId" : 0,
+      "recordMap" : {
+        
+      },
+      "defaultRecordId" : 0
+    },
+    "50" : {
+      "aNode" : {
+        "astNodeId" : 50
+      },
+      "portMap" : {
+        "eventLog" : {
+          "General" : {
+            "aNode" : {
+              "astNodeId" : 49
+            },
+            "specifier" : {
+              "kind" : {
+                "SyncInput" : {
+                  
+                }
+              },
+              "name" : "eventLog",
+              "size" : "None",
+              "port" : {
+                "Some" : {
+                  "astNodeId" : 48
+                }
+              },
+              "priority" : "None",
+              "queueFull" : "None"
+            },
+            "kind" : "SyncInput",
+            "size" : 1,
+            "ty" : {
+              "DefPort" : {
+                "symbol" : {
+                  "Port" : {
+                    "nodeId" : 290,
+                    "unqualifiedName" : "Log"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "specialPortMap" : {
+        
+      },
+      "commandMap" : {
+        
+      },
+      "defaultOpcode" : 0,
+      "tlmChannelMap" : {
+        
+      },
+      "defaultTlmChannelId" : 0,
+      "eventMap" : {
+        
+      },
+      "defaultEventId" : 0,
+      "paramMap" : {
+        
+      },
+      "specPortMatchingList" : [
+      ],
+      "portMatchingList" : [
+      ],
+      "defaultParamId" : 0,
+      "containerMap" : {
+        
+      },
+      "defaultContainerId" : 0,
+      "recordMap" : {
+        
+      },
+      "defaultRecordId" : 0
+    },
+    "37" : {
+      "aNode" : {
+        "astNodeId" : 37
+      },
+      "portMap" : {
+        "cmdIn" : {
+          "General" : {
+            "aNode" : {
+              "astNodeId" : 16
+            },
+            "specifier" : {
+              "kind" : {
+                "SyncInput" : {
+                  
+                }
+              },
+              "name" : "cmdIn",
+              "size" : "None",
+              "port" : {
+                "Some" : {
+                  "astNodeId" : 15
+                }
+              },
+              "priority" : "None",
+              "queueFull" : "None"
+            },
+            "kind" : "SyncInput",
+            "size" : 1,
+            "ty" : {
+              "DefPort" : {
+                "symbol" : {
+                  "Port" : {
+                    "nodeId" : 288,
+                    "unqualifiedName" : "Cmd"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "cmdRegOut" : {
+          "General" : {
+            "aNode" : {
+              "astNodeId" : 20
+            },
+            "specifier" : {
+              "kind" : {
+                "SyncInput" : {
+                  
+                }
+              },
+              "name" : "cmdRegOut",
+              "size" : "None",
+              "port" : {
+                "Some" : {
+                  "astNodeId" : 19
+                }
+              },
+              "priority" : "None",
+              "queueFull" : "None"
+            },
+            "kind" : "SyncInput",
+            "size" : 1,
+            "ty" : {
+              "DefPort" : {
+                "symbol" : {
+                  "Port" : {
+                    "nodeId" : 287,
+                    "unqualifiedName" : "CmdReg"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "cmdResponseOut" : {
+          "General" : {
+            "aNode" : {
+              "astNodeId" : 24
+            },
+            "specifier" : {
+              "kind" : {
+                "SyncInput" : {
+                  
+                }
+              },
+              "name" : "cmdResponseOut",
+              "size" : "None",
+              "port" : {
+                "Some" : {
+                  "astNodeId" : 23
+                }
+              },
+              "priority" : "None",
+              "queueFull" : "None"
+            },
+            "kind" : "SyncInput",
+            "size" : 1,
+            "ty" : {
+              "DefPort" : {
+                "symbol" : {
+                  "Port" : {
+                    "nodeId" : 289,
+                    "unqualifiedName" : "CmdResponse"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "cmdSend" : {
+          "General" : {
+            "aNode" : {
+              "astNodeId" : 36
+            },
+            "specifier" : {
+              "kind" : {
+                "Output" : {
+                  
+                }
+              },
+              "name" : "cmdSend",
+              "size" : "None",
+              "port" : {
+                "Some" : {
+                  "astNodeId" : 35
+                }
+              },
+              "priority" : "None",
+              "queueFull" : "None"
+            },
+            "kind" : "Output",
+            "size" : 1,
+            "ty" : {
+              "DefPort" : {
+                "symbol" : {
+                  "Port" : {
+                    "nodeId" : 288,
+                    "unqualifiedName" : "Cmd"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "specialPortMap" : {
+        
+      },
+      "commandMap" : {
+        
+      },
+      "defaultOpcode" : 0,
+      "tlmChannelMap" : {
+        
+      },
+      "defaultTlmChannelId" : 0,
+      "eventMap" : {
+        
+      },
+      "defaultEventId" : 0,
+      "paramMap" : {
+        
+      },
+      "specPortMatchingList" : [
+      ],
+      "portMatchingList" : [
+      ],
+      "defaultParamId" : 0,
+      "containerMap" : {
+        
+      },
+      "defaultContainerId" : 0,
+      "recordMap" : {
+        
+      },
+      "defaultRecordId" : 0
+    }
+  },
+  "includedFileSet" : [
+  ],
+  "inputFileSet" : [
+    "[ local path prefix ]/compiler/tools/fpp-to-json/test/Fw/symbols.fpp",
+    "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp"
+  ],
+  "locationSpecifierMap" : [
+  ],
+  "parentSymbolMap" : {
+    "287" : {
+      "Module" : {
+        "nodeId" : 298,
+        "unqualifiedName" : "Fw"
+      }
+    },
+    "291" : {
+      "Module" : {
+        "nodeId" : 298,
+        "unqualifiedName" : "Fw"
+      }
+    },
+    "292" : {
+      "Module" : {
+        "nodeId" : 298,
+        "unqualifiedName" : "Fw"
+      }
+    },
+    "297" : {
+      "Module" : {
+        "nodeId" : 298,
+        "unqualifiedName" : "Fw"
+      }
+    },
+    "290" : {
+      "Module" : {
+        "nodeId" : 298,
+        "unqualifiedName" : "Fw"
+      }
+    },
+    "309" : {
+      "Module" : {
+        "nodeId" : 310,
+        "unqualifiedName" : "Svc"
+      }
+    },
+    "293" : {
+      "Module" : {
+        "nodeId" : 298,
+        "unqualifiedName" : "Fw"
+      }
+    },
+    "294" : {
+      "Module" : {
+        "nodeId" : 298,
+        "unqualifiedName" : "Fw"
+      }
+    },
+    "288" : {
+      "Module" : {
+        "nodeId" : 298,
+        "unqualifiedName" : "Fw"
+      }
+    },
+    "286" : {
+      "Module" : {
+        "nodeId" : 298,
+        "unqualifiedName" : "Fw"
+      }
+    },
+    "289" : {
+      "Module" : {
+        "nodeId" : 298,
+        "unqualifiedName" : "Fw"
+      }
+    }
+  },
+  "symbolScopeMap" : {
+    "12" : {
+      "ScopeImpl" : {
+        "map" : {
+          
+        }
+      }
+    },
+    "84" : {
+      "ScopeImpl" : {
+        "map" : {
+          
+        }
+      }
+    },
+    "110" : {
+      "ScopeImpl" : {
+        "map" : {
+          
+        }
+      }
+    },
+    "298" : {
+      "ScopeImpl" : {
+        "map" : {
+          "Port" : {
+            "NameSymbolMapImpl" : {
+              "map" : {
+                "CmdReg" : {
+                  "Port" : {
+                    "nodeId" : 287,
+                    "unqualifiedName" : "CmdReg"
+                  }
+                },
+                "Tlm" : {
+                  "Port" : {
+                    "nodeId" : 294,
+                    "unqualifiedName" : "Tlm"
+                  }
+                },
+                "PrmGet" : {
+                  "Port" : {
+                    "nodeId" : 292,
+                    "unqualifiedName" : "PrmGet"
+                  }
+                },
+                "LogText" : {
+                  "Port" : {
+                    "nodeId" : 291,
+                    "unqualifiedName" : "LogText"
+                  }
+                },
+                "Cmd" : {
+                  "Port" : {
+                    "nodeId" : 288,
+                    "unqualifiedName" : "Cmd"
+                  }
+                },
+                "Log" : {
+                  "Port" : {
+                    "nodeId" : 290,
+                    "unqualifiedName" : "Log"
+                  }
+                },
+                "CmdResponse" : {
+                  "Port" : {
+                    "nodeId" : 289,
+                    "unqualifiedName" : "CmdResponse"
+                  }
+                },
+                "Time" : {
+                  "Port" : {
+                    "nodeId" : 286,
+                    "unqualifiedName" : "Time"
+                  }
+                },
+                "PrmSet" : {
+                  "Port" : {
+                    "nodeId" : 293,
+                    "unqualifiedName" : "PrmSet"
+                  }
+                },
+                "TlmGet" : {
+                  "Port" : {
+                    "nodeId" : 297,
+                    "unqualifiedName" : "TlmGet"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "97" : {
+      "ScopeImpl" : {
+        "map" : {
+          
+        }
+      }
+    },
+    "67" : {
+      "ScopeImpl" : {
+        "map" : {
+          
+        }
+      }
+    },
+    "310" : {
+      "ScopeImpl" : {
+        "map" : {
+          "Port" : {
+            "NameSymbolMapImpl" : {
+              "map" : {
+                "Ping" : {
+                  "Port" : {
+                    "nodeId" : 309,
+                    "unqualifiedName" : "Ping"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "50" : {
+      "ScopeImpl" : {
+        "map" : {
+          
+        }
+      }
+    },
+    "37" : {
+      "ScopeImpl" : {
+        "map" : {
+          
+        }
+      }
+    }
+  },
+  "topologyMap" : {
+    "285" : {
+      "aNode" : {
+        "astNodeId" : 285
+      },
+      "directImportMap" : {
+        
+      },
+      "transitiveImportSet" : [
+      ],
+      "instanceMap" : [
+        [
+          {
+            "aNode" : {
+              "astNodeId" : 134
+            },
+            "qualifiedName" : {
+              "qualifier" : [
+              ],
+              "base" : "c6"
+            },
+            "component" : {
+              "astNodeId" : 97
+            },
+            "baseId" : 1536,
+            "maxId" : 1535,
+            "file" : "None",
+            "queueSize" : "None",
+            "stackSize" : "None",
+            "priority" : "None",
+            "cpu" : "None",
+            "initSpecifierMap" : {
+              
+            }
+          },
+          [
+            {
+              "Public" : {
+                
+              }
+            },
+            {
+              "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+              "pos" : "48.5",
+              "includingLoc" : "None"
+            }
+          ]
+        ],
+        [
+          {
+            "aNode" : {
+              "astNodeId" : 114
+            },
+            "qualifiedName" : {
+              "qualifier" : [
+              ],
+              "base" : "c1"
+            },
+            "component" : {
+              "astNodeId" : 12
+            },
+            "baseId" : 256,
+            "maxId" : 255,
+            "file" : "None",
+            "queueSize" : "None",
+            "stackSize" : "None",
+            "priority" : "None",
+            "cpu" : "None",
+            "initSpecifierMap" : {
+              
+            }
+          },
+          [
+            {
+              "Public" : {
+                
+              }
+            },
+            {
+              "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+              "pos" : "43.5",
+              "includingLoc" : "None"
+            }
+          ]
+        ],
+        [
+          {
+            "aNode" : {
+              "astNodeId" : 138
+            },
+            "qualifiedName" : {
+              "qualifier" : [
+              ],
+              "base" : "c7"
+            },
+            "component" : {
+              "astNodeId" : 110
+            },
+            "baseId" : 1792,
+            "maxId" : 1791,
+            "file" : "None",
+            "queueSize" : "None",
+            "stackSize" : "None",
+            "priority" : "None",
+            "cpu" : "None",
+            "initSpecifierMap" : {
+              
+            }
+          },
+          [
+            {
+              "Public" : {
+                
+              }
+            },
+            {
+              "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+              "pos" : "49.5",
+              "includingLoc" : "None"
+            }
+          ]
+        ],
+        [
+          {
+            "aNode" : {
+              "astNodeId" : 118
+            },
+            "qualifiedName" : {
+              "qualifier" : [
+              ],
+              "base" : "c2"
+            },
+            "component" : {
+              "astNodeId" : 37
+            },
+            "baseId" : 512,
+            "maxId" : 511,
+            "file" : "None",
+            "queueSize" : "None",
+            "stackSize" : "None",
+            "priority" : "None",
+            "cpu" : "None",
+            "initSpecifierMap" : {
+              
+            }
+          },
+          [
+            {
+              "Public" : {
+                
+              }
+            },
+            {
+              "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+              "pos" : "44.5",
+              "includingLoc" : "None"
+            }
+          ]
+        ],
+        [
+          {
+            "aNode" : {
+              "astNodeId" : 130
+            },
+            "qualifiedName" : {
+              "qualifier" : [
+              ],
+              "base" : "c5"
+            },
+            "component" : {
+              "astNodeId" : 84
+            },
+            "baseId" : 1280,
+            "maxId" : 1279,
+            "file" : "None",
+            "queueSize" : "None",
+            "stackSize" : "None",
+            "priority" : "None",
+            "cpu" : "None",
+            "initSpecifierMap" : {
+              
+            }
+          },
+          [
+            {
+              "Public" : {
+                
+              }
+            },
+            {
+              "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+              "pos" : "47.5",
+              "includingLoc" : "None"
+            }
+          ]
+        ],
+        [
+          {
+            "aNode" : {
+              "astNodeId" : 126
+            },
+            "qualifiedName" : {
+              "qualifier" : [
+              ],
+              "base" : "c4"
+            },
+            "component" : {
+              "astNodeId" : 67
+            },
+            "baseId" : 1024,
+            "maxId" : 1023,
+            "file" : "None",
+            "queueSize" : "None",
+            "stackSize" : "None",
+            "priority" : "None",
+            "cpu" : "None",
+            "initSpecifierMap" : {
+              
+            }
+          },
+          [
+            {
+              "Public" : {
+                
+              }
+            },
+            {
+              "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+              "pos" : "46.5",
+              "includingLoc" : "None"
+            }
+          ]
+        ],
+        [
+          {
+            "aNode" : {
+              "astNodeId" : 122
+            },
+            "qualifiedName" : {
+              "qualifier" : [
+              ],
+              "base" : "c3"
+            },
+            "component" : {
+              "astNodeId" : 50
+            },
+            "baseId" : 768,
+            "maxId" : 767,
+            "file" : "None",
+            "queueSize" : "None",
+            "stackSize" : "None",
+            "priority" : "None",
+            "cpu" : "None",
+            "initSpecifierMap" : {
+              
+            }
+          },
+          [
+            {
+              "Public" : {
+                
+              }
+            },
+            {
+              "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+              "pos" : "45.5",
+              "includingLoc" : "None"
+            }
+          ]
+        ]
+      ],
+      "patternMap" : {
+        "Event" : {
+          "aNode" : {
+            "astNodeId" : 266
+          },
+          "ast" : {
+            "kind" : {
+              "Event" : {
+                
+              }
+            },
+            "source" : {
+              "astNodeId" : 265
+            },
+            "targets" : [
+            ]
+          },
+          "source" : [
+            {
+              "aNode" : {
+                "astNodeId" : 122
+              },
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c3"
+              },
+              "component" : {
+                "astNodeId" : 50
+              },
+              "baseId" : 768,
+              "maxId" : 767,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
+            },
+            {
+              "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+              "pos" : "53.32",
+              "includingLoc" : "None"
+            }
+          ],
+          "targets" : [
+          ]
+        },
+        "Command" : {
+          "aNode" : {
+            "astNodeId" : 263
+          },
+          "ast" : {
+            "kind" : {
+              "Command" : {
+                
+              }
+            },
+            "source" : {
+              "astNodeId" : 262
+            },
+            "targets" : [
+            ]
+          },
+          "source" : [
+            {
+              "aNode" : {
+                "astNodeId" : 118
+              },
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c2"
+              },
+              "component" : {
+                "astNodeId" : 37
+              },
+              "baseId" : 512,
+              "maxId" : 511,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
+            },
+            {
+              "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+              "pos" : "52.34",
+              "includingLoc" : "None"
+            }
+          ],
+          "targets" : [
+          ]
+        },
+        "Param" : {
+          "aNode" : {
+            "astNodeId" : 272
+          },
+          "ast" : {
+            "kind" : {
+              "Param" : {
+                
+              }
+            },
+            "source" : {
+              "astNodeId" : 271
+            },
+            "targets" : [
+            ]
+          },
+          "source" : [
+            {
+              "aNode" : {
+                "astNodeId" : 130
+              },
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c5"
+              },
+              "component" : {
+                "astNodeId" : 84
+              },
+              "baseId" : 1280,
+              "maxId" : 1279,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
+            },
+            {
+              "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+              "pos" : "55.32",
+              "includingLoc" : "None"
+            }
+          ],
+          "targets" : [
+          ]
+        },
+        "Telemetry" : {
+          "aNode" : {
+            "astNodeId" : 275
+          },
+          "ast" : {
+            "kind" : {
+              "Telemetry" : {
+                
+              }
+            },
+            "source" : {
+              "astNodeId" : 274
+            },
+            "targets" : [
+            ]
+          },
+          "source" : [
+            {
+              "aNode" : {
+                "astNodeId" : 134
+              },
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c6"
+              },
+              "component" : {
+                "astNodeId" : 97
+              },
+              "baseId" : 1536,
+              "maxId" : 1535,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
+            },
+            {
+              "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+              "pos" : "56.36",
+              "includingLoc" : "None"
+            }
+          ],
+          "targets" : [
+          ]
+        },
+        "Time" : {
+          "aNode" : {
+            "astNodeId" : 260
+          },
+          "ast" : {
+            "kind" : {
+              "Time" : {
+                
+              }
+            },
+            "source" : {
+              "astNodeId" : 259
+            },
+            "targets" : [
+            ]
+          },
+          "source" : [
+            {
+              "aNode" : {
+                "astNodeId" : 114
+              },
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c1"
+              },
+              "component" : {
+                "astNodeId" : 12
+              },
+              "baseId" : 256,
+              "maxId" : 255,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
+            },
+            {
+              "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+              "pos" : "51.31",
+              "includingLoc" : "None"
+            }
+          ],
+          "targets" : [
+          ]
+        },
+        "TextEvent" : {
+          "aNode" : {
+            "astNodeId" : 284
+          },
+          "ast" : {
+            "kind" : {
+              "TextEvent" : {
+                
+              }
+            },
+            "source" : {
+              "astNodeId" : 283
+            },
+            "targets" : [
+            ]
+          },
+          "source" : [
+            {
+              "aNode" : {
+                "astNodeId" : 138
+              },
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c7"
+              },
+              "component" : {
+                "astNodeId" : 110
+              },
+              "baseId" : 1792,
+              "maxId" : 1791,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
+            },
+            {
+              "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+              "pos" : "57.37",
+              "includingLoc" : "None"
+            }
+          ],
+          "targets" : [
+          ]
+        },
+        "Health" : {
+          "aNode" : {
+            "astNodeId" : 269
+          },
+          "ast" : {
+            "kind" : {
+              "Health" : {
+                
+              }
+            },
+            "source" : {
+              "astNodeId" : 268
+            },
+            "targets" : [
+            ]
+          },
+          "source" : [
+            {
+              "aNode" : {
+                "astNodeId" : 126
+              },
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c4"
+              },
+              "component" : {
+                "astNodeId" : 67
+              },
+              "baseId" : 1024,
+              "maxId" : 1023,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
+            },
+            {
+              "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+              "pos" : "54.33",
+              "includingLoc" : "None"
+            }
+          ],
+          "targets" : [
+          ]
+        }
+      },
+      "connectionMap" : {
+        
+      },
+      "localConnectionMap" : {
+        
+      },
+      "outputConnectionMap" : [
+      ],
+      "inputConnectionMap" : [
+      ],
+      "fromPortNumberMap" : [
+      ],
+      "toPortNumberMap" : [
+      ],
+      "unconnectedPortSet" : [
+        {
+          "componentInstance" : {
+            "aNode" : {
+              "astNodeId" : 118
+            },
+            "qualifiedName" : {
+              "qualifier" : [
+              ],
+              "base" : "c2"
+            },
+            "component" : {
+              "astNodeId" : 37
+            },
+            "baseId" : 512,
+            "maxId" : 511,
+            "file" : "None",
+            "queueSize" : "None",
+            "stackSize" : "None",
+            "priority" : "None",
+            "cpu" : "None",
+            "initSpecifierMap" : {
+              
+            }
+          },
+          "portInstance" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 36
+              },
+              "specifier" : {
+                "kind" : {
+                  "Output" : {
+                    
+                  }
+                },
+                "name" : "cmdSend",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 35
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "kind" : "Output",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 288,
+                      "unqualifiedName" : "Cmd"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "componentInstance" : {
+            "aNode" : {
+              "astNodeId" : 130
+            },
+            "qualifiedName" : {
+              "qualifier" : [
+              ],
+              "base" : "c5"
+            },
+            "component" : {
+              "astNodeId" : 84
+            },
+            "baseId" : 1280,
+            "maxId" : 1279,
+            "file" : "None",
+            "queueSize" : "None",
+            "stackSize" : "None",
+            "priority" : "None",
+            "cpu" : "None",
+            "initSpecifierMap" : {
+              
+            }
+          },
+          "portInstance" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 83
+              },
+              "specifier" : {
+                "kind" : {
+                  "SyncInput" : {
+                    
+                  }
+                },
+                "name" : "paramSet",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 82
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "kind" : "SyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 293,
+                      "unqualifiedName" : "PrmSet"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "componentInstance" : {
+            "aNode" : {
+              "astNodeId" : 130
+            },
+            "qualifiedName" : {
+              "qualifier" : [
+              ],
+              "base" : "c5"
+            },
+            "component" : {
+              "astNodeId" : 84
+            },
+            "baseId" : 1280,
+            "maxId" : 1279,
+            "file" : "None",
+            "queueSize" : "None",
+            "stackSize" : "None",
+            "priority" : "None",
+            "cpu" : "None",
+            "initSpecifierMap" : {
+              
+            }
+          },
+          "portInstance" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 71
+              },
+              "specifier" : {
+                "kind" : {
+                  "SyncInput" : {
+                    
+                  }
+                },
+                "name" : "paramGet",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 70
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "kind" : "SyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 292,
+                      "unqualifiedName" : "PrmGet"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "componentInstance" : {
+            "aNode" : {
+              "astNodeId" : 118
+            },
+            "qualifiedName" : {
+              "qualifier" : [
+              ],
+              "base" : "c2"
+            },
+            "component" : {
+              "astNodeId" : 37
+            },
+            "baseId" : 512,
+            "maxId" : 511,
+            "file" : "None",
+            "queueSize" : "None",
+            "stackSize" : "None",
+            "priority" : "None",
+            "cpu" : "None",
+            "initSpecifierMap" : {
+              
+            }
+          },
+          "portInstance" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 24
+              },
+              "specifier" : {
+                "kind" : {
+                  "SyncInput" : {
+                    
+                  }
+                },
+                "name" : "cmdResponseOut",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 23
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "kind" : "SyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 289,
+                      "unqualifiedName" : "CmdResponse"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "componentInstance" : {
+            "aNode" : {
+              "astNodeId" : 126
+            },
+            "qualifiedName" : {
+              "qualifier" : [
+              ],
+              "base" : "c4"
+            },
+            "component" : {
+              "astNodeId" : 67
+            },
+            "baseId" : 1024,
+            "maxId" : 1023,
+            "file" : "None",
+            "queueSize" : "None",
+            "stackSize" : "None",
+            "priority" : "None",
+            "cpu" : "None",
+            "initSpecifierMap" : {
+              
+            }
+          },
+          "portInstance" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 66
+              },
+              "specifier" : {
+                "kind" : {
+                  "SyncInput" : {
+                    
+                  }
+                },
+                "name" : "PingReturn",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 65
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "kind" : "SyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 309,
+                      "unqualifiedName" : "Ping"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "componentInstance" : {
+            "aNode" : {
+              "astNodeId" : 126
+            },
+            "qualifiedName" : {
+              "qualifier" : [
+              ],
+              "base" : "c4"
+            },
+            "component" : {
+              "astNodeId" : 67
+            },
+            "baseId" : 1024,
+            "maxId" : 1023,
+            "file" : "None",
+            "queueSize" : "None",
+            "stackSize" : "None",
+            "priority" : "None",
+            "cpu" : "None",
+            "initSpecifierMap" : {
+              
+            }
+          },
+          "portInstance" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 54
+              },
+              "specifier" : {
+                "kind" : {
+                  "Output" : {
+                    
+                  }
+                },
+                "name" : "PingSend",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 53
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "kind" : "Output",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 309,
+                      "unqualifiedName" : "Ping"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "componentInstance" : {
+            "aNode" : {
+              "astNodeId" : 114
+            },
+            "qualifiedName" : {
+              "qualifier" : [
+              ],
+              "base" : "c1"
+            },
+            "component" : {
+              "astNodeId" : 12
+            },
+            "baseId" : 256,
+            "maxId" : 255,
+            "file" : "None",
+            "queueSize" : "None",
+            "stackSize" : "None",
+            "priority" : "None",
+            "cpu" : "None",
+            "initSpecifierMap" : {
+              
+            }
+          },
+          "portInstance" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 11
+              },
+              "specifier" : {
+                "kind" : {
+                  "SyncInput" : {
+                    
+                  }
+                },
+                "name" : "timeGetPort",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 10
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "kind" : "SyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 286,
+                      "unqualifiedName" : "Time"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "componentInstance" : {
+            "aNode" : {
+              "astNodeId" : 138
+            },
+            "qualifiedName" : {
+              "qualifier" : [
+              ],
+              "base" : "c7"
+            },
+            "component" : {
+              "astNodeId" : 110
+            },
+            "baseId" : 1792,
+            "maxId" : 1791,
+            "file" : "None",
+            "queueSize" : "None",
+            "stackSize" : "None",
+            "priority" : "None",
+            "cpu" : "None",
+            "initSpecifierMap" : {
+              
+            }
+          },
+          "portInstance" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 109
+              },
+              "specifier" : {
+                "kind" : {
+                  "SyncInput" : {
+                    
+                  }
+                },
+                "name" : "textEventLog",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 108
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "kind" : "SyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 291,
+                      "unqualifiedName" : "LogText"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "componentInstance" : {
+            "aNode" : {
+              "astNodeId" : 118
+            },
+            "qualifiedName" : {
+              "qualifier" : [
+              ],
+              "base" : "c2"
+            },
+            "component" : {
+              "astNodeId" : 37
+            },
+            "baseId" : 512,
+            "maxId" : 511,
+            "file" : "None",
+            "queueSize" : "None",
+            "stackSize" : "None",
+            "priority" : "None",
+            "cpu" : "None",
+            "initSpecifierMap" : {
+              
+            }
+          },
+          "portInstance" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 20
+              },
+              "specifier" : {
+                "kind" : {
+                  "SyncInput" : {
+                    
+                  }
+                },
+                "name" : "cmdRegOut",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 19
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "kind" : "SyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 287,
+                      "unqualifiedName" : "CmdReg"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "componentInstance" : {
+            "aNode" : {
+              "astNodeId" : 122
+            },
+            "qualifiedName" : {
+              "qualifier" : [
+              ],
+              "base" : "c3"
+            },
+            "component" : {
+              "astNodeId" : 50
+            },
+            "baseId" : 768,
+            "maxId" : 767,
+            "file" : "None",
+            "queueSize" : "None",
+            "stackSize" : "None",
+            "priority" : "None",
+            "cpu" : "None",
+            "initSpecifierMap" : {
+              
+            }
+          },
+          "portInstance" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 49
+              },
+              "specifier" : {
+                "kind" : {
+                  "SyncInput" : {
+                    
+                  }
+                },
+                "name" : "eventLog",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 48
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "kind" : "SyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 290,
+                      "unqualifiedName" : "Log"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "componentInstance" : {
+            "aNode" : {
+              "astNodeId" : 134
+            },
+            "qualifiedName" : {
+              "qualifier" : [
+              ],
+              "base" : "c6"
+            },
+            "component" : {
+              "astNodeId" : 97
+            },
+            "baseId" : 1536,
+            "maxId" : 1535,
+            "file" : "None",
+            "queueSize" : "None",
+            "stackSize" : "None",
+            "priority" : "None",
+            "cpu" : "None",
+            "initSpecifierMap" : {
+              
+            }
+          },
+          "portInstance" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 96
+              },
+              "specifier" : {
+                "kind" : {
+                  "SyncInput" : {
+                    
+                  }
+                },
+                "name" : "tlm",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 95
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "kind" : "SyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 294,
+                      "unqualifiedName" : "Tlm"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "componentInstance" : {
+            "aNode" : {
+              "astNodeId" : 118
+            },
+            "qualifiedName" : {
+              "qualifier" : [
+              ],
+              "base" : "c2"
+            },
+            "component" : {
+              "astNodeId" : 37
+            },
+            "baseId" : 512,
+            "maxId" : 511,
+            "file" : "None",
+            "queueSize" : "None",
+            "stackSize" : "None",
+            "priority" : "None",
+            "cpu" : "None",
+            "initSpecifierMap" : {
+              
+            }
+          },
+          "portInstance" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 16
+              },
+              "specifier" : {
+                "kind" : {
+                  "SyncInput" : {
+                    
+                  }
+                },
+                "name" : "cmdIn",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 15
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "kind" : "SyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 288,
+                      "unqualifiedName" : "Cmd"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "typeMap" : {
+    "113" : {
+      "Int" : {
+        "Integer" : {
+          
+        }
+      }
+    },
+    "121" : {
+      "Int" : {
+        "Integer" : {
+          
+        }
+      }
+    },
+    "117" : {
+      "Int" : {
+        "Integer" : {
+          
+        }
+      }
+    },
+    "137" : {
+      "Int" : {
+        "Integer" : {
+          
+        }
+      }
+    },
+    "133" : {
+      "Int" : {
+        "Integer" : {
+          
+        }
+      }
+    },
+    "125" : {
+      "Int" : {
+        "Integer" : {
+          
+        }
+      }
+    },
+    "129" : {
+      "Int" : {
+        "Integer" : {
+          
+        }
+      }
+    }
+  },
+  "useDefMap" : {
+    "51" : {
+      "Module" : {
+        "nodeId" : 310,
+        "unqualifiedName" : "Svc"
+      }
+    },
+    "128" : {
+      "Component" : {
+        "nodeId" : 84,
+        "unqualifiedName" : "Param"
+      }
+    },
+    "33" : {
+      "Module" : {
+        "nodeId" : 298,
+        "unqualifiedName" : "Fw"
+      }
+    },
+    "17" : {
+      "Module" : {
+        "nodeId" : 298,
+        "unqualifiedName" : "Fw"
+      }
+    },
+    "95" : {
+      "Port" : {
+        "nodeId" : 294,
+        "unqualifiedName" : "Tlm"
+      }
+    },
+    "53" : {
+      "Port" : {
+        "nodeId" : 309,
+        "unqualifiedName" : "Ping"
+      }
+    },
+    "70" : {
+      "Port" : {
+        "nodeId" : 292,
+        "unqualifiedName" : "PrmGet"
+      }
+    },
+    "283" : {
+      "ComponentInstance" : {
+        "nodeId" : 138,
+        "unqualifiedName" : "c7"
+      }
+    },
+    "247" : {
+      "ComponentInstance" : {
+        "nodeId" : 126,
+        "unqualifiedName" : "c4"
+      }
+    },
+    "63" : {
+      "Module" : {
+        "nodeId" : 310,
+        "unqualifiedName" : "Svc"
+      }
+    },
+    "136" : {
+      "Component" : {
+        "nodeId" : 110,
+        "unqualifiedName" : "TextEvent"
+      }
+    },
+    "120" : {
+      "Component" : {
+        "nodeId" : 50,
+        "unqualifiedName" : "Event"
+      }
+    },
+    "93" : {
+      "Module" : {
+        "nodeId" : 298,
+        "unqualifiedName" : "Fw"
+      }
+    },
+    "124" : {
+      "Component" : {
+        "nodeId" : 67,
+        "unqualifiedName" : "Health"
+      }
+    },
+    "8" : {
+      "Module" : {
+        "nodeId" : 298,
+        "unqualifiedName" : "Fw"
+      }
+    },
+    "19" : {
+      "Port" : {
+        "nodeId" : 287,
+        "unqualifiedName" : "CmdReg"
+      }
+    },
+    "265" : {
+      "ComponentInstance" : {
+        "nodeId" : 122,
+        "unqualifiedName" : "c3"
+      }
+    },
+    "23" : {
+      "Port" : {
+        "nodeId" : 289,
+        "unqualifiedName" : "CmdResponse"
+      }
+    },
+    "15" : {
+      "Port" : {
+        "nodeId" : 288,
+        "unqualifiedName" : "Cmd"
+      }
+    },
+    "132" : {
+      "Component" : {
+        "nodeId" : 97,
+        "unqualifiedName" : "Telemetry"
+      }
+    },
+    "262" : {
+      "ComponentInstance" : {
+        "nodeId" : 118,
+        "unqualifiedName" : "c2"
+      }
+    },
+    "250" : {
+      "ComponentInstance" : {
+        "nodeId" : 130,
+        "unqualifiedName" : "c5"
+      }
+    },
+    "244" : {
+      "ComponentInstance" : {
+        "nodeId" : 122,
+        "unqualifiedName" : "c3"
+      }
+    },
+    "68" : {
+      "Module" : {
+        "nodeId" : 298,
+        "unqualifiedName" : "Fw"
+      }
+    },
+    "13" : {
+      "Module" : {
+        "nodeId" : 298,
+        "unqualifiedName" : "Fw"
+      }
+    },
+    "46" : {
+      "Module" : {
+        "nodeId" : 298,
+        "unqualifiedName" : "Fw"
+      }
+    },
+    "253" : {
+      "ComponentInstance" : {
+        "nodeId" : 134,
+        "unqualifiedName" : "c6"
+      }
+    },
+    "35" : {
+      "Port" : {
+        "nodeId" : 288,
+        "unqualifiedName" : "Cmd"
+      }
+    },
+    "112" : {
+      "Component" : {
+        "nodeId" : 12,
+        "unqualifiedName" : "Time"
+      }
+    },
+    "268" : {
+      "ComponentInstance" : {
+        "nodeId" : 126,
+        "unqualifiedName" : "c4"
+      }
+    },
+    "10" : {
+      "Port" : {
+        "nodeId" : 286,
+        "unqualifiedName" : "Time"
+      }
+    },
+    "274" : {
+      "ComponentInstance" : {
+        "nodeId" : 134,
+        "unqualifiedName" : "c6"
+      }
+    },
+    "256" : {
+      "ComponentInstance" : {
+        "nodeId" : 138,
+        "unqualifiedName" : "c7"
+      }
+    },
+    "48" : {
+      "Port" : {
+        "nodeId" : 290,
+        "unqualifiedName" : "Log"
+      }
+    },
+    "21" : {
+      "Module" : {
+        "nodeId" : 298,
+        "unqualifiedName" : "Fw"
+      }
+    },
+    "116" : {
+      "Component" : {
+        "nodeId" : 37,
+        "unqualifiedName" : "Command"
+      }
+    },
+    "65" : {
+      "Port" : {
+        "nodeId" : 309,
+        "unqualifiedName" : "Ping"
+      }
+    },
+    "108" : {
+      "Port" : {
+        "nodeId" : 291,
+        "unqualifiedName" : "LogText"
+      }
+    },
+    "259" : {
+      "ComponentInstance" : {
+        "nodeId" : 114,
+        "unqualifiedName" : "c1"
+      }
+    },
+    "80" : {
+      "Module" : {
+        "nodeId" : 298,
+        "unqualifiedName" : "Fw"
+      }
+    },
+    "106" : {
+      "Module" : {
+        "nodeId" : 298,
+        "unqualifiedName" : "Fw"
+      }
+    },
+    "82" : {
+      "Port" : {
+        "nodeId" : 293,
+        "unqualifiedName" : "PrmSet"
+      }
+    },
+    "241" : {
+      "ComponentInstance" : {
+        "nodeId" : 118,
+        "unqualifiedName" : "c2"
+      }
+    },
+    "238" : {
+      "ComponentInstance" : {
+        "nodeId" : 114,
+        "unqualifiedName" : "c1"
+      }
+    },
+    "271" : {
+      "ComponentInstance" : {
+        "nodeId" : 130,
+        "unqualifiedName" : "c5"
+      }
+    }
+  },
+  "valueMap" : {
+    "113" : {
+      "Integer" : {
+        "value" : 256
+      }
+    },
+    "121" : {
+      "Integer" : {
+        "value" : 768
+      }
+    },
+    "117" : {
+      "Integer" : {
+        "value" : 512
+      }
+    },
+    "137" : {
+      "Integer" : {
+        "value" : 1792
+      }
+    },
+    "133" : {
+      "Integer" : {
+        "value" : 1536
+      }
+    },
+    "125" : {
+      "Integer" : {
+        "value" : 1024
+      }
+    },
+    "129" : {
+      "Integer" : {
+        "value" : 1280
+      }
+    }
+  }
+}

--- a/compiler/tools/fpp-to-json/test/run
+++ b/compiler/tools/fpp-to-json/test/run
@@ -139,7 +139,7 @@ syntaxOnly(){
 }
 
 patternedConnections(){
-  run_test "Fw/symbols.fpp" patternedConnections
+  run_test "fprime/defs.fpp" patternedConnections
 }
 
 tests="

--- a/compiler/tools/fpp-to-json/test/run
+++ b/compiler/tools/fpp-to-json/test/run
@@ -138,6 +138,10 @@ syntaxOnly(){
   run_test "-s" syntaxOnly 
 }
 
+patternedConnections(){
+  run_test "Fw/symbols.fpp" patternedConnections
+}
+
 tests="
 activeComponents
 commands
@@ -151,6 +155,7 @@ matchedPorts
 modules
 parameters
 passiveComponent
+patternedConnections
 ports
 queuedComponents
 simpleComponents

--- a/compiler/tools/fpp-to-json/test/update-ref
+++ b/compiler/tools/fpp-to-json/test/update-ref
@@ -47,6 +47,7 @@ update "" matchedPorts
 update "" modules
 update "" parameters
 update "" passiveComponent
+update "Fw/symbols.fpp" patternedConnections
 update "" ports
 update "" queuedComponents
 update "" simpleComponents

--- a/compiler/tools/fpp-to-json/test/update-ref
+++ b/compiler/tools/fpp-to-json/test/update-ref
@@ -47,7 +47,7 @@ update "" matchedPorts
 update "" modules
 update "" parameters
 update "" passiveComponent
-update "Fw/symbols.fpp" patternedConnections
+update "fprime/defs.fpp" patternedConnections
 update "" ports
 update "" queuedComponents
 update "" simpleComponents


### PR DESCRIPTION
This PR implements the test case for the patterned connection graphs. This in turn updates the fpp bitmap to solve the issue posed in #467. 

This PR closes #467.