### PR TITLE
Fixing data product pre message hooks

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentPorts.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentPorts.scala
@@ -54,7 +54,7 @@ case class ComponentPorts(
       inputPortWriter.getHandlerBases(typedInputPorts),
       inputPortWriter.getHandlers(serialInputPorts),
       inputPortWriter.getHandlerBases(serialInputPorts),
-      inputPortWriter.getPreMsgHooks(dataProductInputPorts),
+      inputPortWriter.getPreMsgHooks(dataProductAsyncInputPorts),
       inputPortWriter.getPreMsgHooks(typedAsyncInputPorts),
       inputPortWriter.getPreMsgHooks(serialAsyncInputPorts),
       outputPortWriter.getInvokers(dataProductOutputPorts),

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveGuardedProductsComponentAc.ref.cpp
@@ -2601,25 +2601,6 @@ void ActiveGuardedProductsComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Pre-message hooks for special async input ports
-//
-// Each of these functions is invoked just before processing a message
-// on the corresponding port. By default, they do nothing. You can
-// override them to provide specific pre-message behavior.
-// ----------------------------------------------------------------------
-
-void ActiveGuardedProductsComponentBase ::
-  productRecvIn_preMsgHook(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  // Default: no-op
-}
-
-// ----------------------------------------------------------------------
 // Pre-message hooks for typed async input ports
 //
 // Each of these functions is invoked just before processing a message

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveGuardedProductsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveGuardedProductsComponentAc.ref.hpp
@@ -1131,24 +1131,6 @@ class ActiveGuardedProductsComponentBase :
   PROTECTED:
 
     // ----------------------------------------------------------------------
-    // Pre-message hooks for special async input ports
-    //
-    // Each of these functions is invoked just before processing a message
-    // on the corresponding port. By default, they do nothing. You can
-    // override them to provide specific pre-message behavior.
-    // ----------------------------------------------------------------------
-
-    //! Pre-message hook for async input port productRecvIn
-    virtual void productRecvIn_preMsgHook(
-        FwIndexType portNum, //!< The port number
-        FwDpIdType id, //!< The container ID
-        const Fw::Buffer& buffer, //!< The buffer
-        const Fw::Success& status //!< The status
-    );
-
-  PROTECTED:
-
-    // ----------------------------------------------------------------------
     // Pre-message hooks for typed async input ports
     //
     // Each of these functions is invoked just before processing a message

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSyncProductsComponentAc.ref.cpp
@@ -2595,25 +2595,6 @@ void ActiveSyncProductsComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Pre-message hooks for special async input ports
-//
-// Each of these functions is invoked just before processing a message
-// on the corresponding port. By default, they do nothing. You can
-// override them to provide specific pre-message behavior.
-// ----------------------------------------------------------------------
-
-void ActiveSyncProductsComponentBase ::
-  productRecvIn_preMsgHook(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  // Default: no-op
-}
-
-// ----------------------------------------------------------------------
 // Pre-message hooks for typed async input ports
 //
 // Each of these functions is invoked just before processing a message

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSyncProductsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSyncProductsComponentAc.ref.hpp
@@ -1131,24 +1131,6 @@ class ActiveSyncProductsComponentBase :
   PROTECTED:
 
     // ----------------------------------------------------------------------
-    // Pre-message hooks for special async input ports
-    //
-    // Each of these functions is invoked just before processing a message
-    // on the corresponding port. By default, they do nothing. You can
-    // override them to provide specific pre-message behavior.
-    // ----------------------------------------------------------------------
-
-    //! Pre-message hook for async input port productRecvIn
-    virtual void productRecvIn_preMsgHook(
-        FwIndexType portNum, //!< The port number
-        FwDpIdType id, //!< The container ID
-        const Fw::Buffer& buffer, //!< The buffer
-        const Fw::Success& status //!< The status
-    );
-
-  PROTECTED:
-
-    // ----------------------------------------------------------------------
     // Pre-message hooks for typed async input ports
     //
     // Each of these functions is invoked just before processing a message

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveGuardedProductsComponentAc.ref.cpp
@@ -1856,25 +1856,6 @@ void PassiveGuardedProductsComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Pre-message hooks for special async input ports
-//
-// Each of these functions is invoked just before processing a message
-// on the corresponding port. By default, they do nothing. You can
-// override them to provide specific pre-message behavior.
-// ----------------------------------------------------------------------
-
-void PassiveGuardedProductsComponentBase ::
-  productRecvIn_preMsgHook(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  // Default: no-op
-}
-
-// ----------------------------------------------------------------------
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveGuardedProductsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveGuardedProductsComponentAc.ref.hpp
@@ -959,24 +959,6 @@ class PassiveGuardedProductsComponentBase :
   PROTECTED:
 
     // ----------------------------------------------------------------------
-    // Pre-message hooks for special async input ports
-    //
-    // Each of these functions is invoked just before processing a message
-    // on the corresponding port. By default, they do nothing. You can
-    // override them to provide specific pre-message behavior.
-    // ----------------------------------------------------------------------
-
-    //! Pre-message hook for async input port productRecvIn
-    virtual void productRecvIn_preMsgHook(
-        FwIndexType portNum, //!< The port number
-        FwDpIdType id, //!< The container ID
-        const Fw::Buffer& buffer, //!< The buffer
-        const Fw::Success& status //!< The status
-    );
-
-  PROTECTED:
-
-    // ----------------------------------------------------------------------
     // Invocation functions for special output ports
     // ----------------------------------------------------------------------
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductPortsOnlyComponentAc.ref.cpp
@@ -266,25 +266,6 @@ void PassiveSyncProductPortsOnlyComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Pre-message hooks for special async input ports
-//
-// Each of these functions is invoked just before processing a message
-// on the corresponding port. By default, they do nothing. You can
-// override them to provide specific pre-message behavior.
-// ----------------------------------------------------------------------
-
-void PassiveSyncProductPortsOnlyComponentBase ::
-  productRecvIn_preMsgHook(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  // Default: no-op
-}
-
-// ----------------------------------------------------------------------
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductPortsOnlyComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductPortsOnlyComponentAc.ref.hpp
@@ -191,24 +191,6 @@ class PassiveSyncProductPortsOnlyComponentBase :
   PROTECTED:
 
     // ----------------------------------------------------------------------
-    // Pre-message hooks for special async input ports
-    //
-    // Each of these functions is invoked just before processing a message
-    // on the corresponding port. By default, they do nothing. You can
-    // override them to provide specific pre-message behavior.
-    // ----------------------------------------------------------------------
-
-    //! Pre-message hook for async input port productRecvIn
-    virtual void productRecvIn_preMsgHook(
-        FwIndexType portNum, //!< The port number
-        FwDpIdType id, //!< The container ID
-        const Fw::Buffer& buffer, //!< The buffer
-        const Fw::Success& status //!< The status
-    );
-
-  PROTECTED:
-
-    // ----------------------------------------------------------------------
     // Invocation functions for special output ports
     // ----------------------------------------------------------------------
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductsComponentAc.ref.cpp
@@ -1850,25 +1850,6 @@ void PassiveSyncProductsComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Pre-message hooks for special async input ports
-//
-// Each of these functions is invoked just before processing a message
-// on the corresponding port. By default, they do nothing. You can
-// override them to provide specific pre-message behavior.
-// ----------------------------------------------------------------------
-
-void PassiveSyncProductsComponentBase ::
-  productRecvIn_preMsgHook(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  // Default: no-op
-}
-
-// ----------------------------------------------------------------------
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductsComponentAc.ref.hpp
@@ -959,24 +959,6 @@ class PassiveSyncProductsComponentBase :
   PROTECTED:
 
     // ----------------------------------------------------------------------
-    // Pre-message hooks for special async input ports
-    //
-    // Each of these functions is invoked just before processing a message
-    // on the corresponding port. By default, they do nothing. You can
-    // override them to provide specific pre-message behavior.
-    // ----------------------------------------------------------------------
-
-    //! Pre-message hook for async input port productRecvIn
-    virtual void productRecvIn_preMsgHook(
-        FwIndexType portNum, //!< The port number
-        FwDpIdType id, //!< The container ID
-        const Fw::Buffer& buffer, //!< The buffer
-        const Fw::Success& status //!< The status
-    );
-
-  PROTECTED:
-
-    // ----------------------------------------------------------------------
     // Invocation functions for special output ports
     // ----------------------------------------------------------------------
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
@@ -2147,25 +2147,6 @@ void PassiveTestComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Pre-message hooks for special async input ports
-//
-// Each of these functions is invoked just before processing a message
-// on the corresponding port. By default, they do nothing. You can
-// override them to provide specific pre-message behavior.
-// ----------------------------------------------------------------------
-
-void PassiveTestComponentBase ::
-  productRecvIn_preMsgHook(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  // Default: no-op
-}
-
-// ----------------------------------------------------------------------
 // Invocation functions for special output ports
 // ----------------------------------------------------------------------
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.hpp
@@ -1060,24 +1060,6 @@ class PassiveTestComponentBase :
   PROTECTED:
 
     // ----------------------------------------------------------------------
-    // Pre-message hooks for special async input ports
-    //
-    // Each of these functions is invoked just before processing a message
-    // on the corresponding port. By default, they do nothing. You can
-    // override them to provide specific pre-message behavior.
-    // ----------------------------------------------------------------------
-
-    //! Pre-message hook for async input port productRecvIn
-    virtual void productRecvIn_preMsgHook(
-        FwIndexType portNum, //!< The port number
-        FwDpIdType id, //!< The container ID
-        const Fw::Buffer& buffer, //!< The buffer
-        const Fw::Success& status //!< The status
-    );
-
-  PROTECTED:
-
-    // ----------------------------------------------------------------------
     // Invocation functions for special output ports
     // ----------------------------------------------------------------------
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedGuardedProductsComponentAc.ref.cpp
@@ -2601,25 +2601,6 @@ void QueuedGuardedProductsComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Pre-message hooks for special async input ports
-//
-// Each of these functions is invoked just before processing a message
-// on the corresponding port. By default, they do nothing. You can
-// override them to provide specific pre-message behavior.
-// ----------------------------------------------------------------------
-
-void QueuedGuardedProductsComponentBase ::
-  productRecvIn_preMsgHook(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  // Default: no-op
-}
-
-// ----------------------------------------------------------------------
 // Pre-message hooks for typed async input ports
 //
 // Each of these functions is invoked just before processing a message

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedGuardedProductsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedGuardedProductsComponentAc.ref.hpp
@@ -1131,24 +1131,6 @@ class QueuedGuardedProductsComponentBase :
   PROTECTED:
 
     // ----------------------------------------------------------------------
-    // Pre-message hooks for special async input ports
-    //
-    // Each of these functions is invoked just before processing a message
-    // on the corresponding port. By default, they do nothing. You can
-    // override them to provide specific pre-message behavior.
-    // ----------------------------------------------------------------------
-
-    //! Pre-message hook for async input port productRecvIn
-    virtual void productRecvIn_preMsgHook(
-        FwIndexType portNum, //!< The port number
-        FwDpIdType id, //!< The container ID
-        const Fw::Buffer& buffer, //!< The buffer
-        const Fw::Success& status //!< The status
-    );
-
-  PROTECTED:
-
-    // ----------------------------------------------------------------------
     // Pre-message hooks for typed async input ports
     //
     // Each of these functions is invoked just before processing a message

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSyncProductsComponentAc.ref.cpp
@@ -2595,25 +2595,6 @@ void QueuedSyncProductsComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Pre-message hooks for special async input ports
-//
-// Each of these functions is invoked just before processing a message
-// on the corresponding port. By default, they do nothing. You can
-// override them to provide specific pre-message behavior.
-// ----------------------------------------------------------------------
-
-void QueuedSyncProductsComponentBase ::
-  productRecvIn_preMsgHook(
-      FwIndexType portNum,
-      FwDpIdType id,
-      const Fw::Buffer& buffer,
-      const Fw::Success& status
-  )
-{
-  // Default: no-op
-}
-
-// ----------------------------------------------------------------------
 // Pre-message hooks for typed async input ports
 //
 // Each of these functions is invoked just before processing a message

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSyncProductsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSyncProductsComponentAc.ref.hpp
@@ -1131,24 +1131,6 @@ class QueuedSyncProductsComponentBase :
   PROTECTED:
 
     // ----------------------------------------------------------------------
-    // Pre-message hooks for special async input ports
-    //
-    // Each of these functions is invoked just before processing a message
-    // on the corresponding port. By default, they do nothing. You can
-    // override them to provide specific pre-message behavior.
-    // ----------------------------------------------------------------------
-
-    //! Pre-message hook for async input port productRecvIn
-    virtual void productRecvIn_preMsgHook(
-        FwIndexType portNum, //!< The port number
-        FwDpIdType id, //!< The container ID
-        const Fw::Buffer& buffer, //!< The buffer
-        const Fw::Success& status //!< The status
-    );
-
-  PROTECTED:
-
-    // ----------------------------------------------------------------------
     // Pre-message hooks for typed async input ports
     //
     // Each of these functions is invoked just before processing a message


### PR DESCRIPTION
Most ports only have `preMsgHook` when operating as `async`.  However, data product ports erroneously added `preMsgHook` to every use (`guarded`, `sync`, and `async`).  This fixes this oversight.