### PR TITLE
Make generated C++ comply with -Wshadow

### DIFF
--- a/compiler/install
+++ b/compiler/install
@@ -77,7 +77,7 @@ else
 fi
 util=lib/src/main/scala/util
 echo "Updating version to $version"
-sed -i.bak -e "s/val v = .*/val v = \"$version\"/" \
+sed -i.update.bak -e "s/val v = .*/val v = \"$version\"/" \
   $util/Version.scala
 
 echo "Building jar files"
@@ -86,7 +86,8 @@ echo $cmd
 $cmd
 
 echo "Restoring Version.scala"
-cp $util/Version.scala.bak $util/Version.scala
+sed -i.restore.bak -e "s/val v = .*/val v = \"[unknown version]\"/" \
+  $util/Version.scala
 
 mkdir -p $dest
 

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentDataProducts.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentDataProducts.scala
@@ -386,13 +386,13 @@ case class ComponentDataProducts (
             Some("The component base id")
           )
         ),
-        List("Fw::DpContainer(id, buffer)", "baseId(baseId)"),
+        List("Fw::DpContainer(id, buffer)", "m_baseId(baseId)"),
         Nil
       ),
       constructorClassMember(
         Some("Constructor with default initialization"),
         Nil,
-        List("Fw::DpContainer()", "baseId(0)"),
+        List("Fw::DpContainer()", "m_baseId(0)"),
         Nil
       ),
     )
@@ -437,7 +437,7 @@ case class ComponentDataProducts (
         s"""|$computeSizeDelta
             |Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
             |if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-            |  const FwDpIdType id = this->baseId + RecordId::$name;
+            |  const FwDpIdType id = this->m_baseId + RecordId::$name;
             |  status = this->m_dataBuffer.serialize(id);
             |  FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
             |  status = $serialExpr;
@@ -524,7 +524,7 @@ case class ComponentDataProducts (
             |// Serialize the elements if they will fit
             |Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
             |if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-            |  const FwDpIdType id = this->baseId + RecordId::$name;
+            |  const FwDpIdType id = this->m_baseId + RecordId::$name;
             |  status = this->m_dataBuffer.serialize(id);
             |  FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
             |  status = this->m_dataBuffer.serializeSize(size);
@@ -575,9 +575,9 @@ case class ComponentDataProducts (
     private val getAccessFunctionsMember = linesClassMember(
       lines(
         raw"""|
-              |FwDpIdType getBaseId() const { return this->baseId; }
+              |FwDpIdType getBaseId() const { return this->m_baseId; }
               |
-              |void setBaseId(FwDpIdType baseId) { this->baseId = baseId; }"""
+              |void setBaseId(FwDpIdType baseId) { this->m_baseId = baseId; }"""
       )
     )
 
@@ -589,7 +589,7 @@ case class ComponentDataProducts (
       linesClassMember(
         CppDocHppWriter.writeAccessTag("PRIVATE") ++
         CppDocWriter.writeDoxygenComment("The component base id") ++
-        lines("FwDpIdType baseId;")
+        lines("FwDpIdType m_baseId;")
       )
     )
 

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentExternalStateMachines.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentExternalStateMachines.scala
@@ -151,7 +151,7 @@ case class ComponentExternalStateMachines(
   private val writeDeserializeSmVars = lines(
     """|// Deserialize the state machine ID to an FwEnumStoreType
        |FwEnumStoreType enumStoreSmId = 0;
-       |Fw::SerializeStatus deserStatus = msg.deserialize(enumStoreSmId);
+       |deserStatus = msg.deserialize(enumStoreSmId);
        |FW_ASSERT(
        |  deserStatus == Fw::FW_SERIALIZE_OK,
        |  static_cast<FwAssertArgType>(deserStatus)

--- a/compiler/scripts/fprime-gcc
+++ b/compiler/scripts/fprime-gcc
@@ -16,12 +16,20 @@ then
   exit 1
 fi
 
+flags="
+-Wall
+-Wextra
+-Werror
+-Wshadow
+-pedantic
+"
+
 unset os_flags
 os=`uname`
 case "$os" in
   Darwin)
     os_type=DARWIN
-    os_flags='-Wno-nullability-completeness -Wpedantic -ferror-limit=1'
+    os_flags='-Wno-nullability-completeness -ferror-limit=1'
     ;;
   Linux)
     os_type=LINUX
@@ -33,4 +41,4 @@ case "$os" in
 esac
 
 # Removing -Wconversion because of many implicit casts of size type in F Prime
-g++ --std=c++11 -Wall -Wextra $os_flags -DTGT_OS_TYPE_$os_type -I $FPRIME -I $FPRIME/config -I $FPRIME/cmake/platform/types -I . $FPRIME_GCC_FLAGS $@
+g++ --std=c++11 $flags $os_flags -DTGT_OS_TYPE_$os_type -I $FPRIME -I $FPRIME/config -I $FPRIME/cmake/platform/types -I . $FPRIME_GCC_FLAGS $@

--- a/compiler/scripts/fprime-gcc
+++ b/compiler/scripts/fprime-gcc
@@ -18,8 +18,9 @@ fi
 
 flags="
 -Wall
--Wextra
 -Werror
+-Wextra
+-Wold-style-cast
 -Wshadow
 -pedantic
 "

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductsComponentAc.ref.cpp
@@ -80,7 +80,7 @@ ActiveAsyncProductsComponentBase::DpContainer ::
       FwDpIdType baseId
   ) :
     Fw::DpContainer(id, buffer),
-    baseId(baseId)
+    m_baseId(baseId)
 {
 
 }
@@ -88,7 +88,7 @@ ActiveAsyncProductsComponentBase::DpContainer ::
 ActiveAsyncProductsComponentBase::DpContainer ::
   DpContainer() :
     Fw::DpContainer(),
-    baseId(0)
+    m_baseId(0)
 {
 
 }
@@ -108,7 +108,7 @@ Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::DataArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -133,7 +133,7 @@ Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
     ActiveAsyncProducts_Data::SERIALIZED_SIZE;
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::DataRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serialize(elt);
@@ -166,7 +166,7 @@ Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::StringArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -194,7 +194,7 @@ Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
     elt.serializedTruncatedSize(stringSize);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::StringRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = elt.serialize(this->m_dataBuffer, stringSize);
@@ -222,7 +222,7 @@ Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U32ArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -247,7 +247,7 @@ Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
     sizeof(U32);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U32Record;
+    const FwDpIdType id = this->m_baseId + RecordId::U32Record;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serialize(elt);
@@ -275,7 +275,7 @@ Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U8ArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductsComponentAc.ref.hpp
@@ -225,14 +225,14 @@ class ActiveAsyncProductsComponentBase :
             FwSizeType size //!< The array size
         );
 
-        FwDpIdType getBaseId() const { return this->baseId; }
+        FwDpIdType getBaseId() const { return this->m_baseId; }
 
-        void setBaseId(FwDpIdType baseId) { this->baseId = baseId; }
+        void setBaseId(FwDpIdType baseId) { this->m_baseId = baseId; }
 
       PRIVATE:
 
         //! The component base id
-        FwDpIdType baseId;
+        FwDpIdType m_baseId;
 
     };
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveExternalStateMachinesComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveExternalStateMachinesComponentAc.ref.cpp
@@ -536,7 +536,7 @@ namespace ExternalSm {
 
         // Deserialize the state machine ID to an FwEnumStoreType
         FwEnumStoreType enumStoreSmId = 0;
-        Fw::SerializeStatus deserStatus = msg.deserialize(enumStoreSmId);
+        deserStatus = msg.deserialize(enumStoreSmId);
         FW_ASSERT(
           deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(deserStatus)

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveGetProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveGetProductsComponentAc.ref.cpp
@@ -78,7 +78,7 @@ ActiveGetProductsComponentBase::DpContainer ::
       FwDpIdType baseId
   ) :
     Fw::DpContainer(id, buffer),
-    baseId(baseId)
+    m_baseId(baseId)
 {
 
 }
@@ -86,7 +86,7 @@ ActiveGetProductsComponentBase::DpContainer ::
 ActiveGetProductsComponentBase::DpContainer ::
   DpContainer() :
     Fw::DpContainer(),
-    baseId(0)
+    m_baseId(0)
 {
 
 }
@@ -106,7 +106,7 @@ Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::DataArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -131,7 +131,7 @@ Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
     ActiveGetProducts_Data::SERIALIZED_SIZE;
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::DataRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serialize(elt);
@@ -164,7 +164,7 @@ Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::StringArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -192,7 +192,7 @@ Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
     elt.serializedTruncatedSize(stringSize);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::StringRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = elt.serialize(this->m_dataBuffer, stringSize);
@@ -220,7 +220,7 @@ Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U32ArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -245,7 +245,7 @@ Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
     sizeof(U32);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U32Record;
+    const FwDpIdType id = this->m_baseId + RecordId::U32Record;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serialize(elt);
@@ -273,7 +273,7 @@ Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U8ArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveGetProductsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveGetProductsComponentAc.ref.hpp
@@ -223,14 +223,14 @@ class ActiveGetProductsComponentBase :
             FwSizeType size //!< The array size
         );
 
-        FwDpIdType getBaseId() const { return this->baseId; }
+        FwDpIdType getBaseId() const { return this->m_baseId; }
 
-        void setBaseId(FwDpIdType baseId) { this->baseId = baseId; }
+        void setBaseId(FwDpIdType baseId) { this->m_baseId = baseId; }
 
       PRIVATE:
 
         //! The component base id
-        FwDpIdType baseId;
+        FwDpIdType m_baseId;
 
     };
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveGuardedProductsComponentAc.ref.cpp
@@ -78,7 +78,7 @@ ActiveGuardedProductsComponentBase::DpContainer ::
       FwDpIdType baseId
   ) :
     Fw::DpContainer(id, buffer),
-    baseId(baseId)
+    m_baseId(baseId)
 {
 
 }
@@ -86,7 +86,7 @@ ActiveGuardedProductsComponentBase::DpContainer ::
 ActiveGuardedProductsComponentBase::DpContainer ::
   DpContainer() :
     Fw::DpContainer(),
-    baseId(0)
+    m_baseId(0)
 {
 
 }
@@ -106,7 +106,7 @@ Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::DataArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -131,7 +131,7 @@ Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
     ActiveGuardedProducts_Data::SERIALIZED_SIZE;
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::DataRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serialize(elt);
@@ -164,7 +164,7 @@ Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::StringArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -192,7 +192,7 @@ Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
     elt.serializedTruncatedSize(stringSize);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::StringRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = elt.serialize(this->m_dataBuffer, stringSize);
@@ -220,7 +220,7 @@ Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U32ArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -245,7 +245,7 @@ Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
     sizeof(U32);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U32Record;
+    const FwDpIdType id = this->m_baseId + RecordId::U32Record;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serialize(elt);
@@ -273,7 +273,7 @@ Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U8ArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveGuardedProductsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveGuardedProductsComponentAc.ref.hpp
@@ -225,14 +225,14 @@ class ActiveGuardedProductsComponentBase :
             FwSizeType size //!< The array size
         );
 
-        FwDpIdType getBaseId() const { return this->baseId; }
+        FwDpIdType getBaseId() const { return this->m_baseId; }
 
-        void setBaseId(FwDpIdType baseId) { this->baseId = baseId; }
+        void setBaseId(FwDpIdType baseId) { this->m_baseId = baseId; }
 
       PRIVATE:
 
         //! The component base id
-        FwDpIdType baseId;
+        FwDpIdType m_baseId;
 
     };
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSyncProductsComponentAc.ref.cpp
@@ -78,7 +78,7 @@ ActiveSyncProductsComponentBase::DpContainer ::
       FwDpIdType baseId
   ) :
     Fw::DpContainer(id, buffer),
-    baseId(baseId)
+    m_baseId(baseId)
 {
 
 }
@@ -86,7 +86,7 @@ ActiveSyncProductsComponentBase::DpContainer ::
 ActiveSyncProductsComponentBase::DpContainer ::
   DpContainer() :
     Fw::DpContainer(),
-    baseId(0)
+    m_baseId(0)
 {
 
 }
@@ -106,7 +106,7 @@ Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::DataArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -131,7 +131,7 @@ Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
     ActiveSyncProducts_Data::SERIALIZED_SIZE;
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::DataRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serialize(elt);
@@ -164,7 +164,7 @@ Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::StringArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -192,7 +192,7 @@ Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
     elt.serializedTruncatedSize(stringSize);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::StringRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = elt.serialize(this->m_dataBuffer, stringSize);
@@ -220,7 +220,7 @@ Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U32ArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -245,7 +245,7 @@ Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
     sizeof(U32);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U32Record;
+    const FwDpIdType id = this->m_baseId + RecordId::U32Record;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serialize(elt);
@@ -273,7 +273,7 @@ Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U8ArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSyncProductsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSyncProductsComponentAc.ref.hpp
@@ -225,14 +225,14 @@ class ActiveSyncProductsComponentBase :
             FwSizeType size //!< The array size
         );
 
-        FwDpIdType getBaseId() const { return this->baseId; }
+        FwDpIdType getBaseId() const { return this->m_baseId; }
 
-        void setBaseId(FwDpIdType baseId) { this->baseId = baseId; }
+        void setBaseId(FwDpIdType baseId) { this->m_baseId = baseId; }
 
       PRIVATE:
 
         //! The component base id
-        FwDpIdType baseId;
+        FwDpIdType m_baseId;
 
     };
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
@@ -116,7 +116,7 @@ namespace M {
         FwDpIdType baseId
     ) :
       Fw::DpContainer(id, buffer),
-      baseId(baseId)
+      m_baseId(baseId)
   {
 
   }
@@ -124,7 +124,7 @@ namespace M {
   ActiveTestComponentBase::DpContainer ::
     DpContainer() :
       Fw::DpContainer(),
-      baseId(0)
+      m_baseId(0)
   {
 
   }
@@ -144,7 +144,7 @@ namespace M {
     // Serialize the elements if they will fit
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-      const FwDpIdType id = this->baseId + RecordId::DataArrayRecord;
+      const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
       status = this->m_dataBuffer.serialize(id);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
       status = this->m_dataBuffer.serializeSize(size);
@@ -169,7 +169,7 @@ namespace M {
       M::ActiveTest_Data::SERIALIZED_SIZE;
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-      const FwDpIdType id = this->baseId + RecordId::DataRecord;
+      const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
       status = this->m_dataBuffer.serialize(id);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
       status = this->m_dataBuffer.serialize(elt);
@@ -202,7 +202,7 @@ namespace M {
     // Serialize the elements if they will fit
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-      const FwDpIdType id = this->baseId + RecordId::StringArrayRecord;
+      const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
       status = this->m_dataBuffer.serialize(id);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
       status = this->m_dataBuffer.serializeSize(size);
@@ -230,7 +230,7 @@ namespace M {
       elt.serializedTruncatedSize(stringSize);
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-      const FwDpIdType id = this->baseId + RecordId::StringRecord;
+      const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
       status = this->m_dataBuffer.serialize(id);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
       status = elt.serialize(this->m_dataBuffer, stringSize);
@@ -258,7 +258,7 @@ namespace M {
     // Serialize the elements if they will fit
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-      const FwDpIdType id = this->baseId + RecordId::U32ArrayRecord;
+      const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
       status = this->m_dataBuffer.serialize(id);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
       status = this->m_dataBuffer.serializeSize(size);
@@ -283,7 +283,7 @@ namespace M {
       sizeof(U32);
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-      const FwDpIdType id = this->baseId + RecordId::U32Record;
+      const FwDpIdType id = this->m_baseId + RecordId::U32Record;
       status = this->m_dataBuffer.serialize(id);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
       status = this->m_dataBuffer.serialize(elt);
@@ -311,7 +311,7 @@ namespace M {
     // Serialize the elements if they will fit
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-      const FwDpIdType id = this->baseId + RecordId::U8ArrayRecord;
+      const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
       status = this->m_dataBuffer.serialize(id);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
       status = this->m_dataBuffer.serializeSize(size);

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.hpp
@@ -312,14 +312,14 @@ namespace M {
               FwSizeType size //!< The array size
           );
 
-          FwDpIdType getBaseId() const { return this->baseId; }
+          FwDpIdType getBaseId() const { return this->m_baseId; }
 
-          void setBaseId(FwDpIdType baseId) { this->baseId = baseId; }
+          void setBaseId(FwDpIdType baseId) { this->m_baseId = baseId; }
 
         PRIVATE:
 
           //! The component base id
-          FwDpIdType baseId;
+          FwDpIdType m_baseId;
 
       };
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveGetProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveGetProductsComponentAc.ref.cpp
@@ -22,7 +22,7 @@ PassiveGetProductsComponentBase::DpContainer ::
       FwDpIdType baseId
   ) :
     Fw::DpContainer(id, buffer),
-    baseId(baseId)
+    m_baseId(baseId)
 {
 
 }
@@ -30,7 +30,7 @@ PassiveGetProductsComponentBase::DpContainer ::
 PassiveGetProductsComponentBase::DpContainer ::
   DpContainer() :
     Fw::DpContainer(),
-    baseId(0)
+    m_baseId(0)
 {
 
 }
@@ -50,7 +50,7 @@ Fw::SerializeStatus PassiveGetProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::DataArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -75,7 +75,7 @@ Fw::SerializeStatus PassiveGetProductsComponentBase::DpContainer ::
     PassiveGetProducts_Data::SERIALIZED_SIZE;
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::DataRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serialize(elt);
@@ -108,7 +108,7 @@ Fw::SerializeStatus PassiveGetProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::StringArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -136,7 +136,7 @@ Fw::SerializeStatus PassiveGetProductsComponentBase::DpContainer ::
     elt.serializedTruncatedSize(stringSize);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::StringRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = elt.serialize(this->m_dataBuffer, stringSize);
@@ -164,7 +164,7 @@ Fw::SerializeStatus PassiveGetProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U32ArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -189,7 +189,7 @@ Fw::SerializeStatus PassiveGetProductsComponentBase::DpContainer ::
     sizeof(U32);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U32Record;
+    const FwDpIdType id = this->m_baseId + RecordId::U32Record;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serialize(elt);
@@ -217,7 +217,7 @@ Fw::SerializeStatus PassiveGetProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U8ArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveGetProductsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveGetProductsComponentAc.ref.hpp
@@ -218,14 +218,14 @@ class PassiveGetProductsComponentBase :
             FwSizeType size //!< The array size
         );
 
-        FwDpIdType getBaseId() const { return this->baseId; }
+        FwDpIdType getBaseId() const { return this->m_baseId; }
 
-        void setBaseId(FwDpIdType baseId) { this->baseId = baseId; }
+        void setBaseId(FwDpIdType baseId) { this->m_baseId = baseId; }
 
       PRIVATE:
 
         //! The component base id
-        FwDpIdType baseId;
+        FwDpIdType m_baseId;
 
     };
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveGuardedProductsComponentAc.ref.cpp
@@ -22,7 +22,7 @@ PassiveGuardedProductsComponentBase::DpContainer ::
       FwDpIdType baseId
   ) :
     Fw::DpContainer(id, buffer),
-    baseId(baseId)
+    m_baseId(baseId)
 {
 
 }
@@ -30,7 +30,7 @@ PassiveGuardedProductsComponentBase::DpContainer ::
 PassiveGuardedProductsComponentBase::DpContainer ::
   DpContainer() :
     Fw::DpContainer(),
-    baseId(0)
+    m_baseId(0)
 {
 
 }
@@ -50,7 +50,7 @@ Fw::SerializeStatus PassiveGuardedProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::DataArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -75,7 +75,7 @@ Fw::SerializeStatus PassiveGuardedProductsComponentBase::DpContainer ::
     PassiveGuardedProducts_Data::SERIALIZED_SIZE;
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::DataRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serialize(elt);
@@ -108,7 +108,7 @@ Fw::SerializeStatus PassiveGuardedProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::StringArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -136,7 +136,7 @@ Fw::SerializeStatus PassiveGuardedProductsComponentBase::DpContainer ::
     elt.serializedTruncatedSize(stringSize);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::StringRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = elt.serialize(this->m_dataBuffer, stringSize);
@@ -164,7 +164,7 @@ Fw::SerializeStatus PassiveGuardedProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U32ArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -189,7 +189,7 @@ Fw::SerializeStatus PassiveGuardedProductsComponentBase::DpContainer ::
     sizeof(U32);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U32Record;
+    const FwDpIdType id = this->m_baseId + RecordId::U32Record;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serialize(elt);
@@ -217,7 +217,7 @@ Fw::SerializeStatus PassiveGuardedProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U8ArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveGuardedProductsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveGuardedProductsComponentAc.ref.hpp
@@ -220,14 +220,14 @@ class PassiveGuardedProductsComponentBase :
             FwSizeType size //!< The array size
         );
 
-        FwDpIdType getBaseId() const { return this->baseId; }
+        FwDpIdType getBaseId() const { return this->m_baseId; }
 
-        void setBaseId(FwDpIdType baseId) { this->baseId = baseId; }
+        void setBaseId(FwDpIdType baseId) { this->m_baseId = baseId; }
 
       PRIVATE:
 
         //! The component base id
-        FwDpIdType baseId;
+        FwDpIdType m_baseId;
 
     };
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductsComponentAc.ref.cpp
@@ -22,7 +22,7 @@ PassiveSyncProductsComponentBase::DpContainer ::
       FwDpIdType baseId
   ) :
     Fw::DpContainer(id, buffer),
-    baseId(baseId)
+    m_baseId(baseId)
 {
 
 }
@@ -30,7 +30,7 @@ PassiveSyncProductsComponentBase::DpContainer ::
 PassiveSyncProductsComponentBase::DpContainer ::
   DpContainer() :
     Fw::DpContainer(),
-    baseId(0)
+    m_baseId(0)
 {
 
 }
@@ -50,7 +50,7 @@ Fw::SerializeStatus PassiveSyncProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::DataArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -75,7 +75,7 @@ Fw::SerializeStatus PassiveSyncProductsComponentBase::DpContainer ::
     PassiveSyncProducts_Data::SERIALIZED_SIZE;
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::DataRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serialize(elt);
@@ -108,7 +108,7 @@ Fw::SerializeStatus PassiveSyncProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::StringArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -136,7 +136,7 @@ Fw::SerializeStatus PassiveSyncProductsComponentBase::DpContainer ::
     elt.serializedTruncatedSize(stringSize);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::StringRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = elt.serialize(this->m_dataBuffer, stringSize);
@@ -164,7 +164,7 @@ Fw::SerializeStatus PassiveSyncProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U32ArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -189,7 +189,7 @@ Fw::SerializeStatus PassiveSyncProductsComponentBase::DpContainer ::
     sizeof(U32);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U32Record;
+    const FwDpIdType id = this->m_baseId + RecordId::U32Record;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serialize(elt);
@@ -217,7 +217,7 @@ Fw::SerializeStatus PassiveSyncProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U8ArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductsComponentAc.ref.hpp
@@ -220,14 +220,14 @@ class PassiveSyncProductsComponentBase :
             FwSizeType size //!< The array size
         );
 
-        FwDpIdType getBaseId() const { return this->baseId; }
+        FwDpIdType getBaseId() const { return this->m_baseId; }
 
-        void setBaseId(FwDpIdType baseId) { this->baseId = baseId; }
+        void setBaseId(FwDpIdType baseId) { this->m_baseId = baseId; }
 
       PRIVATE:
 
         //! The component base id
-        FwDpIdType baseId;
+        FwDpIdType m_baseId;
 
     };
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
@@ -22,7 +22,7 @@ PassiveTestComponentBase::DpContainer ::
       FwDpIdType baseId
   ) :
     Fw::DpContainer(id, buffer),
-    baseId(baseId)
+    m_baseId(baseId)
 {
 
 }
@@ -30,7 +30,7 @@ PassiveTestComponentBase::DpContainer ::
 PassiveTestComponentBase::DpContainer ::
   DpContainer() :
     Fw::DpContainer(),
-    baseId(0)
+    m_baseId(0)
 {
 
 }
@@ -50,7 +50,7 @@ Fw::SerializeStatus PassiveTestComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::DataArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -75,7 +75,7 @@ Fw::SerializeStatus PassiveTestComponentBase::DpContainer ::
     PassiveTest_Data::SERIALIZED_SIZE;
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::DataRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serialize(elt);
@@ -108,7 +108,7 @@ Fw::SerializeStatus PassiveTestComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::StringArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -136,7 +136,7 @@ Fw::SerializeStatus PassiveTestComponentBase::DpContainer ::
     elt.serializedTruncatedSize(stringSize);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::StringRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = elt.serialize(this->m_dataBuffer, stringSize);
@@ -164,7 +164,7 @@ Fw::SerializeStatus PassiveTestComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U32ArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -189,7 +189,7 @@ Fw::SerializeStatus PassiveTestComponentBase::DpContainer ::
     sizeof(U32);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U32Record;
+    const FwDpIdType id = this->m_baseId + RecordId::U32Record;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serialize(elt);
@@ -217,7 +217,7 @@ Fw::SerializeStatus PassiveTestComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U8ArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.hpp
@@ -299,14 +299,14 @@ class PassiveTestComponentBase :
             FwSizeType size //!< The array size
         );
 
-        FwDpIdType getBaseId() const { return this->baseId; }
+        FwDpIdType getBaseId() const { return this->m_baseId; }
 
-        void setBaseId(FwDpIdType baseId) { this->baseId = baseId; }
+        void setBaseId(FwDpIdType baseId) { this->m_baseId = baseId; }
 
       PRIVATE:
 
         //! The component base id
-        FwDpIdType baseId;
+        FwDpIdType m_baseId;
 
     };
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductsComponentAc.ref.cpp
@@ -80,7 +80,7 @@ QueuedAsyncProductsComponentBase::DpContainer ::
       FwDpIdType baseId
   ) :
     Fw::DpContainer(id, buffer),
-    baseId(baseId)
+    m_baseId(baseId)
 {
 
 }
@@ -88,7 +88,7 @@ QueuedAsyncProductsComponentBase::DpContainer ::
 QueuedAsyncProductsComponentBase::DpContainer ::
   DpContainer() :
     Fw::DpContainer(),
-    baseId(0)
+    m_baseId(0)
 {
 
 }
@@ -108,7 +108,7 @@ Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::DataArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -133,7 +133,7 @@ Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
     QueuedAsyncProducts_Data::SERIALIZED_SIZE;
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::DataRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serialize(elt);
@@ -166,7 +166,7 @@ Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::StringArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -194,7 +194,7 @@ Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
     elt.serializedTruncatedSize(stringSize);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::StringRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = elt.serialize(this->m_dataBuffer, stringSize);
@@ -222,7 +222,7 @@ Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U32ArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -247,7 +247,7 @@ Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
     sizeof(U32);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U32Record;
+    const FwDpIdType id = this->m_baseId + RecordId::U32Record;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serialize(elt);
@@ -275,7 +275,7 @@ Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U8ArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductsComponentAc.ref.hpp
@@ -225,14 +225,14 @@ class QueuedAsyncProductsComponentBase :
             FwSizeType size //!< The array size
         );
 
-        FwDpIdType getBaseId() const { return this->baseId; }
+        FwDpIdType getBaseId() const { return this->m_baseId; }
 
-        void setBaseId(FwDpIdType baseId) { this->baseId = baseId; }
+        void setBaseId(FwDpIdType baseId) { this->m_baseId = baseId; }
 
       PRIVATE:
 
         //! The component base id
-        FwDpIdType baseId;
+        FwDpIdType m_baseId;
 
     };
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedGetProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedGetProductsComponentAc.ref.cpp
@@ -78,7 +78,7 @@ QueuedGetProductsComponentBase::DpContainer ::
       FwDpIdType baseId
   ) :
     Fw::DpContainer(id, buffer),
-    baseId(baseId)
+    m_baseId(baseId)
 {
 
 }
@@ -86,7 +86,7 @@ QueuedGetProductsComponentBase::DpContainer ::
 QueuedGetProductsComponentBase::DpContainer ::
   DpContainer() :
     Fw::DpContainer(),
-    baseId(0)
+    m_baseId(0)
 {
 
 }
@@ -106,7 +106,7 @@ Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::DataArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -131,7 +131,7 @@ Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
     QueuedGetProducts_Data::SERIALIZED_SIZE;
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::DataRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serialize(elt);
@@ -164,7 +164,7 @@ Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::StringArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -192,7 +192,7 @@ Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
     elt.serializedTruncatedSize(stringSize);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::StringRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = elt.serialize(this->m_dataBuffer, stringSize);
@@ -220,7 +220,7 @@ Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U32ArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -245,7 +245,7 @@ Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
     sizeof(U32);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U32Record;
+    const FwDpIdType id = this->m_baseId + RecordId::U32Record;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serialize(elt);
@@ -273,7 +273,7 @@ Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U8ArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedGetProductsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedGetProductsComponentAc.ref.hpp
@@ -223,14 +223,14 @@ class QueuedGetProductsComponentBase :
             FwSizeType size //!< The array size
         );
 
-        FwDpIdType getBaseId() const { return this->baseId; }
+        FwDpIdType getBaseId() const { return this->m_baseId; }
 
-        void setBaseId(FwDpIdType baseId) { this->baseId = baseId; }
+        void setBaseId(FwDpIdType baseId) { this->m_baseId = baseId; }
 
       PRIVATE:
 
         //! The component base id
-        FwDpIdType baseId;
+        FwDpIdType m_baseId;
 
     };
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedGuardedProductsComponentAc.ref.cpp
@@ -78,7 +78,7 @@ QueuedGuardedProductsComponentBase::DpContainer ::
       FwDpIdType baseId
   ) :
     Fw::DpContainer(id, buffer),
-    baseId(baseId)
+    m_baseId(baseId)
 {
 
 }
@@ -86,7 +86,7 @@ QueuedGuardedProductsComponentBase::DpContainer ::
 QueuedGuardedProductsComponentBase::DpContainer ::
   DpContainer() :
     Fw::DpContainer(),
-    baseId(0)
+    m_baseId(0)
 {
 
 }
@@ -106,7 +106,7 @@ Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::DataArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -131,7 +131,7 @@ Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
     QueuedGuardedProducts_Data::SERIALIZED_SIZE;
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::DataRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serialize(elt);
@@ -164,7 +164,7 @@ Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::StringArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -192,7 +192,7 @@ Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
     elt.serializedTruncatedSize(stringSize);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::StringRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = elt.serialize(this->m_dataBuffer, stringSize);
@@ -220,7 +220,7 @@ Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U32ArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -245,7 +245,7 @@ Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
     sizeof(U32);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U32Record;
+    const FwDpIdType id = this->m_baseId + RecordId::U32Record;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serialize(elt);
@@ -273,7 +273,7 @@ Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U8ArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedGuardedProductsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedGuardedProductsComponentAc.ref.hpp
@@ -225,14 +225,14 @@ class QueuedGuardedProductsComponentBase :
             FwSizeType size //!< The array size
         );
 
-        FwDpIdType getBaseId() const { return this->baseId; }
+        FwDpIdType getBaseId() const { return this->m_baseId; }
 
-        void setBaseId(FwDpIdType baseId) { this->baseId = baseId; }
+        void setBaseId(FwDpIdType baseId) { this->m_baseId = baseId; }
 
       PRIVATE:
 
         //! The component base id
-        FwDpIdType baseId;
+        FwDpIdType m_baseId;
 
     };
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSyncProductsComponentAc.ref.cpp
@@ -78,7 +78,7 @@ QueuedSyncProductsComponentBase::DpContainer ::
       FwDpIdType baseId
   ) :
     Fw::DpContainer(id, buffer),
-    baseId(baseId)
+    m_baseId(baseId)
 {
 
 }
@@ -86,7 +86,7 @@ QueuedSyncProductsComponentBase::DpContainer ::
 QueuedSyncProductsComponentBase::DpContainer ::
   DpContainer() :
     Fw::DpContainer(),
-    baseId(0)
+    m_baseId(0)
 {
 
 }
@@ -106,7 +106,7 @@ Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::DataArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -131,7 +131,7 @@ Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
     QueuedSyncProducts_Data::SERIALIZED_SIZE;
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::DataRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serialize(elt);
@@ -164,7 +164,7 @@ Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::StringArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -192,7 +192,7 @@ Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
     elt.serializedTruncatedSize(stringSize);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::StringRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = elt.serialize(this->m_dataBuffer, stringSize);
@@ -220,7 +220,7 @@ Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U32ArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -245,7 +245,7 @@ Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
     sizeof(U32);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U32Record;
+    const FwDpIdType id = this->m_baseId + RecordId::U32Record;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serialize(elt);
@@ -273,7 +273,7 @@ Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U8ArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSyncProductsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSyncProductsComponentAc.ref.hpp
@@ -225,14 +225,14 @@ class QueuedSyncProductsComponentBase :
             FwSizeType size //!< The array size
         );
 
-        FwDpIdType getBaseId() const { return this->baseId; }
+        FwDpIdType getBaseId() const { return this->m_baseId; }
 
-        void setBaseId(FwDpIdType baseId) { this->baseId = baseId; }
+        void setBaseId(FwDpIdType baseId) { this->m_baseId = baseId; }
 
       PRIVATE:
 
         //! The component base id
-        FwDpIdType baseId;
+        FwDpIdType m_baseId;
 
     };
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
@@ -114,7 +114,7 @@ QueuedTestComponentBase::DpContainer ::
       FwDpIdType baseId
   ) :
     Fw::DpContainer(id, buffer),
-    baseId(baseId)
+    m_baseId(baseId)
 {
 
 }
@@ -122,7 +122,7 @@ QueuedTestComponentBase::DpContainer ::
 QueuedTestComponentBase::DpContainer ::
   DpContainer() :
     Fw::DpContainer(),
-    baseId(0)
+    m_baseId(0)
 {
 
 }
@@ -142,7 +142,7 @@ Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::DataArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -167,7 +167,7 @@ Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
     QueuedTest_Data::SERIALIZED_SIZE;
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::DataRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serialize(elt);
@@ -200,7 +200,7 @@ Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::StringArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -228,7 +228,7 @@ Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
     elt.serializedTruncatedSize(stringSize);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::StringRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = elt.serialize(this->m_dataBuffer, stringSize);
@@ -256,7 +256,7 @@ Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U32ArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);
@@ -281,7 +281,7 @@ Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
     sizeof(U32);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U32Record;
+    const FwDpIdType id = this->m_baseId + RecordId::U32Record;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serialize(elt);
@@ -309,7 +309,7 @@ Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
   // Serialize the elements if they will fit
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
-    const FwDpIdType id = this->baseId + RecordId::U8ArrayRecord;
+    const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     status = this->m_dataBuffer.serializeSize(size);

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.hpp
@@ -310,14 +310,14 @@ class QueuedTestComponentBase :
             FwSizeType size //!< The array size
         );
 
-        FwDpIdType getBaseId() const { return this->baseId; }
+        FwDpIdType getBaseId() const { return this->m_baseId; }
 
-        void setBaseId(FwDpIdType baseId) { this->baseId = baseId; }
+        void setBaseId(FwDpIdType baseId) { this->m_baseId = baseId; }
 
       PRIVATE:
 
         //! The component base id
-        FwDpIdType baseId;
+        FwDpIdType m_baseId;
 
     };
 


### PR DESCRIPTION
Also

* Revise install script so that it restores `Version.scala` properly, even if the version stamp is corrupted
* Revise `fprime-gcc` script to add warnings

Closes #613.