### PR TITLE
Fix code gen for command overflow hooks

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCommands.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCommands.scala
@@ -192,7 +192,7 @@ case class ComponentCommands (
                   priority,
                   MessageType.Command,
                   cmd.getName,
-                  opcodeParam :: cmdSeqParam :: cmdParamMap(opcode)
+                  opcodeParam :: cmdSeqParam :: Nil
                 )
               )
             )
@@ -339,7 +339,7 @@ case class ComponentCommands (
         functionClassMember(
           Some(s"Overflow hook for command ${cmd.getName}"),
           inputOverflowHookName(cmd.getName, MessageType.Command),
-          opcodeParam :: cmdSeqParam :: cmdParamMap(opcode),
+          opcodeParam :: cmdSeqParam :: Nil,
           CppDoc.Type("void"),
           Nil,
           CppDoc.Function.PureVirtual

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriterUtils.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriterUtils.scala
@@ -631,27 +631,13 @@ abstract class ComponentCppWriterUtils(
                |}
                |"""
           )
-          case Ast.QueueFull.Hook => {
-            messageType match {
-              case MessageType.Command =>
-                lines(
-                  s"""|if (qStatus == Os::Queue::QUEUE_FULL) {
-                      |  // TODO: Deserialize command arguments and call the hook
-                      |  // this->${inputOverflowHookName(name, messageType)}(${arguments.map(_.name).mkString(", ")});
-                      |  return;
-                      |}
-                      |"""
-                )
-              case _ =>
-                lines(
-                  s"""|if (qStatus == Os::Queue::QUEUE_FULL) {
-                      |  this->${inputOverflowHookName(name, messageType)}(${arguments.map(_.name).mkString(", ")});
-                      |  return;
-                      |}
-                      |"""
-                )
-            }
-          }
+          case Ast.QueueFull.Hook => lines(
+            s"""|if (qStatus == Os::Queue::QUEUE_FULL) {
+                |  this->${inputOverflowHookName(name, messageType)}(${arguments.map(_.name).mkString(", ")});
+                |  return;
+                |}
+                |"""
+          )
           case _ => Nil
         }
         ,

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentImplWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentImplWriter.scala
@@ -209,7 +209,7 @@ private def getOverflowHooks: List[CppDoc.Class.Member] = {
         functionClassMember(
           Some(s"Overflow hook implementation for ${cmd.getName}"),
           inputOverflowHookName(cmd.getName, MessageType.Command),
-          opcodeParam :: cmdSeqParam :: cmdParamMap(opcode),
+          opcodeParam :: cmdSeqParam :: Nil,
           CppDoc.Type("void"),
           lines("// TODO"),
           CppDoc.Function.Override

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveOverflowComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveOverflowComponentAc.ref.cpp
@@ -1819,8 +1819,7 @@ void ActiveOverflowComponentBase ::
   Os::Queue::QueueStatus qStatus = this->m_queue.send(msg, 0, _block);
 
   if (qStatus == Os::Queue::QUEUE_FULL) {
-    // TODO: Deserialize command arguments and call the hook
-    // this->CMD_HOOK_cmdOverflowHook(opCode, cmdSeq);
+    this->CMD_HOOK_cmdOverflowHook(opCode, cmdSeq);
     return;
   }
 
@@ -1884,8 +1883,7 @@ void ActiveOverflowComponentBase ::
   Os::Queue::QueueStatus qStatus = this->m_queue.send(msg, 30, _block);
 
   if (qStatus == Os::Queue::QUEUE_FULL) {
-    // TODO: Deserialize command arguments and call the hook
-    // this->CMD_PARAMS_PRIORITY_HOOK_cmdOverflowHook(opCode, cmdSeq, u32);
+    this->CMD_PARAMS_PRIORITY_HOOK_cmdOverflowHook(opCode, cmdSeq);
     return;
   }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveOverflowComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveOverflowComponentAc.ref.hpp
@@ -912,8 +912,7 @@ class ActiveOverflowComponentBase :
     //! Overflow hook for command CMD_PARAMS_PRIORITY_HOOK
     virtual void CMD_PARAMS_PRIORITY_HOOK_cmdOverflowHook(
         FwOpcodeType opCode, //!< The opcode
-        U32 cmdSeq, //!< The command sequence number
-        U32 u32
+        U32 cmdSeq //!< The command sequence number
     ) = 0;
 
   PROTECTED:

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedOverflowComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedOverflowComponentAc.ref.cpp
@@ -1819,8 +1819,7 @@ void QueuedOverflowComponentBase ::
   Os::Queue::QueueStatus qStatus = this->m_queue.send(msg, 0, _block);
 
   if (qStatus == Os::Queue::QUEUE_FULL) {
-    // TODO: Deserialize command arguments and call the hook
-    // this->CMD_HOOK_cmdOverflowHook(opCode, cmdSeq);
+    this->CMD_HOOK_cmdOverflowHook(opCode, cmdSeq);
     return;
   }
 
@@ -1884,8 +1883,7 @@ void QueuedOverflowComponentBase ::
   Os::Queue::QueueStatus qStatus = this->m_queue.send(msg, 30, _block);
 
   if (qStatus == Os::Queue::QUEUE_FULL) {
-    // TODO: Deserialize command arguments and call the hook
-    // this->CMD_PARAMS_PRIORITY_HOOK_cmdOverflowHook(opCode, cmdSeq, u32);
+    this->CMD_PARAMS_PRIORITY_HOOK_cmdOverflowHook(opCode, cmdSeq);
     return;
   }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedOverflowComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedOverflowComponentAc.ref.hpp
@@ -912,8 +912,7 @@ class QueuedOverflowComponentBase :
     //! Overflow hook for command CMD_PARAMS_PRIORITY_HOOK
     virtual void CMD_PARAMS_PRIORITY_HOOK_cmdOverflowHook(
         FwOpcodeType opCode, //!< The opcode
-        U32 cmdSeq, //!< The command sequence number
-        U32 u32
+        U32 cmdSeq //!< The command sequence number
     ) = 0;
 
   PROTECTED:

--- a/compiler/tools/fpp-to-cpp/test/component/impl/ActiveOverflow.template.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/ActiveOverflow.template.ref.cpp
@@ -201,8 +201,7 @@ void ActiveOverflow ::
 void ActiveOverflow ::
   CMD_PARAMS_PRIORITY_HOOK_cmdOverflowHook(
       FwOpcodeType opCode,
-      U32 cmdSeq,
-      U32 u32
+      U32 cmdSeq
   )
 {
   // TODO

--- a/compiler/tools/fpp-to-cpp/test/component/impl/ActiveOverflow.template.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/ActiveOverflow.template.ref.hpp
@@ -193,8 +193,7 @@ class ActiveOverflow :
     //! Overflow hook implementation for CMD_PARAMS_PRIORITY_HOOK
     void CMD_PARAMS_PRIORITY_HOOK_cmdOverflowHook(
         FwOpcodeType opCode, //!< The opcode
-        U32 cmdSeq, //!< The command sequence number
-        U32 u32
+        U32 cmdSeq //!< The command sequence number
     ) override;
 
 };

--- a/compiler/tools/fpp-to-cpp/test/component/impl/QueuedOverflow.template.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/QueuedOverflow.template.ref.cpp
@@ -201,8 +201,7 @@ void QueuedOverflow ::
 void QueuedOverflow ::
   CMD_PARAMS_PRIORITY_HOOK_cmdOverflowHook(
       FwOpcodeType opCode,
-      U32 cmdSeq,
-      U32 u32
+      U32 cmdSeq
   )
 {
   // TODO

--- a/compiler/tools/fpp-to-cpp/test/component/impl/QueuedOverflow.template.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/QueuedOverflow.template.ref.hpp
@@ -193,8 +193,7 @@ class QueuedOverflow :
     //! Overflow hook implementation for CMD_PARAMS_PRIORITY_HOOK
     void CMD_PARAMS_PRIORITY_HOOK_cmdOverflowHook(
         FwOpcodeType opCode, //!< The opcode
-        U32 cmdSeq, //!< The command sequence number
-        U32 u32
+        U32 cmdSeq //!< The command sequence number
     ) override;
 
 };

--- a/docs/fpp-spec.html
+++ b/docs/fpp-spec.html
@@ -5,7 +5,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="Asciidoctor 2.0.20">
-<title>The F Prime Prime (FPP) Language Specification, v2.1.0</title>
+<title>The F Prime Prime (FPP) Language Specification, Unreleased, after v2.1.0</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
 /*! Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
@@ -436,7 +436,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </head>
 <body class="article toc2 toc-left">
 <div id="header">
-<h1>The F Prime Prime (FPP) Language Specification, v2.1.0</h1>
+<h1>The F Prime Prime (FPP) Language Specification, Unreleased, after v2.1.0</h1>
 <div id="toc" class="toc2">
 <div id="toctitle">Table of Contents</div>
 <ul class="sectlevel1">
@@ -8558,7 +8558,7 @@ equivalent.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2024-08-22 08:28:42 -0700
+Last updated 2024-08-22 08:48:41 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-spec.html
+++ b/docs/fpp-spec.html
@@ -1006,6 +1006,7 @@ get
 guarded
 health
 high
+hook
 id
 import
 include
@@ -4595,6 +4596,9 @@ of a
 <li>
 <p><code>drop</code></p>
 </li>
+<li>
+<p><code>hook</code></p>
+</li>
 </ol>
 </div>
 <div class="paragraph">
@@ -4746,6 +4750,9 @@ space on the queue for the message.</p>
 </li>
 <li>
 <p><code>drop</code> means that the message is dropped.</p>
+</li>
+<li>
+<p><code>hook</code> means that the message is passed to a user-supplied hook function.</p>
 </li>
 </ol>
 </div>
@@ -8551,7 +8558,7 @@ equivalent.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2024-07-22 17:41:09 -0700
+Last updated 2024-08-22 08:28:42 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-users-guide.html
+++ b/docs/fpp-users-guide.html
@@ -3877,11 +3877,14 @@ There are three possible behaviors:</p>
 <li>
 <p><code>drop</code>: Drop the incoming message and proceed.</p>
 </li>
+<li>
+<p><code>hook</code>: Call a user function to respond to the queue overflow.</p>
+</li>
 </ol>
 </div>
 <div class="paragraph">
 <p>To specify queue full behavior, you write one of the keywords <code>assert</code>,
-<code>block</code>, or <code>drop</code> after the port type and after the priority
+<code>block</code>, <code>drop</code>, or <code>hook</code> after the port type and after the priority
 (if any).
 As an example, here is the <code>ActiveF32Adder</code> updated with explicit
 queue full behavior.</p>
@@ -3900,6 +3903,9 @@ active component ActiveF32Adder {
 
   @ Input 2: Drop on queue full
   async input port f32ValueIn2: F32Value drop
+
+  @ Input 3: Call hook function on queue full
+  async input port f32ValueIn3: F32Value hook
 
   @ Output
   output port f32ValueOut: F32Value
@@ -12293,7 +12299,7 @@ function, you may.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2024-07-22 17:45:06 -0700
+Last updated 2024-08-22 08:29:18 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-users-guide.html
+++ b/docs/fpp-users-guide.html
@@ -5,7 +5,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="Asciidoctor 2.0.20">
-<title>The F Prime Prime (FPP) User&#8217;s Guide, v2.1.0</title>
+<title>The F Prime Prime (FPP) User&#8217;s Guide, Unreleased, after v2.1.0</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
 /*! Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
@@ -436,7 +436,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </head>
 <body class="article toc2 toc-left">
 <div id="header">
-<h1>The F Prime Prime (FPP) User&#8217;s Guide, v2.1.0</h1>
+<h1>The F Prime Prime (FPP) User&#8217;s Guide, Unreleased, after v2.1.0</h1>
 <div id="toc" class="toc2">
 <div id="toctitle">Table of Contents</div>
 <ul class="sectlevel1">
@@ -12299,7 +12299,7 @@ function, you may.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2024-08-22 08:29:18 -0700
+Last updated 2024-08-22 08:49:17 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/version.sh
+++ b/version.sh
@@ -2,4 +2,4 @@
 # The FPP version
 # ----------------------------------------------------------------------
 
-export VERSION="v2.1.0"
+export VERSION="Unreleased, after v2.1.0"


### PR DESCRIPTION
* In the function prototypes and at the call sites, follow the pattern of the pre-message hooks. Don't include the command arguments. At the call sites, these are in serialized form and so are not available in typed argument form.
* Re-enable the call sites, which were commented out to get the code to compile.
* Update the unit tests.
* Update the version stamp to after v2.1.0.
* Re-generate the docs.

Closes #496.