### PR TITLE
Switch deprecated Actions artifact@v3 to v4

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -64,7 +64,7 @@ jobs:
           ${{ inputs.build }} ${{ inputs.output-directory }}
         shell: bash
       - name: "Archiving JARs package"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-jar
           path: ${{ inputs.output-directory }}/*
@@ -80,7 +80,7 @@ jobs:
           ${{ inputs.test }}
           echo -e "Trace output files:\n$( find ${{ inputs.trace-directory }} -name *.json )"
       - name: "Archiving Tracing"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jar-traces
           path: ${{ inputs.trace-directory }}/*.json
@@ -138,13 +138,13 @@ jobs:
       - name: "Setup Native Image Tools"
         uses: fprime-community/native-images-action@main
       - name: "Download JARs"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-jar
           path:  ${{ inputs.output-directory }}
       - if: ${{ inputs.trace }}
         name: "Download Tracing"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: jar-traces
           path: ${{ inputs.trace-directory }}
@@ -155,7 +155,7 @@ jobs:
           $NATIVE_IMAGE_TOOLS_PATH/native-images ${{ inputs.output-directory }} ${{ inputs.tools }}
         shell: bash
       - name: "Archive Native Images"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-${{ matrix.run.tag }}
           path:  ${{ inputs.output-directory }}/*
@@ -176,7 +176,7 @@ jobs:
         with:
           submodules: recursive
       - name: "Download Package"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-${{ matrix.tag }}
           path: ${{ inputs.output-directory }}
@@ -198,7 +198,7 @@ jobs:
           fprime-native-packager ${{ inputs.output-directory }} ${FLAGS}
         shell: bash
       - name: "Archiving Wheels"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wheels-${{ matrix.tag }}
           path: packages/dist/*
@@ -213,12 +213,12 @@ jobs:
       - name: "Setup Native Image Tools"
         uses: fprime-community/native-images-action@main
       - name: "Download Native Wheels"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: wheels-${{ matrix.run.tag }}
           path: ${{ inputs.output-directory }}/native
       - name: "Download JAR Wheels"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: wheels-jar
           path: ${{ inputs.output-directory }}/jars
@@ -240,7 +240,7 @@ jobs:
       matrix: ${{ fromJson(needs.generate-run-matricies.outputs.tags) }}
     steps:
       - name: "Download Package"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: wheels-${{ matrix.tag }}
           path: dist


### PR DESCRIPTION
Fix https://github.com/nasa/fpp/issues/556

`actions/{download,upload}-artifacts@v3` is being deprecated. Updating to @v4