### PR TITLE
Revise links to F Prime docs

### DIFF
--- a/docs/fpp-spec.html
+++ b/docs/fpp-spec.html
@@ -11107,7 +11107,7 @@ equivalent.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2025-02-11 17:00:39 -0800
+Last updated 2025-02-18 09:43:20 -0800
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-spec.html
+++ b/docs/fpp-spec.html
@@ -11107,7 +11107,7 @@ equivalent.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2025-02-18 09:43:20 -0800
+Last updated 2025-02-18 10:31:17 -0800
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-users-guide.html
+++ b/docs/fpp-users-guide.html
@@ -754,7 +754,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 FPP is a modeling language for the
 <a href="https://fprime.jpl.nasa.gov">F Prime flight software framework</a>.
 For more detailed information about F Prime, see the
-<a href="https://fprime.jpl.nasa.gov/latest/docs/user-manual/">F Prime User Manual</a>.</p>
+<a href="https://fprime.jpl.nasa.gov/devel/docs/user-manual/">F Prime User Manual</a>.</p>
 </div>
 <div class="paragraph">
 <p>The goals of FPP are as follows:</p>
@@ -3633,7 +3633,7 @@ applications that use F Prime.</p>
 of FPP state machines.
 For more details about the C&#43;&#43; code generation
 for state machines, see the
-<a href="https://fprime.jpl.nasa.gov/latest/docs/user-manual/design/state-machines/">F
+<a href="https://fprime.jpl.nasa.gov/devel/docs/user-manual/framework/state-machines/">F
 Prime design documentation</a>.</p>
 </div>
 </div>
@@ -4221,7 +4221,7 @@ After <em>s'</em> is complete, <em>s</em> is dispatched from the queue and handl
 </div>
 <div class="paragraph">
 <p>For more details on sending signals to an FPP state machine, see the
-<a href="https://fprime.jpl.nasa.gov/latest/docs/user-manual/design/state-machines/">F
+<a href="https://fprime.jpl.nasa.gov/devel/docs/user-manual/framework/state-machines/">F
 Prime design documentation</a>.</p>
 </div>
 </div>
@@ -5833,7 +5833,7 @@ For example, in the C&#43;&#43; implementation, you would generate a
 base class with a virtual handler function, and then override that virtual
 function in a derived class that you write.
 For further details about implementing F Prime components, see the
-<a href="https://fprime.jpl.nasa.gov/latest/docs/user-manual/">F Prime User Manual</a>.</p>
+<a href="https://fprime.jpl.nasa.gov/devel/docs/user-manual/">F Prime User Manual</a>.</p>
 </div>
 <div class="paragraph">
 <p><strong>Note on terminology:</strong> As explained above, there is a technical
@@ -5842,7 +5842,7 @@ the type of a port instance)
 and a <em>port instance</em> (specified inside a component and instantiating
 a port type).
 However, it is sometimes useful to refer to a port instance with
-the shorter term "port" when there is no danger of confusion.
+the shorter term &#8220;port&#8221; when there is no danger of confusion.
 We will do that in this manual.
 For example, we will say that the <code>F32Adder</code> component has three
 ports: two async input ports of type <code>F32Value</code> and one output port
@@ -6128,7 +6128,7 @@ on that side.
 This flexibility comes at the cost that you lose the type
 compile-time type checking provided by port connections with named types.
 For more information about serial ports and their use, see
-the <a href="https://fprime.jpl.nasa.gov/latest/docs/user-manual/">F Prime User Manual</a>.</p>
+the <a href="https://fprime.jpl.nasa.gov/devel/docs/user-manual/">F Prime User Manual</a>.</p>
 </div>
 </div>
 </div>
@@ -6267,7 +6267,7 @@ properly with F Prime C&#43;&#43; code generation.</p>
 <div class="paragraph">
 <p>For further information about command registration, receipt, and
 response, and implementing command handlers, see the
-<a href="https://fprime.jpl.nasa.gov/latest/docs/user-manual/">F Prime User Manual</a>.</p>
+<a href="https://fprime.jpl.nasa.gov/devel/docs/user-manual/">F Prime User Manual</a>.</p>
 </div>
 </div>
 <div class="sect3">
@@ -6348,7 +6348,7 @@ simplified definitions of these ports:</p>
 </div>
 <div class="paragraph">
 <p>For further information about events in F Prime, see the
-<a href="https://fprime.jpl.nasa.gov/latest/docs/user-manual/">F Prime User Manual</a>.</p>
+<a href="https://fprime.jpl.nasa.gov/devel/docs/user-manual/">F Prime User Manual</a>.</p>
 </div>
 </div>
 <div class="sect3">
@@ -6397,7 +6397,7 @@ simplified definition of this port:</p>
 </div>
 <div class="paragraph">
 <p>For further information about telemetry in F Prime, see the
-<a href="https://fprime.jpl.nasa.gov/latest/docs/user-manual/">F Prime User Manual</a>.</p>
+<a href="https://fprime.jpl.nasa.gov/devel/docs/user-manual/">F Prime User Manual</a>.</p>
 </div>
 </div>
 <div class="sect3">
@@ -6482,7 +6482,7 @@ simplified definitions of these ports:</p>
 </div>
 <div class="paragraph">
 <p>For further information about parameters in F Prime, see the
-<a href="https://fprime.jpl.nasa.gov/latest/docs/user-manual/">F Prime User Manual</a>.</p>
+<a href="https://fprime.jpl.nasa.gov/devel/docs/user-manual/">F Prime User Manual</a>.</p>
 </div>
 </div>
 <div class="sect3">
@@ -6532,7 +6532,7 @@ simplified definition of this port:</p>
 </div>
 <div class="paragraph">
 <p>For further information about time in F Prime, see the
-<a href="https://fprime.jpl.nasa.gov/latest/docs/user-manual/">F Prime User Manual</a>.</p>
+<a href="https://fprime.jpl.nasa.gov/devel/docs/user-manual/">F Prime User Manual</a>.</p>
 </div>
 </div>
 <div class="sect3">
@@ -6655,7 +6655,7 @@ simplified definitions of these ports:</p>
 </div>
 <div class="paragraph">
 <p>For further information about data products in F Prime, see the
-<a href="https://fprime.jpl.nasa.gov/latest/docs/user-manual/design/data-products/">F
+<a href="https://fprime.jpl.nasa.gov/devel/docs/user-manual/framework/data-products/">F
 Prime design documentation</a>.</p>
 </div>
 </div>
@@ -6800,7 +6800,7 @@ as part of the component implementation.</p>
 <div class="paragraph">
 <p>For complete information about F Prime command dispatch and
 handling, see the
-<a href="https://fprime.jpl.nasa.gov/latest/docs/user-manual/">F Prime User Manual</a>.
+<a href="https://fprime.jpl.nasa.gov/devel/docs/user-manual/">F Prime User Manual</a>.
 Here we concentrate on how to specify commands in FPP.</p>
 </div>
 <div class="sect3">
@@ -7163,7 +7163,7 @@ you can store in an on-board file system or send to the ground.</p>
 <div class="paragraph">
 <p>For complete information about F Prime event
 handling, see the
-<a href="https://fprime.jpl.nasa.gov/latest/docs/user-manual/">F Prime User Manual</a>.
+<a href="https://fprime.jpl.nasa.gov/devel/docs/user-manual/">F Prime User Manual</a>.
 Here we concentrate on how to specify events in FPP.</p>
 </div>
 <div class="sect3">
@@ -7462,7 +7462,7 @@ instance has emitted it ten times.</p>
 emit the event until the throttling is canceled.
 Typically, the canceling happens via a FSW command.
 For details, see the
-<a href="https://fprime.jpl.nasa.gov/latest/docs/user-manual/">F Prime User Manual</a>.</p>
+<a href="https://fprime.jpl.nasa.gov/devel/docs/user-manual/">F Prime User Manual</a>.</p>
 </div>
 </div>
 </div>
@@ -7483,7 +7483,7 @@ or send them the ground.</p>
 <div class="paragraph">
 <p>For complete information about F Prime telemetry
 handling, see the
-<a href="https://fprime.jpl.nasa.gov/latest/docs/user-manual/">F Prime User Manual</a>.
+<a href="https://fprime.jpl.nasa.gov/devel/docs/user-manual/">F Prime User Manual</a>.
 Here we concentrate on how to specify telemetry channels in FPP.</p>
 </div>
 <div class="sect3">
@@ -7843,7 +7843,7 @@ for a hardware device or a software algorithm.</p>
 database component for storing parameters in a non-volatile
 manner (e.g., on a file system).
 For complete information about F Prime parameters, see the
-<a href="https://fprime.jpl.nasa.gov/latest/docs/user-manual/">F Prime User Manual</a>.
+<a href="https://fprime.jpl.nasa.gov/devel/docs/user-manual/">F Prime User Manual</a>.
 Here we concentrate on how to specify parameters in FPP.</p>
 </div>
 <div class="sect3">
@@ -8174,7 +8174,7 @@ for (1) managing buffers that can store data products in memory;
 (2) writing data products to the file system; and (3)
 cataloging stored data products for downlink in priority order.
 For more information about these F Prime features, see the
-<a href="https://fprime.jpl.nasa.gov/latest/docs/user-manual/design/data-products/">F
+<a href="https://fprime.jpl.nasa.gov/devel/docs/user-manual/framework/data-products/">F
 Prime design documentation</a>.</p>
 </div>
 <div class="sect3">
@@ -8256,7 +8256,7 @@ passive component BasicDataProducts {
 <p>The FPP back end uses this specification to generate code for requesting
 buffers to hold containers and for serializing records into containers.
 See the
-<a href="https://fprime.jpl.nasa.gov/latest/docs/user-manual/design/data-products/">F
+<a href="https://fprime.jpl.nasa.gov/devel/docs/user-manual/framework/data-products/">F
 Prime design documentation</a> for the details.</p>
 </div>
 <div class="paragraph">
@@ -8497,7 +8497,7 @@ active component StateMachine {
 machine definitions may be internal (specified in FPP) or external (specified
 by an external tool).  For more details about the C&#43;&#43; code generation for
 instances of internal state machines, see the
-<a href="https://fprime.jpl.nasa.gov/latest/docs/user-manual/design/state-machines/">F
+<a href="https://fprime.jpl.nasa.gov/devel/docs/user-manual/framework/state-machines/">F
 Prime design documentation</a>.</p>
 </div>
 </div>
@@ -8892,8 +8892,8 @@ a time get port for getting the time, and a telemetry port
 for reporting telemetry.
 (For more information on rate groups and the use of <code>Svc.Sched</code>
 ports, see the
-<a href="https://fprime.jpl.nasa.gov/latest/docs/user-manual/design/rate-group/">F Prime
-documentation</a>.)
+<a href="https://fprime.jpl.nasa.gov/devel/docs/user-manual/design-patterns/rate-group/">F
+Prime documentation</a>.)
 We have given the component two telemetry channels:
 <code>ImpulseTemp</code> for reporting the temperature of the impulse engine,
 and <code>WarpTemp</code> for reporting the temperature of the warp core.</p>
@@ -13031,13 +13031,13 @@ uses the name <code>A_B_CComponentAc_HPP</code> in its include guard.</p>
 <div class="paragraph">
 <p>Once you generate C&#43;&#43; code for these definitions, you can use it to
 write a flight software implementation.
-The <a href="https://fprime.jpl.nasa.gov/latest/docs/user-manual/">F
+The <a href="https://fprime.jpl.nasa.gov/devel/docs/user-manual/">F
 User Manual</a> explains how to do this.</p>
 </div>
 <div class="paragraph">
 <p>For more information about the generated code for data products,
 for state machines, and for state machine instances, see the
-<a href="https://fprime.jpl.nasa.gov/latest/docs/user-manual/design/state-machines/">F
+<a href="https://fprime.jpl.nasa.gov/devel/docs/user-manual/">F
 Prime design documentation</a>.</p>
 </div>
 </div>
@@ -13049,7 +13049,7 @@ or
 partial implementations and for generating unit test code.
 Here we cover the mechanics of using these options.
 For more information on implementing and testing components in F Prime, see
-the <a href="https://fprime.jpl.nasa.gov/latest/docs/user-manual/">F Prime User Manual</a>.</p>
+the <a href="https://fprime.jpl.nasa.gov/devel/docs/user-manual/">F Prime User Manual</a>.</p>
 </div>
 <div class="paragraph">
 <p><strong>Generating implementation templates:</strong>
@@ -14024,8 +14024,8 @@ file
 <em>T</em> <code>TopologyDictionary.json</code>.
 The dictionary is specified in JavaScript Object Notation (JSON) format.
 The JSON format is specified in the
-<a href="https://fprime.jpl.nasa.gov/latest/docs/user-manual/design/fpp-json-dict/">F
-Prime design documentation</a>.</p>
+<a href="https://fprime.jpl.nasa.gov/devel/docs/reference/fpp-json-dict/">F Prime design
+documentation</a>.</p>
 </div>
 <div class="paragraph">
 <p>Here is a common use case:</p>
@@ -14859,7 +14859,7 @@ function, you may.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2025-02-11 09:19:43 -0800
+Last updated 2025-02-18 09:44:01 -0800
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-users-guide.html
+++ b/docs/fpp-users-guide.html
@@ -8188,7 +8188,7 @@ the container (e.g., the size of the data payload), and binary data
 representing a list of serialized <strong>records</strong>.
 A record is a unit of data.
 For a complete specification of the container format, see the
-<a href="https://fprime.jpl.nasa.gov/latest/Fw/Dp/docs/sdd/">F Prime design
+<a href="https://fprime.jpl.nasa.gov/devel/Fw/Dp/docs/sdd/">F Prime design
 documentation</a>.</p>
 </div>
 <div class="paragraph">
@@ -14859,7 +14859,7 @@ function, you may.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2025-02-18 09:44:01 -0800
+Last updated 2025-02-18 10:31:58 -0800
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -463,7 +463,7 @@ generated code.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2025-01-30 11:12:52 -0800
+Last updated 2025-02-18 09:43:03 -0800
 </div>
 </div>
 </body>

--- a/docs/users-guide/Analyzing-and-Translating-Models.adoc
+++ b/docs/users-guide/Analyzing-and-Translating-Models.adoc
@@ -566,12 +566,12 @@ uses the name `A_B_CComponentAc_HPP` in its include guard.
 
 Once you generate {cpp} code for these definitions, you can use it to
 write a flight software implementation.
-The https://fprime.jpl.nasa.gov/latest/docs/user-manual/[F
+The https://fprime.jpl.nasa.gov/devel/docs/user-manual/[F
 User Manual] explains how to do this.
 
 For more information about the generated code for data products,
 for state machines, and for state machine instances, see the
-https://fprime.jpl.nasa.gov/latest/docs/user-manual/design/state-machines/[F
+https://fprime.jpl.nasa.gov/devel/docs/user-manual/[F
 Prime design documentation].
 
 ==== Component Implementation and Unit Test Code
@@ -581,7 +581,7 @@ or
 partial implementations and for generating unit test code.
 Here we cover the mechanics of using these options.
 For more information on implementing and testing components in F Prime, see
-the https://fprime.jpl.nasa.gov/latest/docs/user-manual/[F Prime User Manual].
+the https://fprime.jpl.nasa.gov/devel/docs/user-manual/[F Prime User Manual].
 
 *Generating implementation templates:*
 When you run `fpp-to-cpp` with option `-t` and without option `-u`,
@@ -1360,8 +1360,8 @@ file
 _T_ `TopologyDictionary.json`.
 The dictionary is specified in JavaScript Object Notation (JSON) format.
 The JSON format is specified in the
-https://fprime.jpl.nasa.gov/latest/docs/user-manual/design/fpp-json-dict/[F 
-Prime design documentation].
+https://fprime.jpl.nasa.gov/devel/docs/reference/fpp-json-dict/[F Prime design 
+documentation].
 
 Here is a common use case:
 

--- a/docs/users-guide/Defining-Component-Instances.adoc
+++ b/docs/users-guide/Defining-Component-Instances.adoc
@@ -85,8 +85,8 @@ a time get port for getting the time, and a telemetry port
 for reporting telemetry.
 (For more information on rate groups and the use of `Svc.Sched`
 ports, see the 
-https://fprime.jpl.nasa.gov/latest/docs/user-manual/design/rate-group/[F Prime 
-documentation].)
+https://fprime.jpl.nasa.gov/devel/docs/user-manual/design-patterns/rate-group/[F 
+Prime documentation].)
 We have given the component two telemetry channels:
 `ImpulseTemp` for reporting the temperature of the impulse engine,
 and `WarpTemp` for reporting the temperature of the warp core.

--- a/docs/users-guide/Defining-Components.adoc
+++ b/docs/users-guide/Defining-Components.adoc
@@ -2212,7 +2212,7 @@ the container (e.g., the size of the data payload), and binary data
 representing a list of serialized *records*.
 A record is a unit of data.
 For a complete specification of the container format, see the 
-https://fprime.jpl.nasa.gov/latest/Fw/Dp/docs/sdd/[F Prime design 
+https://fprime.jpl.nasa.gov/devel/Fw/Dp/docs/sdd/[F Prime design 
 documentation].
 
 In an F Prime component, you can specify one or more containers

--- a/docs/users-guide/Defining-Components.adoc
+++ b/docs/users-guide/Defining-Components.adoc
@@ -142,7 +142,7 @@ For example, in the {cpp} implementation, you would generate a
 base class with a virtual handler function, and then override that virtual
 function in a derived class that you write.
 For further details about implementing F Prime components, see the
-https://fprime.jpl.nasa.gov/latest/docs/user-manual/[F Prime User Manual].
+https://fprime.jpl.nasa.gov/devel/docs/user-manual/[F Prime User Manual].
 
 *Note on terminology:* As explained above, there is a technical
 distinction between a _port type_ (defined outside any component, and providing
@@ -150,7 +150,7 @@ the type of a port instance)
 and a _port instance_ (specified inside a component and instantiating
 a port type).
 However, it is sometimes useful to refer to a port instance with
-the shorter term "port" when there is no danger of confusion.
+the shorter term "`port`" when there is no danger of confusion.
 We will do that in this manual.
 For example, we will say that the `F32Adder` component has three
 ports: two async input ports of type `F32Value` and one output port
@@ -405,7 +405,7 @@ on that side.
 This flexibility comes at the cost that you lose the type
 compile-time type checking provided by port connections with named types.
 For more information about serial ports and their use, see
-the https://fprime.jpl.nasa.gov/latest/docs/user-manual/[F Prime User Manual].
+the https://fprime.jpl.nasa.gov/devel/docs/user-manual/[F Prime User Manual].
 
 === Special Port Instances
 
@@ -507,7 +507,7 @@ properly with F Prime {cpp} code generation.
 
 For further information about command registration, receipt, and
 response, and implementing command handlers, see the
-https://fprime.jpl.nasa.gov/latest/docs/user-manual/[F Prime User Manual].
+https://fprime.jpl.nasa.gov/devel/docs/user-manual/[F Prime User Manual].
 
 ==== Event Ports
 
@@ -566,7 +566,7 @@ module Fw {
 --------
 
 For further information about events in F Prime, see the
-https://fprime.jpl.nasa.gov/latest/docs/user-manual/[F Prime User Manual].
+https://fprime.jpl.nasa.gov/devel/docs/user-manual/[F Prime User Manual].
 
 ==== Telemetry Ports
 
@@ -609,7 +609,7 @@ module Fw {
 --------
 
 For further information about telemetry in F Prime, see the
-https://fprime.jpl.nasa.gov/latest/docs/user-manual/[F Prime User Manual].
+https://fprime.jpl.nasa.gov/devel/docs/user-manual/[F Prime User Manual].
 
 ==== Parameter Ports
 
@@ -671,7 +671,7 @@ module Fw {
 --------
 
 For further information about parameters in F Prime, see the
-https://fprime.jpl.nasa.gov/latest/docs/user-manual/[F Prime User Manual].
+https://fprime.jpl.nasa.gov/devel/docs/user-manual/[F Prime User Manual].
 
 ==== Time Get Ports
 
@@ -715,7 +715,7 @@ module Fw {
 --------
 
 For further information about time in F Prime, see the
-https://fprime.jpl.nasa.gov/latest/docs/user-manual/[F Prime User Manual].
+https://fprime.jpl.nasa.gov/devel/docs/user-manual/[F Prime User Manual].
 
 ==== Data Product Ports
 
@@ -811,7 +811,7 @@ module Fw {
 --------
 
 For further information about data products in F Prime, see the
-https://fprime.jpl.nasa.gov/latest/docs/user-manual/design/data-products/[F 
+https://fprime.jpl.nasa.gov/devel/docs/user-manual/framework/data-products/[F 
 Prime design documentation].
 
 
@@ -944,7 +944,7 @@ as part of the component implementation.
 
 For complete information about F Prime command dispatch and
 handling, see the
-https://fprime.jpl.nasa.gov/latest/docs/user-manual/[F Prime User Manual].
+https://fprime.jpl.nasa.gov/devel/docs/user-manual/[F Prime User Manual].
 Here we concentrate on how to specify commands in FPP.
 
 ==== Basic Commands
@@ -1271,7 +1271,7 @@ you can store in an on-board file system or send to the ground.
 
 For complete information about F Prime event
 handling, see the
-https://fprime.jpl.nasa.gov/latest/docs/user-manual/[F Prime User Manual].
+https://fprime.jpl.nasa.gov/devel/docs/user-manual/[F Prime User Manual].
 Here we concentrate on how to specify events in FPP.
 
 ==== Basic Events
@@ -1545,7 +1545,7 @@ Once an event is throttled, the component instance will no longer
 emit the event until the throttling is canceled.
 Typically, the canceling happens via a FSW command.
 For details, see the
-https://fprime.jpl.nasa.gov/latest/docs/user-manual/[F Prime User Manual].
+https://fprime.jpl.nasa.gov/devel/docs/user-manual/[F Prime User Manual].
 
 === Telemetry
 
@@ -1562,7 +1562,7 @@ or send them the ground.
 
 For complete information about F Prime telemetry
 handling, see the
-https://fprime.jpl.nasa.gov/latest/docs/user-manual/[F Prime User Manual].
+https://fprime.jpl.nasa.gov/devel/docs/user-manual/[F Prime User Manual].
 Here we concentrate on how to specify telemetry channels in FPP.
 
 ==== Basic Telemetry
@@ -1890,7 +1890,7 @@ F Prime has special support for parameters, including a parameter
 database component for storing parameters in a non-volatile
 manner (e.g., on a file system).
 For complete information about F Prime parameters, see the
-https://fprime.jpl.nasa.gov/latest/docs/user-manual/[F Prime User Manual].
+https://fprime.jpl.nasa.gov/devel/docs/user-manual/[F Prime User Manual].
 Here we concentrate on how to specify parameters in FPP.
 
 ==== Basic Parameters
@@ -2199,7 +2199,7 @@ for (1) managing buffers that can store data products in memory;
 (2) writing data products to the file system; and (3)
 cataloging stored data products for downlink in priority order.
 For more information about these F Prime features, see the
-https://fprime.jpl.nasa.gov/latest/docs/user-manual/design/data-products/[F 
+https://fprime.jpl.nasa.gov/devel/docs/user-manual/framework/data-products/[F 
 Prime design documentation].
 
 ==== Basic Data Products
@@ -2277,7 +2277,7 @@ passive component BasicDataProducts {
 The FPP back end uses this specification to generate code for requesting
 buffers to hold containers and for serializing records into containers.
 See the
-https://fprime.jpl.nasa.gov/latest/docs/user-manual/design/data-products/[F
+https://fprime.jpl.nasa.gov/devel/docs/user-manual/framework/data-products/[F
 Prime design documentation] for the details.
 
 Note the following:
@@ -2497,7 +2497,7 @@ As discussed
 machine definitions may be internal (specified in FPP) or external (specified
 by an external tool).  For more details about the {cpp} code generation for
 instances of internal state machines, see the
-https://fprime.jpl.nasa.gov/latest/docs/user-manual/design/state-machines/[F 
+https://fprime.jpl.nasa.gov/devel/docs/user-manual/framework/state-machines/[F 
 Prime design documentation].
 
 === Constants, Types, Enums, and State Machines

--- a/docs/users-guide/Defining-State-Machines.adoc
+++ b/docs/users-guide/Defining-State-Machines.adoc
@@ -87,7 +87,7 @@ In this manual, we focus on the syntax and high-level behavior
 of FPP state machines.
 For more details about the {cpp} code generation
 for state machines, see the
-https://fprime.jpl.nasa.gov/latest/docs/user-manual/design/state-machines/[F 
+https://fprime.jpl.nasa.gov/devel/docs/user-manual/framework/state-machines/[F 
 Prime design documentation].
 
 === States, Signals, and Transitions
@@ -585,7 +585,7 @@ When _s'_ is handled and _A_ is run, _s_ is placed on the queue.
 After _s'_ is complete, _s_ is dispatched from the queue and handled.
 
 For more details on sending signals to an FPP state machine, see the
-https://fprime.jpl.nasa.gov/latest/docs/user-manual/design/state-machines/[F
+https://fprime.jpl.nasa.gov/devel/docs/user-manual/framework/state-machines/[F
 Prime design documentation].
 
 === More on State Transitions

--- a/docs/users-guide/Introduction.adoc
+++ b/docs/users-guide/Introduction.adoc
@@ -4,7 +4,7 @@ This document describes **F Prime Prime**, also known as FPP or F Double Prime.
 FPP is a modeling language for the
 https://fprime.jpl.nasa.gov[F Prime flight software framework].
 For more detailed information about F Prime, see the
-https://fprime.jpl.nasa.gov/latest/docs/user-manual/[F Prime User Manual].
+https://fprime.jpl.nasa.gov/devel/docs/user-manual/[F Prime User Manual].
 
 The goals of FPP are as follows:
 


### PR DESCRIPTION
* Switch links from `/latest/` to `/devel/`. This is necessary to pick up the new structure of the docs. We will likely keep it going forward, as the FPP docs linked on the FPP wiki are also the latest.
* Make the links conform to the latest structure.

Closes #611.