### PR TITLE
Rename enter exprs to transition exprs

### DIFF
--- a/docs/code-prettify/run_prettify.js
+++ b/docs/code-prettify/run_prettify.js
@@ -427,8 +427,8 @@ var IN_GLOBAL_SCOPE = false;
           "do," +
           "drop," +
           "else," +
-          "enter" +
-          "entry" +
+          "enter," +
+          "entry," +
           "enum," +
           "event," +
           "exit," +

--- a/docs/fpp-spec.html
+++ b/docs/fpp-spec.html
@@ -562,67 +562,67 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#State-Machine-Behavior-Elements_Do-Expressions_Examples">6.2.3. Examples</a></li>
 </ul>
 </li>
-<li><a href="#State-Machine-Behavior-Elements_Enter-Expressions">6.3. Enter Expressions</a>
+<li><a href="#State-Machine-Behavior-Elements_Guard-Definitions">6.3. Guard Definitions</a>
 <ul class="sectlevel3">
-<li><a href="#State-Machine-Behavior-Elements_Enter-Expressions_Syntax">6.3.1. Syntax</a></li>
-<li><a href="#State-Machine-Behavior-Elements_Enter-Expressions_Semantics">6.3.2. Semantics</a></li>
-<li><a href="#State-Machine-Behavior-Elements_Enter-Expressions_Examples">6.3.3. Examples</a></li>
+<li><a href="#State-Machine-Behavior-Elements_Guard-Definitions_Syntax">6.3.1. Syntax</a></li>
+<li><a href="#State-Machine-Behavior-Elements_Guard-Definitions_Semantics">6.3.2. Semantics</a></li>
+<li><a href="#State-Machine-Behavior-Elements_Guard-Definitions_Examples">6.3.3. Examples</a></li>
 </ul>
 </li>
-<li><a href="#State-Machine-Behavior-Elements_Guard-Definitions">6.4. Guard Definitions</a>
+<li><a href="#State-Machine-Behavior-Elements_Initial-Transition-Specifiers">6.4. Initial Transition Specifiers</a>
 <ul class="sectlevel3">
-<li><a href="#State-Machine-Behavior-Elements_Guard-Definitions_Syntax">6.4.1. Syntax</a></li>
-<li><a href="#State-Machine-Behavior-Elements_Guard-Definitions_Semantics">6.4.2. Semantics</a></li>
-<li><a href="#State-Machine-Behavior-Elements_Guard-Definitions_Examples">6.4.3. Examples</a></li>
+<li><a href="#State-Machine-Behavior-Elements_Initial-Transition-Specifiers_Syntax">6.4.1. Syntax</a></li>
+<li><a href="#State-Machine-Behavior-Elements_Initial-Transition-Specifiers_Semantics">6.4.2. Semantics</a></li>
+<li><a href="#State-Machine-Behavior-Elements_Initial-Transition-Specifiers_Examples">6.4.3. Examples</a></li>
 </ul>
 </li>
-<li><a href="#State-Machine-Behavior-Elements_Initial-Transition-Specifiers">6.5. Initial Transition Specifiers</a>
+<li><a href="#State-Machine-Behavior-Elements_Junction-Definitions">6.5. Junction Definitions</a>
 <ul class="sectlevel3">
-<li><a href="#State-Machine-Behavior-Elements_Initial-Transition-Specifiers_Syntax">6.5.1. Syntax</a></li>
-<li><a href="#State-Machine-Behavior-Elements_Initial-Transition-Specifiers_Semantics">6.5.2. Semantics</a></li>
-<li><a href="#State-Machine-Behavior-Elements_Initial-Transition-Specifiers_Examples">6.5.3. Examples</a></li>
+<li><a href="#State-Machine-Behavior-Elements_Junction-Definitions_Syntax">6.5.1. Syntax</a></li>
+<li><a href="#State-Machine-Behavior-Elements_Junction-Definitions_Semantics">6.5.2. Semantics</a></li>
+<li><a href="#State-Machine-Behavior-Elements_Junction-Definitions_Examples">6.5.3. Examples</a></li>
 </ul>
 </li>
-<li><a href="#State-Machine-Behavior-Elements_Junction-Definitions">6.6. Junction Definitions</a>
+<li><a href="#State-Machine-Behavior-Elements_Signal-Definitions">6.6. Signal Definitions</a>
 <ul class="sectlevel3">
-<li><a href="#State-Machine-Behavior-Elements_Junction-Definitions_Syntax">6.6.1. Syntax</a></li>
-<li><a href="#State-Machine-Behavior-Elements_Junction-Definitions_Semantics">6.6.2. Semantics</a></li>
-<li><a href="#State-Machine-Behavior-Elements_Junction-Definitions_Examples">6.6.3. Examples</a></li>
+<li><a href="#State-Machine-Behavior-Elements_Signal-Definitions_Syntax">6.6.1. Syntax</a></li>
+<li><a href="#State-Machine-Behavior-Elements_Signal-Definitions_Semantics">6.6.2. Semantics</a></li>
+<li><a href="#State-Machine-Behavior-Elements_Signal-Definitions_Examples">6.6.3. Examples</a></li>
 </ul>
 </li>
-<li><a href="#State-Machine-Behavior-Elements_Signal-Definitions">6.7. Signal Definitions</a>
+<li><a href="#State-Machine-Behavior-Elements_State-Definitions">6.7. State Definitions</a>
 <ul class="sectlevel3">
-<li><a href="#State-Machine-Behavior-Elements_Signal-Definitions_Syntax">6.7.1. Syntax</a></li>
-<li><a href="#State-Machine-Behavior-Elements_Signal-Definitions_Semantics">6.7.2. Semantics</a></li>
-<li><a href="#State-Machine-Behavior-Elements_Signal-Definitions_Examples">6.7.3. Examples</a></li>
+<li><a href="#State-Machine-Behavior-Elements_State-Definitions_Syntax">6.7.1. Syntax</a></li>
+<li><a href="#State-Machine-Behavior-Elements_State-Definitions_Semantics">6.7.2. Semantics</a></li>
+<li><a href="#State-Machine-Behavior-Elements_State-Definitions_Examples">6.7.3. Examples</a></li>
 </ul>
 </li>
-<li><a href="#State-Machine-Behavior-Elements_State-Definitions">6.8. State Definitions</a>
+<li><a href="#State-Machine-Behavior-Elements_State-Entry-Specifiers">6.8. State Entry Specifiers</a>
 <ul class="sectlevel3">
-<li><a href="#State-Machine-Behavior-Elements_State-Definitions_Syntax">6.8.1. Syntax</a></li>
-<li><a href="#State-Machine-Behavior-Elements_State-Definitions_Semantics">6.8.2. Semantics</a></li>
-<li><a href="#State-Machine-Behavior-Elements_State-Definitions_Examples">6.8.3. Examples</a></li>
+<li><a href="#State-Machine-Behavior-Elements_State-Entry-Specifiers_Syntax">6.8.1. Syntax</a></li>
+<li><a href="#State-Machine-Behavior-Elements_State-Entry-Specifiers_Semantics">6.8.2. Semantics</a></li>
+<li><a href="#State-Machine-Behavior-Elements_State-Entry-Specifiers_Examples">6.8.3. Examples</a></li>
 </ul>
 </li>
-<li><a href="#State-Machine-Behavior-Elements_State-Entry-Specifiers">6.9. State Entry Specifiers</a>
+<li><a href="#State-Machine-Behavior-Elements_State-Exit-Specifiers">6.9. State Exit Specifiers</a>
 <ul class="sectlevel3">
-<li><a href="#State-Machine-Behavior-Elements_State-Entry-Specifiers_Syntax">6.9.1. Syntax</a></li>
-<li><a href="#State-Machine-Behavior-Elements_State-Entry-Specifiers_Semantics">6.9.2. Semantics</a></li>
-<li><a href="#State-Machine-Behavior-Elements_State-Entry-Specifiers_Examples">6.9.3. Examples</a></li>
+<li><a href="#State-Machine-Behavior-Elements_State-Exit-Specifiers_Syntax">6.9.1. Syntax</a></li>
+<li><a href="#State-Machine-Behavior-Elements_State-Exit-Specifiers_Semantics">6.9.2. Semantics</a></li>
+<li><a href="#State-Machine-Behavior-Elements_State-Exit-Specifiers_Examples">6.9.3. Examples</a></li>
 </ul>
 </li>
-<li><a href="#State-Machine-Behavior-Elements_State-Exit-Specifiers">6.10. State Exit Specifiers</a>
+<li><a href="#State-Machine-Behavior-Elements_State-Transition-Specifiers">6.10. State Transition Specifiers</a>
 <ul class="sectlevel3">
-<li><a href="#State-Machine-Behavior-Elements_State-Exit-Specifiers_Syntax">6.10.1. Syntax</a></li>
-<li><a href="#State-Machine-Behavior-Elements_State-Exit-Specifiers_Semantics">6.10.2. Semantics</a></li>
-<li><a href="#State-Machine-Behavior-Elements_State-Exit-Specifiers_Examples">6.10.3. Examples</a></li>
+<li><a href="#State-Machine-Behavior-Elements_State-Transition-Specifiers_Syntax">6.10.1. Syntax</a></li>
+<li><a href="#State-Machine-Behavior-Elements_State-Transition-Specifiers_Semantics">6.10.2. Semantics</a></li>
+<li><a href="#State-Machine-Behavior-Elements_State-Transition-Specifiers_Examples">6.10.3. Examples</a></li>
 </ul>
 </li>
-<li><a href="#State-Machine-Behavior-Elements_State-Transition-Specifiers">6.11. State Transition Specifiers</a>
+<li><a href="#State-Machine-Behavior-Elements_Transition-Expressions">6.11. Transition Expressions</a>
 <ul class="sectlevel3">
-<li><a href="#State-Machine-Behavior-Elements_State-Transition-Specifiers_Syntax">6.11.1. Syntax</a></li>
-<li><a href="#State-Machine-Behavior-Elements_State-Transition-Specifiers_Semantics">6.11.2. Semantics</a></li>
-<li><a href="#State-Machine-Behavior-Elements_State-Transition-Specifiers_Examples">6.11.3. Examples</a></li>
+<li><a href="#State-Machine-Behavior-Elements_Transition-Expressions_Syntax">6.11.1. Syntax</a></li>
+<li><a href="#State-Machine-Behavior-Elements_Transition-Expressions_Semantics">6.11.2. Semantics</a></li>
+<li><a href="#State-Machine-Behavior-Elements_Transition-Expressions_Examples">6.11.3. Examples</a></li>
 </ul>
 </li>
 </ul>
@@ -2881,8 +2881,8 @@ state definitions, and
 junction definitions that are transitive members of <em>M</em>.</p>
 </li>
 <li>
-<p>The arcs of the transition graph are given by the <a href="#State-Machine-Behavior-Elements_Enter-Expressions">enter expressions</a> <em>e</em> that are parts of transitive members of <em>M</em>.
-Each enter expression represents an arc from an <strong>initial node</strong> to a <strong>terminal node</strong>.
+<p>The arcs of the transition graph are given by the <a href="#State-Machine-Behavior-Elements_Transition-Expressions">transition expressions</a> <em>e</em> that are parts of transitive members of <em>M</em>.
+Each transition expression represents an arc from an <strong>initial node</strong> to a <strong>terminal node</strong>.
 The initial node is defined as follows:</p>
 <div class="olist loweralpha">
 <ol class="loweralpha" type="a">
@@ -2970,15 +2970,15 @@ A typed element <em>e</em> <strong>points to</strong> a junction <em>J</em> if</
 <div class="olist arabic">
 <ol class="arabic">
 <li>
-<p><em>e</em> is an initial transition specifier, and its enter expression
+<p><em>e</em> is an initial transition specifier, and its transition expression
 refers to <em>J</em>; or</p>
 </li>
 <li>
-<p><em>e</em> is a state transition specifier with an enter expression that refers to
+<p><em>e</em> is a state transition specifier with a transition expression that refers to
 <em>J</em>; or</p>
 </li>
 <li>
-<p><em>e</em> is a junction, and at least one of its enter expressions
+<p><em>e</em> is a junction, and at least one of its transition expressions
 refers to <em>J</em>.</p>
 </li>
 </ol>
@@ -3946,69 +3946,7 @@ to an
 </div>
 </div>
 <div class="sect2">
-<h3 id="State-Machine-Behavior-Elements_Enter-Expressions">6.3. Enter Expressions</h3>
-<div class="paragraph">
-<p>An <strong>enter expression</strong> specifies a transition as part of an
-<a href="#State-Machine-Behavior-Elements_Initial-Transition-Specifiers">initial transition</a>,
-a <a href="#State-Machine-Behavior-Elements_State-Transition-Specifiers">state transition</a>,
-or
-a <a href="#State-Machine-Behavior-Elements_Junction-Definitions">junction</a>.
-The transition enters a state or junction and optionally performs
-some action.</p>
-</div>
-<div class="sect3">
-<h4 id="State-Machine-Behavior-Elements_Enter-Expressions_Syntax">6.3.1. Syntax</h4>
-<div class="paragraph">
-<p><em>[</em>
-<a href="#State-Machine-Behavior-Elements_Do-Expressions"><em>do-expression</em></a>
-<em>]</em>
-<code>enter</code> <a href="#Scoping-of-Names_Qualified-Identifiers"><em>qual-ident</em></a></p>
-</div>
-</div>
-<div class="sect3">
-<h4 id="State-Machine-Behavior-Elements_Enter-Expressions_Semantics">6.3.2. Semantics</h4>
-<div class="olist arabic">
-<ol class="arabic">
-<li>
-<p>If present, the do-expression specifies the list of actions to be
-performed when making the transition.</p>
-</li>
-<li>
-<p>The qualified identifier after the keyword <code>enter</code> must
-<a href="#Definitions_State-Machine-Definitions_Semantics_Scoping-of-Names">refer</a>
-to a
-<a href="#State-Machine-Behavior-Elements_State-Definitions">state definition</a>
-or a
-<a href="#State-Machine-Behavior-Elements_Junction-Definitions">junction definition</a>
-It is the state or junction that is entered.</p>
-</li>
-</ol>
-</div>
-</div>
-<div class="sect3">
-<h4 id="State-Machine-Behavior-Elements_Enter-Expressions_Examples">6.3.3. Examples</h4>
-<div class="listingblock">
-<div class="content">
-<pre class="prettyprint highlight"><code data-lang="fpp">state machine Device {
-
-  action initDev1
-  action initDev2
-
-  initial do {
-    initDev1
-    initDev2
-  } \
-  enter OFF
-
-  state OFF
-
-}</code></pre>
-</div>
-</div>
-</div>
-</div>
-<div class="sect2">
-<h3 id="State-Machine-Behavior-Elements_Guard-Definitions">6.4. Guard Definitions</h3>
+<h3 id="State-Machine-Behavior-Elements_Guard-Definitions">6.3. Guard Definitions</h3>
 <div class="paragraph">
 <p>A <strong>guard definition</strong> is part of a
 <a href="#Definitions_State-Machine-Definitions">state machine definition</a>.
@@ -4021,7 +3959,7 @@ If the guard evaluates to <code>true</code>, then the state transition occurs
 or the branch of the junction is taken.</p>
 </div>
 <div class="sect3">
-<h4 id="State-Machine-Behavior-Elements_Guard-Definitions_Syntax">6.4.1. Syntax</h4>
+<h4 id="State-Machine-Behavior-Elements_Guard-Definitions_Syntax">6.3.1. Syntax</h4>
 <div class="paragraph">
 <p><code>guard</code>
 <a href="#Lexical-Elements_Identifiers"><em>identifier</em></a>
@@ -4032,7 +3970,7 @@ or the branch of the junction is taken.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="State-Machine-Behavior-Elements_Guard-Definitions_Semantics">6.4.2. Semantics</h4>
+<h4 id="State-Machine-Behavior-Elements_Guard-Definitions_Semantics">6.3.2. Semantics</h4>
 <div class="olist arabic">
 <ol class="arabic">
 <li>
@@ -4049,7 +3987,7 @@ guard.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="State-Machine-Behavior-Elements_Guard-Definitions_Examples">6.4.3. Examples</h4>
+<h4 id="State-Machine-Behavior-Elements_Guard-Definitions_Examples">6.3.3. Examples</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="fpp">enum EnabledStatus { ENABLED, DISABLED }
@@ -4077,7 +4015,7 @@ state machine GuardDefs {
 </div>
 </div>
 <div class="sect2">
-<h3 id="State-Machine-Behavior-Elements_Initial-Transition-Specifiers">6.5. Initial Transition Specifiers</h3>
+<h3 id="State-Machine-Behavior-Elements_Initial-Transition-Specifiers">6.4. Initial Transition Specifiers</h3>
 <div class="paragraph">
 <p>An <strong>initial transition specifier</strong> is part of a
 <a href="#Definitions_State-Machine-Definitions">state machine definition</a>
@@ -4088,23 +4026,23 @@ when starting up a state machine or entering a state with
 substates.</p>
 </div>
 <div class="sect3">
-<h4 id="State-Machine-Behavior-Elements_Initial-Transition-Specifiers_Syntax">6.5.1. Syntax</h4>
+<h4 id="State-Machine-Behavior-Elements_Initial-Transition-Specifiers_Syntax">6.4.1. Syntax</h4>
 <div class="paragraph">
 <p><code>initial</code>
-<a href="#State-Machine-Behavior-Elements_Enter-Expressions"><em>enter-expression</em></a></p>
+<a href="#State-Machine-Behavior-Elements_Transition-Expressions"><em>transition-expression</em></a></p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="State-Machine-Behavior-Elements_Initial-Transition-Specifiers_Semantics">6.5.2. Semantics</h4>
+<h4 id="State-Machine-Behavior-Elements_Initial-Transition-Specifiers_Semantics">6.4.2. Semantics</h4>
 <div class="paragraph">
 <p>The state definition or junction definition referred to in the
-enter expression must be a member of the same
+transition expression must be a member of the same
 state machine definition or state definition in which the initial
 transition specifier appears.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="State-Machine-Behavior-Elements_Initial-Transition-Specifiers_Examples">6.5.3. Examples</h4>
+<h4 id="State-Machine-Behavior-Elements_Initial-Transition-Specifiers_Examples">6.4.3. Examples</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="fpp">state machine Device {
@@ -4134,7 +4072,7 @@ transition specifier appears.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="State-Machine-Behavior-Elements_Junction-Definitions">6.6. Junction Definitions</h3>
+<h3 id="State-Machine-Behavior-Elements_Junction-Definitions">6.5. Junction Definitions</h3>
 <div class="paragraph">
 <p>A <strong>junction definition</strong> specifies a junction as part of a
 <a href="#Definitions_State-Machine-Definitions">state machine definition</a>
@@ -4144,17 +4082,17 @@ A junction is a branch point controlled by a
 <a href="#State-Machine-Behavior-Elements_Guard-Definitions">guard</a>.</p>
 </div>
 <div class="sect3">
-<h4 id="State-Machine-Behavior-Elements_Junction-Definitions_Syntax">6.6.1. Syntax</h4>
+<h4 id="State-Machine-Behavior-Elements_Junction-Definitions_Syntax">6.5.1. Syntax</h4>
 <div class="paragraph">
 <p><code>junction</code> <a href="#Lexical-Elements_Identifiers"><em>identifier</em></a>
 <code>{</code>
-<code>if</code> <a href="#Lexical-Elements_Identifiers"><em>identifier</em></a> <a href="#State-Machine-Behavior-Elements_Enter-Expressions"><em>enter-expression</em></a>
-<code>else</code> <a href="#State-Machine-Behavior-Elements_Enter-Expressions"><em>enter-expression</em></a>
+<code>if</code> <a href="#Lexical-Elements_Identifiers"><em>identifier</em></a> <a href="#State-Machine-Behavior-Elements_Transition-Expressions"><em>transition-expression</em></a>
+<code>else</code> <a href="#State-Machine-Behavior-Elements_Transition-Expressions"><em>transition-expression</em></a>
 <code>}</code></p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="State-Machine-Behavior-Elements_Junction-Definitions_Semantics">6.6.2. Semantics</h4>
+<h4 id="State-Machine-Behavior-Elements_Junction-Definitions_Semantics">6.5.2. Semantics</h4>
 <div class="olist arabic">
 <ol class="arabic">
 <li>
@@ -4168,15 +4106,15 @@ to a
 It specifies the guard that controls the branch.</p>
 </li>
 <li>
-<p>Each of the enter expressions must be valid.
-The first enter expression is run if the guard evaluates to <code>true</code>;
-otherwise the second enter expression is run.</p>
+<p>Each of the transition expressions must be valid.
+The first transition expression is run if the guard evaluates to <code>true</code>;
+otherwise the second transition expression is run.</p>
 </li>
 </ol>
 </div>
 </div>
 <div class="sect3">
-<h4 id="State-Machine-Behavior-Elements_Junction-Definitions_Examples">6.6.3. Examples</h4>
+<h4 id="State-Machine-Behavior-Elements_Junction-Definitions_Examples">6.5.3. Examples</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="fpp">state machine Device {
@@ -4201,7 +4139,7 @@ otherwise the second enter expression is run.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="State-Machine-Behavior-Elements_Signal-Definitions">6.7. Signal Definitions</h3>
+<h3 id="State-Machine-Behavior-Elements_Signal-Definitions">6.6. Signal Definitions</h3>
 <div class="paragraph">
 <p>A <strong>signal definition</strong> is part of a
 <a href="#Definitions_State-Machine-Definitions">state machine definition</a>.
@@ -4224,7 +4162,7 @@ entering a state, and after it has run the entry function
 for that state.</p>
 </div>
 <div class="sect3">
-<h4 id="State-Machine-Behavior-Elements_Signal-Definitions_Syntax">6.7.1. Syntax</h4>
+<h4 id="State-Machine-Behavior-Elements_Signal-Definitions_Syntax">6.6.1. Syntax</h4>
 <div class="paragraph">
 <p><code>signal</code>
 <a href="#Lexical-Elements_Identifiers"><em>identifier</em></a>
@@ -4235,7 +4173,7 @@ for that state.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="State-Machine-Behavior-Elements_Signal-Definitions_Semantics">6.7.2. Semantics</h4>
+<h4 id="State-Machine-Behavior-Elements_Signal-Definitions_Semantics">6.6.2. Semantics</h4>
 <div class="olist arabic">
 <ol class="arabic">
 <li>
@@ -4250,7 +4188,7 @@ If <em>type-name</em> is not present, then the signal carries no data.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="State-Machine-Behavior-Elements_Signal-Definitions_Examples">6.7.3. Examples</h4>
+<h4 id="State-Machine-Behavior-Elements_Signal-Definitions_Examples">6.6.3. Examples</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="fpp">struct FaultData {
@@ -4275,7 +4213,7 @@ state machine SignalDefs {
 </div>
 </div>
 <div class="sect2">
-<h3 id="State-Machine-Behavior-Elements_State-Definitions">6.8. State Definitions</h3>
+<h3 id="State-Machine-Behavior-Elements_State-Definitions">6.7. State Definitions</h3>
 <div class="paragraph">
 <p>A <strong>state definition</strong> is part of a
 <a href="#Definitions_State-Machine-Definitions">state machine definition</a>
@@ -4286,7 +4224,7 @@ A state <em>S'</em> defined inside a state <em>S</em> expresses a hierarchy
 of states: <em>S'</em> is a substate of <em>S</em>.</p>
 </div>
 <div class="sect3">
-<h4 id="State-Machine-Behavior-Elements_State-Definitions_Syntax">6.8.1. Syntax</h4>
+<h4 id="State-Machine-Behavior-Elements_State-Definitions_Syntax">6.7.1. Syntax</h4>
 <div class="paragraph">
 <p><code>state</code> <a href="#Lexical-Elements_Identifiers"><em>identifier</em></a>
 <em>[</em> <code>{</code> <em>state-definition-member-sequence</em> <code>}</code> <em>]</em></p>
@@ -4322,7 +4260,7 @@ A state definition member is one of the following:</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="State-Machine-Behavior-Elements_State-Definitions_Semantics">6.8.2. Semantics</h4>
+<h4 id="State-Machine-Behavior-Elements_State-Definitions_Semantics">6.7.2. Semantics</h4>
 <div class="olist arabic">
 <ol class="arabic">
 <li>
@@ -4361,7 +4299,7 @@ Otherwise it is called a <strong>leaf state definition</strong>.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="State-Machine-Behavior-Elements_State-Definitions_Examples">6.8.3. Examples</h4>
+<h4 id="State-Machine-Behavior-Elements_State-Definitions_Examples">6.7.3. Examples</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="fpp">state machine MonitorSm {
@@ -4432,26 +4370,26 @@ Otherwise it is called a <strong>leaf state definition</strong>.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="State-Machine-Behavior-Elements_State-Entry-Specifiers">6.9. State Entry Specifiers</h3>
+<h3 id="State-Machine-Behavior-Elements_State-Entry-Specifiers">6.8. State Entry Specifiers</h3>
 <div class="paragraph">
 <p>A <strong>state entry specifier</strong> is part of a
 <a href="#State-Machine-Behavior-Elements_State-Definitions">state definition</a>.
 It specifies the actions to take when entering the state.</p>
 </div>
 <div class="sect3">
-<h4 id="State-Machine-Behavior-Elements_State-Entry-Specifiers_Syntax">6.9.1. Syntax</h4>
+<h4 id="State-Machine-Behavior-Elements_State-Entry-Specifiers_Syntax">6.8.1. Syntax</h4>
 <div class="paragraph">
 <p><code>entry</code> <a href="#State-Machine-Behavior-Elements_Do-Expressions"><em>do-expression</em></a></p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="State-Machine-Behavior-Elements_State-Entry-Specifiers_Semantics">6.9.2. Semantics</h4>
+<h4 id="State-Machine-Behavior-Elements_State-Entry-Specifiers_Semantics">6.8.2. Semantics</h4>
 <div class="paragraph">
 <p>The do expression must be valid.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="State-Machine-Behavior-Elements_State-Entry-Specifiers_Examples">6.9.3. Examples</h4>
+<h4 id="State-Machine-Behavior-Elements_State-Entry-Specifiers_Examples">6.8.3. Examples</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="fpp">state machine Device {
@@ -4473,26 +4411,26 @@ It specifies the actions to take when entering the state.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="State-Machine-Behavior-Elements_State-Exit-Specifiers">6.10. State Exit Specifiers</h3>
+<h3 id="State-Machine-Behavior-Elements_State-Exit-Specifiers">6.9. State Exit Specifiers</h3>
 <div class="paragraph">
 <p>A <strong>state exit specifier</strong> is part of a
 <a href="#State-Machine-Behavior-Elements_State-Definitions">state definition</a>.
 It specifies the actions to take when exiting the state.</p>
 </div>
 <div class="sect3">
-<h4 id="State-Machine-Behavior-Elements_State-Exit-Specifiers_Syntax">6.10.1. Syntax</h4>
+<h4 id="State-Machine-Behavior-Elements_State-Exit-Specifiers_Syntax">6.9.1. Syntax</h4>
 <div class="paragraph">
 <p><code>exit</code> <a href="#State-Machine-Behavior-Elements_Do-Expressions"><em>do-expression</em></a></p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="State-Machine-Behavior-Elements_State-Exit-Specifiers_Semantics">6.10.2. Semantics</h4>
+<h4 id="State-Machine-Behavior-Elements_State-Exit-Specifiers_Semantics">6.9.2. Semantics</h4>
 <div class="paragraph">
 <p>The do expression must be valid.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="State-Machine-Behavior-Elements_State-Exit-Specifiers_Examples">6.10.3. Examples</h4>
+<h4 id="State-Machine-Behavior-Elements_State-Exit-Specifiers_Examples">6.9.3. Examples</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="fpp">state machine Device {
@@ -4514,28 +4452,28 @@ It specifies the actions to take when exiting the state.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="State-Machine-Behavior-Elements_State-Transition-Specifiers">6.11. State Transition Specifiers</h3>
+<h3 id="State-Machine-Behavior-Elements_State-Transition-Specifiers">6.10. State Transition Specifiers</h3>
 <div class="paragraph">
 <p>A <strong>state transition specifier</strong> is part of a
 <a href="#State-Machine-Behavior-Elements_State-Definitions">state definition</a>.
 It specifies a transition from the state in which it appears.</p>
 </div>
 <div class="sect3">
-<h4 id="State-Machine-Behavior-Elements_State-Transition-Specifiers_Syntax">6.11.1. Syntax</h4>
+<h4 id="State-Machine-Behavior-Elements_State-Transition-Specifiers_Syntax">6.10.1. Syntax</h4>
 <div class="paragraph">
 <p><code>on</code> <a href="#Lexical-Elements_Identifiers"><em>identifier</em></a>
 <em>[</em>
 <code>if</code> <a href="#Lexical-Elements_Identifiers"><em>identifier</em></a>
 <em>]</em>
-<em>enter-or-do</em></p>
+<em>transition-or-do</em></p>
 </div>
 <div class="paragraph">
-<p><em>enter-or-do</em> is one of the following:</p>
+<p><em>transition-or-do</em> is one of the following:</p>
 </div>
 <div class="olist arabic">
 <ol class="arabic">
 <li>
-<p><a href="#State-Machine-Behavior-Elements_Enter-Expressions"><em>enter-expression</em></a></p>
+<p><a href="#State-Machine-Behavior-Elements_Transition-Expressions"><em>transition-expression</em></a></p>
 </li>
 <li>
 <p><a href="#State-Machine-Behavior-Elements_Do-Expressions"><em>do-expression</em></a></p>
@@ -4544,7 +4482,7 @@ It specifies a transition from the state in which it appears.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="State-Machine-Behavior-Elements_State-Transition-Specifiers_Semantics">6.11.2. Semantics</h4>
+<h4 id="State-Machine-Behavior-Elements_State-Transition-Specifiers_Semantics">6.10.2. Semantics</h4>
 <div class="olist arabic">
 <ol class="arabic">
 <li>
@@ -4562,16 +4500,15 @@ to a
 It specifies a guard for the transition.</p>
 </li>
 <li>
-<p>The first form of the <em>enter-or-do</em> syntax specifies an optional
+<p>The first form of the <em>transition-or-do</em> syntax specifies an optional
 list of actions and a target state.
-The do expression, if it appears, and the enter expression must be valid.
-The target state in the enter expression may be the same as the
+The target state in the transition expression may be the same as the
 enclosing state; in this case the transition is called a <strong>self transition</strong>.
 When making a self transition, the state machine runs the code associated with
 exiting and then re-entering the state.</p>
 </li>
 <li>
-<p>Second form of the <em>enter-or-do</em> syntax specifies an
+<p>Second form of the <em>transition-or-do</em> syntax specifies an
 <strong>internal transition</strong>, i.e., a list of actions to take while remaining
 in the same state.
 When making an internal transition, the exit and re-entry code is not run.
@@ -4581,7 +4518,7 @@ The do expression must be valid.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="State-Machine-Behavior-Elements_State-Transition-Specifiers_Examples">6.11.3. Examples</h4>
+<h4 id="State-Machine-Behavior-Elements_State-Transition-Specifiers_Examples">6.10.3. Examples</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="fpp">state machine Device {
@@ -4608,6 +4545,69 @@ The do expression must be valid.</p>
   state ON {
     on RTI do performStuff
   }
+
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="State-Machine-Behavior-Elements_Transition-Expressions">6.11. Transition Expressions</h3>
+<div class="paragraph">
+<p>An <strong>transition expression</strong> specifies a transition as part of an
+<a href="#State-Machine-Behavior-Elements_Initial-Transition-Specifiers">initial transition</a>,
+a <a href="#State-Machine-Behavior-Elements_State-Transition-Specifiers">state transition</a>,
+or
+a <a href="#State-Machine-Behavior-Elements_Junction-Definitions">junction</a>.
+The transition performs zero or more actions and then
+enters a state or junction.</p>
+</div>
+<div class="sect3">
+<h4 id="State-Machine-Behavior-Elements_Transition-Expressions_Syntax">6.11.1. Syntax</h4>
+<div class="paragraph">
+<p><em>[</em>
+<a href="#State-Machine-Behavior-Elements_Do-Expressions"><em>do-expression</em></a>
+<em>]</em>
+<code>enter</code> <a href="#Scoping-of-Names_Qualified-Identifiers"><em>qual-ident</em></a></p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="State-Machine-Behavior-Elements_Transition-Expressions_Semantics">6.11.2. Semantics</h4>
+<div class="olist arabic">
+<ol class="arabic">
+<li>
+<p>The do expression specifies the list of actions to be
+performed when making the transition.
+If there are no actions, the do expression may be omitted.</p>
+</li>
+<li>
+<p>The qualified identifier after the keyword <code>enter</code> must
+<a href="#Definitions_State-Machine-Definitions_Semantics_Scoping-of-Names">refer</a>
+to a
+<a href="#State-Machine-Behavior-Elements_State-Definitions">state definition</a>
+or a
+<a href="#State-Machine-Behavior-Elements_Junction-Definitions">junction definition</a>
+It is the state or junction that is entered in the transition.</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="State-Machine-Behavior-Elements_Transition-Expressions_Examples">6.11.3. Examples</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="prettyprint highlight"><code data-lang="fpp">state machine Device {
+
+  action initDev1
+  action initDev2
+
+  initial do {
+    initDev1
+    initDev2
+  } \
+  enter OFF
+
+  state OFF
 
 }</code></pre>
 </div>
@@ -10103,7 +10103,7 @@ equivalent.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2024-07-31 12:01:57 -0700
+Last updated 2024-07-31 14:50:07 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-spec.html
+++ b/docs/fpp-spec.html
@@ -4543,7 +4543,7 @@ The do expression must be valid.</p>
   }
 
   state ON {
-    on RTI do performStuff
+    on RTI do { performStuff }
   }
 
 }</code></pre>
@@ -10103,7 +10103,7 @@ equivalent.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2024-07-31 14:50:07 -0700
+Last updated 2024-07-31 15:56:10 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-users-guide.html
+++ b/docs/fpp-users-guide.html
@@ -12293,7 +12293,7 @@ function, you may.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2024-07-31 11:23:51 -0700
+Last updated 2024-07-31 14:45:45 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -463,7 +463,7 @@ generated code.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2024-07-16 14:57:58 -0700
+Last updated 2024-07-20 12:45:03 -0700
 </div>
 </div>
 </body>

--- a/docs/spec/Definitions/State-Machine-Definitions.adoc
+++ b/docs/spec/Definitions/State-Machine-Definitions.adoc
@@ -71,9 +71,9 @@ follows:
 state definitions, and
 junction definitions that are transitive members of _M_.
 
-. The arcs of the transition graph are given by the <<State-Machine-Behavior-Elements_Enter-Expressions,
-enter expressions>> _e_ that are parts of transitive members of _M_.
-Each enter expression represents an arc from an *initial node* to a *terminal node*.
+. The arcs of the transition graph are given by the <<State-Machine-Behavior-Elements_Transition-Expressions,
+transition expressions>> _e_ that are parts of transitive members of _M_.
+Each transition expression represents an arc from an *initial node* to a *terminal node*.
 The initial node is defined as follows:
 
 .. If _e_ appears in an
@@ -132,13 +132,13 @@ or a
 <<State-Machine-Behavior-Elements_Junction-Definitions,junction definition>>.
 A typed element _e_ *points to* a junction _J_ if
 
-. _e_ is an initial transition specifier, and its enter expression
+. _e_ is an initial transition specifier, and its transition expression
 refers to _J_; or
 
-. _e_ is a state transition specifier with an enter expression that refers to
+. _e_ is a state transition specifier with a transition expression that refers to
 _J_; or
 
-. _e_ is a junction, and at least one of its enter expressions
+. _e_ is a junction, and at least one of its transition expressions
 refers to _J_.
 
 It must be possible to assign <<Type-Options,type options>>

--- a/docs/spec/State-Machine-Behavior-Elements/Initial-Transition-Specifiers.adoc
+++ b/docs/spec/State-Machine-Behavior-Elements/Initial-Transition-Specifiers.adoc
@@ -11,12 +11,12 @@ substates.
 ==== Syntax
 
 `initial` 
-<<State-Machine-Behavior-Elements_Enter-Expressions,_enter-expression_>>
+<<State-Machine-Behavior-Elements_Transition-Expressions,_transition-expression_>>
 
 ==== Semantics
 
 The state definition or junction definition referred to in the
-enter expression must be a member of the same 
+transition expression must be a member of the same 
 state machine definition or state definition in which the initial
 transition specifier appears.
 

--- a/docs/spec/State-Machine-Behavior-Elements/Junction-Definitions.adoc
+++ b/docs/spec/State-Machine-Behavior-Elements/Junction-Definitions.adoc
@@ -11,8 +11,8 @@ A junction is a branch point controlled by a
 
 `junction` <<Lexical-Elements_Identifiers,_identifier_>>
 `{`
-`if` <<Lexical-Elements_Identifiers,_identifier_>> <<State-Machine-Behavior-Elements_Enter-Expressions,_enter-expression_>>
-`else` <<State-Machine-Behavior-Elements_Enter-Expressions,_enter-expression_>>
+`if` <<Lexical-Elements_Identifiers,_identifier_>> <<State-Machine-Behavior-Elements_Transition-Expressions,_transition-expression_>>
+`else` <<State-Machine-Behavior-Elements_Transition-Expressions,_transition-expression_>>
 `}`
 
 ==== Semantics
@@ -25,9 +25,9 @@ to a
 <<State-Machine-Behavior-Elements_Guard-Definitions,guard definition>>.
 It specifies the guard that controls the branch.
 
-. Each of the enter expressions must be valid.
-The first enter expression is run if the guard evaluates to `true`;
-otherwise the second enter expression is run.
+. Each of the transition expressions must be valid.
+The first transition expression is run if the guard evaluates to `true`;
+otherwise the second transition expression is run.
 
 ==== Examples
 

--- a/docs/spec/State-Machine-Behavior-Elements/State-Transition-Specifiers.adoc
+++ b/docs/spec/State-Machine-Behavior-Elements/State-Transition-Specifiers.adoc
@@ -10,11 +10,11 @@ It specifies a transition from the state in which it appears.
 _[_
 `if` <<Lexical-Elements_Identifiers,_identifier_>>
 _]_
-_enter-or-do_
+_transition-or-do_
 
-_enter-or-do_ is one of the following:
+_transition-or-do_ is one of the following:
 
-.  <<State-Machine-Behavior-Elements_Enter-Expressions,_enter-expression_>>
+.  <<State-Machine-Behavior-Elements_Transition-Expressions,_transition-expression_>>
 
 .  <<State-Machine-Behavior-Elements_Do-Expressions,_do-expression_>>
 
@@ -32,15 +32,14 @@ to a
 <<State-Machine-Behavior-Elements_Guard-Definitions,guard definition>>.
 It specifies a guard for the transition.
 
-. The first form of the _enter-or-do_ syntax specifies an optional
+. The first form of the _transition-or-do_ syntax specifies an optional
 list of actions and a target state.
-The do expression, if it appears, and the enter expression must be valid.
-The target state in the enter expression may be the same as the
+The target state in the transition expression may be the same as the
 enclosing state; in this case the transition is called a *self transition*.
 When making a self transition, the state machine runs the code associated with
 exiting and then re-entering the state.
 
-. Second form of the _enter-or-do_ syntax specifies an
+. Second form of the _transition-or-do_ syntax specifies an
 *internal transition*, i.e., a list of actions to take while remaining
 in the same state.
 When making an internal transition, the exit and re-entry code is not run.

--- a/docs/spec/State-Machine-Behavior-Elements/State-Transition-Specifiers.adoc
+++ b/docs/spec/State-Machine-Behavior-Elements/State-Transition-Specifiers.adoc
@@ -71,7 +71,7 @@ state machine Device {
   }
 
   state ON {
-    on RTI do performStuff
+    on RTI do { performStuff }
   }
 
 }

--- a/docs/spec/State-Machine-Behavior-Elements/Transition-Expressions.adoc
+++ b/docs/spec/State-Machine-Behavior-Elements/Transition-Expressions.adoc
@@ -1,12 +1,12 @@
-=== Enter Expressions
+=== Transition Expressions
 
-An *enter expression* specifies a transition as part of an
+An *transition expression* specifies a transition as part of an
 <<State-Machine-Behavior-Elements_Initial-Transition-Specifiers,initial transition>>,
 a <<State-Machine-Behavior-Elements_State-Transition-Specifiers,state transition>>,
 or
 a <<State-Machine-Behavior-Elements_Junction-Definitions,junction>>.
-The transition enters a state or junction and optionally performs
-some action.
+The transition performs zero or more actions and then
+enters a state or junction.
 
 ==== Syntax
 
@@ -18,8 +18,9 @@ _]_
 
 ==== Semantics
 
-. If present, the do-expression specifies the list of actions to be
+. The do expression specifies the list of actions to be
 performed when making the transition.
+If there are no actions, the do expression may be omitted.
 
 . The qualified identifier after the keyword `enter` must
 <<Definitions_State-Machine-Definitions_Semantics_Scoping-of-Names,refer>>
@@ -27,7 +28,7 @@ to a
 <<State-Machine-Behavior-Elements_State-Definitions,state definition>>
 or a
 <<State-Machine-Behavior-Elements_Junction-Definitions,junction definition>>
-It is the state or junction that is entered.
+It is the state or junction that is entered in the transition.
 
 ==== Examples
 

--- a/docs/spec/State-Machine-Behavior-Elements/defs.sh
+++ b/docs/spec/State-Machine-Behavior-Elements/defs.sh
@@ -10,7 +10,6 @@ export FILES="
 Introduction.adoc
 Action-Definitions.adoc
 Do-Expressions.adoc
-Enter-Expressions.adoc
 Guard-Definitions.adoc
 Initial-Transition-Specifiers.adoc
 Junction-Definitions.adoc
@@ -19,4 +18,5 @@ State-Definitions.adoc
 State-Entry-Specifiers.adoc
 State-Exit-Specifiers.adoc
 State-Transition-Specifiers.adoc
+Transition-Expressions.adoc
 "


### PR DESCRIPTION
Calling _[_ _do-expr_ _]_ `enter` _qual-ident_ an "enter expression" seems confusing, since it's not just an enter; it's also an optional do. I propose to rename this construct a "transition expression." This renaming works better in the spec and in the algorithm descriptions. E.g., the flattening algorithm maps flattened transitions to these constructs.

This change affects the parser and AST, but it's a simple renaming change.