### PR TITLE
Configure JVM options

### DIFF
--- a/compiler/.jvmopts
+++ b/compiler/.jvmopts
@@ -1,2 +1,1 @@
--XX:+CMSClassUnloadingEnabled
--Xss2M
+-XX:+UseG1GC

--- a/compiler/.jvmopts
+++ b/compiler/.jvmopts
@@ -1,1 +1,1 @@
--Xmx2G -XX:+UseG1GC
+-Xmx2G -XX:+UseG1GC -Xss2M

--- a/compiler/.jvmopts
+++ b/compiler/.jvmopts
@@ -1,1 +1,1 @@
--XX:+UseG1GC
+-Xmx2G -XX:+UseG1GC

--- a/compiler/install
+++ b/compiler/install
@@ -86,7 +86,8 @@ echo $cmd
 $cmd
 
 echo "Restoring Version.scala"
-cp $util/Version.scala.bak $util/Version.scala
+sed -i.bak -e "s/val v = .*/val v = \"[unknown version]\"/" \
+  $util/Version.scala
 
 mkdir -p $dest
 


### PR DESCRIPTION
* Use the newer G1GC garbage collector. Remove the older GC option that doesn't work in Java 17.
* Increase the heap size to 2G.
* Revise `compiler/install` so it restores `version.scala` properly on failure.

Closes #610.