### PR TITLE
Fix compilation error in fpp-to-cpp tests

### DIFF
--- a/compiler/tools/fpp-to-cpp/test/struct/AliasTypeSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/AliasTypeSerializableAc.ref.cpp
@@ -14,20 +14,20 @@
 AliasType ::
   AliasType() :
     Serializable(),
-    m_t(0),
-    m_ta()
+    m_x(0),
+    m_y()
 {
 
 }
 
 AliasType ::
   AliasType(
-      U16 t,
-      const AbT& ta
+      U16 x,
+      const T& y
   ) :
     Serializable(),
-    m_t(t),
-    m_ta(ta)
+    m_x(x),
+    m_y(y)
 {
 
 }
@@ -35,8 +35,8 @@ AliasType ::
 AliasType ::
   AliasType(const AliasType& obj) :
     Serializable(),
-    m_t(obj.m_t),
-    m_ta(obj.m_ta)
+    m_x(obj.m_x),
+    m_y(obj.m_y)
 {
 
 }
@@ -52,7 +52,7 @@ AliasType& AliasType ::
     return *this;
   }
 
-  set(obj.m_t, obj.m_ta);
+  set(obj.m_x, obj.m_y);
   return *this;
 }
 
@@ -60,8 +60,8 @@ bool AliasType ::
   operator==(const AliasType& obj) const
 {
   return (
-    (this->m_t == obj.m_t) &&
-    (this->m_ta == obj.m_ta)
+    (this->m_x == obj.m_x) &&
+    (this->m_y == obj.m_y)
   );
 }
 
@@ -91,11 +91,11 @@ Fw::SerializeStatus AliasType ::
 {
   Fw::SerializeStatus status;
 
-  status = buffer.serialize(this->m_t);
+  status = buffer.serialize(this->m_x);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_ta);
+  status = buffer.serialize(this->m_y);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
@@ -108,11 +108,11 @@ Fw::SerializeStatus AliasType ::
 {
   Fw::SerializeStatus status;
 
-  status = buffer.deserialize(this->m_t);
+  status = buffer.deserialize(this->m_x);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_ta);
+  status = buffer.deserialize(this->m_y);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
@@ -127,20 +127,20 @@ void AliasType ::
 {
   static const char* formatString =
     "( "
-    "t = %s, "
-    "ta = %s"
+    "x = %s, "
+    "y = %s"
     " )";
 
   // Declare strings to hold any serializable toString() arguments
-  Fw::String taStr;
+  Fw::String yStr;
 
   // Call toString for arrays and serializable types
-  this->m_ta.toString(taStr);
+  this->m_y.toString(yStr);
 
   sb.format(
     formatString,
-    this->m_t,
-    taStr.toChar()
+    this->m_x,
+    yStr.toChar()
   );
 }
 
@@ -152,22 +152,22 @@ void AliasType ::
 
 void AliasType ::
   set(
-      U16 t,
-      const AbT& ta
+      U16 x,
+      const T& y
   )
 {
-  this->m_t = t;
-  this->m_ta = ta;
+  this->m_x = x;
+  this->m_y = y;
 }
 
 void AliasType ::
-  sett(U16 t)
+  setx(U16 x)
 {
-  this->m_t = t;
+  this->m_x = x;
 }
 
 void AliasType ::
-  setta(const AbT& ta)
+  sety(const T& y)
 {
-  this->m_ta = ta;
+  this->m_y = y;
 }

--- a/compiler/tools/fpp-to-cpp/test/struct/AliasTypeSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/AliasTypeSerializableAc.ref.hpp
@@ -7,11 +7,11 @@
 #ifndef AliasTypeSerializableAc_HPP
 #define AliasTypeSerializableAc_HPP
 
-#include "AbT.hpp"
 #include "FpConfig.hpp"
 #include "Fw/Types/ExternalString.hpp"
 #include "Fw/Types/Serializable.hpp"
 #include "Fw/Types/String.hpp"
+#include "T.hpp"
 
 class AliasType :
   public Fw::Serializable
@@ -27,7 +27,7 @@ class AliasType :
       //! The size of the serial representation
       SERIALIZED_SIZE =
         sizeof(U16) +
-        AbT::SERIALIZED_SIZE
+        T::SERIALIZED_SIZE
     };
 
   public:
@@ -41,8 +41,8 @@ class AliasType :
 
     //! Member constructor
     AliasType(
-        U16 t,
-        const AbT& ta
+        U16 x,
+        const T& y
     );
 
     //! Copy constructor
@@ -110,22 +110,22 @@ class AliasType :
     // Getter functions
     // ----------------------------------------------------------------------
 
-    //! Get member t
-    U16 gett() const
+    //! Get member x
+    U16 getx() const
     {
-      return this->m_t;
+      return this->m_x;
     }
 
-    //! Get member ta
-    AbT& getta()
+    //! Get member y
+    T& gety()
     {
-      return this->m_ta;
+      return this->m_y;
     }
 
-    //! Get member ta (const)
-    const AbT& getta() const
+    //! Get member y (const)
+    const T& gety() const
     {
-      return this->m_ta;
+      return this->m_y;
     }
 
     // ----------------------------------------------------------------------
@@ -134,15 +134,15 @@ class AliasType :
 
     //! Set all members
     void set(
-        U16 t,
-        const AbT& ta
+        U16 x,
+        const T& y
     );
 
-    //! Set member t
-    void sett(U16 t);
+    //! Set member x
+    void setx(U16 x);
 
-    //! Set member ta
-    void setta(const AbT& ta);
+    //! Set member y
+    void sety(const T& y);
 
   protected:
 
@@ -150,8 +150,8 @@ class AliasType :
     // Member variables
     // ----------------------------------------------------------------------
 
-    U16 m_t;
-    AbT m_ta;
+    U16 m_x;
+    T m_y;
 
 };
 

--- a/compiler/tools/fpp-to-cpp/test/struct/alias_type.fpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/alias_type.fpp
@@ -1,4 +1,4 @@
-type T = U16
-type AbT
-type TA = AbT
-struct AliasType { t: T, ta: TA }
+type U16Alias = U16
+type T
+type TAlias = T
+struct AliasType { x: U16Alias, y: TAlias }


### PR DESCRIPTION
After merging #591, `check-cpp` broke for the struct tests. The fix is to use the name `T` for the abstract type definition, so that the included header file is `T.hpp`, which is available in the test environment. The name that was being used was not available.