### PR TITLE
Improve quality of generated C++

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/ArrayCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ArrayCppWriter.scala
@@ -423,7 +423,7 @@ case class ArrayCppWriter (
       else s"str$i.toChar()"
     val formatArgs = lines(
       List.range(0, arraySize).map(
-        writeFormatArg(eltType) compose getFormatArg
+        promoteF32ToU64(eltType) compose getFormatArg
       ).mkString(",\n")
     )
 

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ArrayCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ArrayCppWriter.scala
@@ -423,7 +423,7 @@ case class ArrayCppWriter (
       else s"str$i.toChar()"
     val formatArgs = lines(
       List.range(0, arraySize).map(
-        promoteF32ToU64(eltType) compose getFormatArg
+        promoteF32ToF64(eltType) compose getFormatArg
       ).mkString(",\n")
     )
 

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ArrayCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ArrayCppWriter.scala
@@ -417,13 +417,15 @@ case class ArrayCppWriter (
         List(Line.blank),
       ).flatten
     // Write format arguments in toString()
-    val formatArgs =
-      if hasPrimitiveEltType then
-        lines(List.range(0, arraySize).map(i => s"this->elements[$i]").mkString(",\n"))
-      else if hasStringEltType then
-        lines(List.range(0, arraySize).map(i => s"this->elements[$i].toChar()").mkString(",\n"))
-      else
-          lines(List.range(0, arraySize).map(i => s"str$i.toChar()").mkString(",\n"))
+    def getFormatArg(i: Int) =
+      if hasPrimitiveEltType then s"this->elements[$i]"
+      else if hasStringEltType then s"this->elements[$i].toChar()"
+      else s"str$i.toChar()"
+    val formatArgs = lines(
+      List.range(0, arraySize).map(
+        writeFormatArg(eltType) compose getFormatArg
+      ).mkString(",\n")
+    )
 
     List(
       linesClassMember(

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriter.scala
@@ -635,7 +635,10 @@ case class ComponentCppWriter (
         case PortInstance.Type.Serial => lines(
           s"""|// Deserialize serialized buffer into new buffer
               |U8 handBuff[this->m_msgSize];
-              |Fw::ExternalSerializeBuffer serHandBuff(handBuff,this->m_msgSize);
+              |Fw::ExternalSerializeBuffer serHandBuff(
+              |  handBuff,
+              |  static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+              |);
               |deserStatus = msg.deserialize(serHandBuff);
               |FW_ASSERT(
               |  deserStatus == Fw::FW_SERIALIZE_OK,
@@ -814,7 +817,10 @@ case class ComponentCppWriter (
             List(
               if hasSerialAsyncInputPorts then lines(
                 """|U8 msgBuff[this->m_msgSize];
-                   |Fw::ExternalSerializeBuffer msg(msgBuff,this->m_msgSize);
+                   |Fw::ExternalSerializeBuffer msg(
+                   |  msgBuff,
+                   |  static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+                   |);
                    |"""
               )
               else lines("ComponentIpcSerializableBuffer msg;"),

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentDataProducts.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentDataProducts.scala
@@ -248,7 +248,11 @@ case class ComponentDataProducts (
               """|DpContainer container(id, buffer, this->getIdBase());
                  |// Convert global id to local id
                  |const FwDpIdType idBase = this->getIdBase();
-                 |FW_ASSERT(id >= idBase, id, idBase);
+                 |FW_ASSERT(
+                 |  id >= idBase,
+                 |  static_cast<FwAssertArgType>(id),
+                 |  static_cast<FwAssertArgType>(idBase)
+                 |);
                  |const FwDpIdType localId = id - idBase;
                  |// Switch on the local id"""
             ),
@@ -439,9 +443,9 @@ case class ComponentDataProducts (
             |if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
             |  const FwDpIdType id = this->m_baseId + RecordId::$name;
             |  status = this->m_dataBuffer.serialize(id);
-            |  FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+            |  FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
             |  status = $serialExpr;
-            |  FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+            |  FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
             |  this->m_dataSize += sizeDelta;
             |}
             |else {
@@ -500,20 +504,20 @@ case class ComponentDataProducts (
         // Optimize the U8 case
         case Type.U8 =>
           """|  status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
-             |  FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);"""
+             |  FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));"""
         // Handle the string case
         case ts: Type.String =>
           s"""|  for (FwSizeType i = 0; i < size; i++) {
               |    const Fw::StringBase *const sbPtr = array[i];
               |    FW_ASSERT(sbPtr != nullptr);
               |    status = sbPtr->serialize(this->m_dataBuffer, stringSize);
-              |    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+              |    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
               |  }"""
         // Handle the general case
         case _ =>
           """|  for (FwSizeType i = 0; i < size; i++) {
              |    status = this->m_dataBuffer.serialize(array[i]);
-             |    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+             |    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
              |  }"""
       }).stripMargin
       // Construct the function body
@@ -526,9 +530,9 @@ case class ComponentDataProducts (
             |if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
             |  const FwDpIdType id = this->m_baseId + RecordId::$name;
             |  status = this->m_dataBuffer.serialize(id);
-            |  FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+            |  FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
             |  status = this->m_dataBuffer.serializeSize(size);
-            |  FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+            |  FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
             |$serializeElts
             |  this->m_dataSize += sizeDelta;
             |}

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentEvents.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentEvents.scala
@@ -223,7 +223,7 @@ case class ComponentEvents (
                     s.a.typeMap(param._2.data.typeName.id) match {
                       case Type.String(_) => s"$name.toChar()"
                       case t if s.isPrimitive(t, writeFormalParamType(param._2.data)) =>
-                        promoteF32ToU64 (t) (name)
+                        promoteF32ToF64 (t) (name)
                       case _ => s"${name}Str.toChar()"
                     }
                   })).mkString(",\n")

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentEvents.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentEvents.scala
@@ -222,7 +222,8 @@ case class ComponentEvents (
                     val name = param._2.data.name
                     s.a.typeMap(param._2.data.typeName.id) match {
                       case Type.String(_) => s"$name.toChar()"
-                      case t if s.isPrimitive(t, writeFormalParamType(param._2.data)) => name
+                      case t if s.isPrimitive(t, writeFormalParamType(param._2.data)) =>
+                        promoteF32ToU64 (t) (name)
                       case _ => s"${name}Str.toChar()"
                     }
                   })).mkString(",\n")

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentInputPorts.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentInputPorts.scala
@@ -124,7 +124,10 @@ case class ComponentInputPorts(
             case PortInstance.Type.Serial => lines(
               s"""|// Declare buffer for ${p.getUnqualifiedName}
                   |U8 msgBuff[this->m_msgSize];
-                  |Fw::ExternalSerializeBuffer $bufferName(msgBuff, this->m_msgSize);
+                  |Fw::ExternalSerializeBuffer $bufferName(
+                  |  msgBuff,
+                  |  static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+                  |);
                   |Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
                   |"""
             )

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentTesterBaseWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentTesterBaseWriter.scala
@@ -807,7 +807,11 @@ case class ComponentTesterBaseWriter(
                 val length = params.length
                 event.aNode._2.data.severity match {
                   case Ast.SpecEvent.Fatal => lines(
-                    s"""|FW_ASSERT(_numArgs == $length + 1, _numArgs, $length + 1);
+                    s"""|FW_ASSERT(
+                        |  _numArgs == $length + 1,
+                        |  static_cast<FwAssertArgType>(_numArgs),
+                        |  static_cast<FwAssertArgType>($length + 1)
+                        |);
                         |
                         |// For FATAL, there is a stack size of 4 and a dummy entry
                         |U8 stackArgLen;
@@ -816,7 +820,10 @@ case class ComponentTesterBaseWriter(
                         |    _status == Fw::FW_SERIALIZE_OK,
                         |    static_cast<FwAssertArgType>(_status)
                         |);
-                        |FW_ASSERT(stackArgLen == 4, stackArgLen);
+                        |FW_ASSERT(
+                        |  stackArgLen == 4,
+                        |  static_cast<FwAssertArgType>(stackArgLen)
+                        |);
                         |
                         |U32 dummyStackArg;
                         |_status = args.deserialize(dummyStackArg);
@@ -824,10 +831,19 @@ case class ComponentTesterBaseWriter(
                         |    _status == Fw::FW_SERIALIZE_OK,
                         |    static_cast<FwAssertArgType>(_status)
                         |);
-                        |FW_ASSERT(dummyStackArg == 0, dummyStackArg);
+                        |FW_ASSERT(
+                        |  dummyStackArg == 0,
+                        |  static_cast<FwAssertArgType>(dummyStackArg)
+                        |);
                         |"""
                   )
-                  case _ => lines(s"FW_ASSERT(_numArgs == $length, _numArgs, $length);")
+                  case _ => lines(
+                    s"""|FW_ASSERT(
+                        |  _numArgs == $length,
+                        |  static_cast<FwAssertArgType>(_numArgs),
+                        |  static_cast<FwAssertArgType>($length)
+                        |);"""
+                  )
                 }
               },
               lines("#endif")
@@ -852,7 +868,11 @@ case class ComponentTesterBaseWriter(
                   |    _status == Fw::FW_SERIALIZE_OK,
                   |    static_cast<FwAssertArgType>(_status)
                   |  );
-                  |  FW_ASSERT(_argSize == $serializedSizeExpr, _argSize, $serializedSizeExpr);
+                  |  FW_ASSERT(
+                  |    _argSize == $serializedSizeExpr,
+                  |    static_cast<FwAssertArgType>(_argSize),
+                  |    static_cast<FwAssertArgType>($serializedSizeExpr)
+                  |  );
                   |}
                   |#endif
                   |_status = args.deserialize($name);
@@ -883,7 +903,7 @@ case class ComponentTesterBaseWriter(
         sortedEvents.map((id, event) => writeSwitchCase(id, event)) ++ List(
           lines(
             """|default: {
-               |  FW_ASSERT(0, id);
+               |  FW_ASSERT(0, static_cast<FwAssertArgType>(id));
                |  break;
                |}
                |"""
@@ -919,7 +939,11 @@ case class ComponentTesterBaseWriter(
           """|args.resetDeser();
              |
              |const U32 idBase = this->getIdBase();
-             |FW_ASSERT(id >= idBase, id, idBase);
+             |FW_ASSERT(
+             |  id >= idBase,
+             |  static_cast<FwAssertArgType>(id),
+             |  static_cast<FwAssertArgType>(idBase)
+             |);
              |"""
         ),
         switchStatement
@@ -1031,7 +1055,7 @@ case class ComponentTesterBaseWriter(
           wrapInScope(
             "default: {",
             lines(
-              """|FW_ASSERT(0, id);
+              """|FW_ASSERT(0, static_cast<FwAssertArgType>(id));
                  |break;
                  |"""
             ),
@@ -1067,7 +1091,11 @@ case class ComponentTesterBaseWriter(
               """|val.resetDeser();
                  |
                  |const U32 idBase = this->getIdBase();
-                 |FW_ASSERT(id >= idBase, id, idBase);
+                 |FW_ASSERT(
+                 |  id >= idBase,
+                 |  static_cast<FwAssertArgType>(id),
+                 |  static_cast<FwAssertArgType>(idBase)
+                 |);
                  |"""
             ),
             Line.blank :: switchStatement
@@ -1245,7 +1273,11 @@ case class ComponentTesterBaseWriter(
               |$value.resetSer();
               |
               |const U32 idBase = _testerBase->getIdBase();
-              |FW_ASSERT($id >= idBase, $id, idBase);
+              |FW_ASSERT(
+              |  $id >= idBase,
+              |  static_cast<FwAssertArgType>($id),
+              |  static_cast<FwAssertArgType>(idBase)
+              |);
               |"""
         ),
         wrapInSwitch(
@@ -1273,7 +1305,7 @@ case class ComponentTesterBaseWriter(
             ) ++ List(
               lines(
                 """|default:
-                   |  FW_ASSERT(0, id);
+                   |  FW_ASSERT(0, static_cast<FwAssertArgType>(id));
                    |  break;
                    |"""
               )
@@ -1291,7 +1323,11 @@ case class ComponentTesterBaseWriter(
         s"""|$value.resetSer();
             |
             |const U32 idBase = _testerBase->getIdBase();
-            |FW_ASSERT($id >= idBase, $id, idBase);
+            |FW_ASSERT(
+            |  $id >= idBase,
+            |  static_cast<FwAssertArgType>($id),
+            |  static_cast<FwAssertArgType>(idBase)
+            |);
             |"""
       ),
       Line.blank :: wrapInSwitch(
@@ -1324,7 +1360,7 @@ case class ComponentTesterBaseWriter(
           }) ++ List(
             lines(
               s"""|default:
-                  |  FW_ASSERT(0, $id);
+                  |  FW_ASSERT(0, static_cast<FwAssertArgType>($id));
                   |  break;
                   |"""
             )

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentTesterBaseWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentTesterBaseWriter.scala
@@ -835,7 +835,7 @@ case class ComponentTesterBaseWriter(
           },
           event.aNode._2.data.params.flatMap(aNode => {
             val data = aNode._2.data
-            val name = data.name
+            val name = s"_event_arg_${data.name}"
             val tn = writeFormalParamType(data, "Fw::LogStringArg")
             val paramType = s.a.typeMap(data.typeName.id)
             val serializedSizeExpr = writeSerializedSizeExpr(s, paramType, tn)
@@ -865,7 +865,7 @@ case class ComponentTesterBaseWriter(
           }),
           {
             val handlerName = eventHandlerName(event)
-            val paramString = params.map(_._1).mkString(", ")
+            val paramString = params.map(p => s"_event_arg_${p._1}").mkString(", ")
             lines(
               s"""|this->$handlerName($paramString);
                   |break;

--- a/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterUtils.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterUtils.scala
@@ -321,8 +321,8 @@ trait CppWriterUtils extends LineUtils {
       case (_, true) => s"sizeof($typeName)"
       case _ => s"$typeName::SERIALIZED_SIZE"
     }
-  
-  /** Promotes an F32 value to a F64 */
+
+  /** Explicitly promotes an F32 value to an F64 value */
   def promoteF32ToF64 (t: Type) (v: String) =
     if t == Type.F32
     then s"static_cast<F64>($v)"

--- a/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterUtils.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterUtils.scala
@@ -321,6 +321,12 @@ trait CppWriterUtils extends LineUtils {
       case (_, true) => s"sizeof($typeName)"
       case _ => s"$typeName::SERIALIZED_SIZE"
     }
+  
+  /** Writes a format argument U64 */
+  def writeFormatArg (t: Type) (arg: String) =
+    if t == Type.F32
+    then s"static_cast<U64>($arg)"
+    else arg
 
   def classMember(
     comment: Option[String],

--- a/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterUtils.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterUtils.scala
@@ -322,10 +322,10 @@ trait CppWriterUtils extends LineUtils {
       case _ => s"$typeName::SERIALIZED_SIZE"
     }
   
-  /** Promotes an F32 value to a U64 */
-  def promoteF32ToU64 (t: Type) (v: String) =
+  /** Promotes an F32 value to a F64 */
+  def promoteF32ToF64 (t: Type) (v: String) =
     if t == Type.F32
-    then s"static_cast<U64>($v)"
+    then s"static_cast<F64>($v)"
     else v
 
   def classMember(

--- a/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterUtils.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterUtils.scala
@@ -322,11 +322,11 @@ trait CppWriterUtils extends LineUtils {
       case _ => s"$typeName::SERIALIZED_SIZE"
     }
   
-  /** Writes a format argument U64 */
-  def writeFormatArg (t: Type) (arg: String) =
+  /** Promotes an F32 value to a U64 */
+  def promoteF32ToU64 (t: Type) (v: String) =
     if t == Type.F32
-    then s"static_cast<U64>($arg)"
-    else arg
+    then s"static_cast<U64>($v)"
+    else v
 
   def classMember(
     comment: Option[String],

--- a/compiler/lib/src/main/scala/codegen/CppWriter/StructCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/StructCppWriter.scala
@@ -489,13 +489,13 @@ case class StructCppWriter(
                       case (false, _: Type.String) =>
                         List(s"this->m_$n.toChar()")
                       case (false, t) if s.isPrimitive(t, tn) =>
-                        List(promoteF32ToU64 (t) (s"this->m_$n"))
+                        List(promoteF32ToF64 (t) (s"this->m_$n"))
                       case (false, _) =>
                         List(s"${n}Str.toChar()")
                       case (true, _: Type.String) =>
                         List.range(0, sizes(n)).map(i => s"this->m_$n[$i].toChar()")
                       case (true, t) if s.isPrimitive(t, tn) =>
-                        List.range(0, sizes(n)).map(i => promoteF32ToU64 (t) (s"this->m_$n[$i]"))
+                        List.range(0, sizes(n)).map(i => promoteF32ToF64 (t) (s"this->m_$n[$i]"))
                       case _ =>
                         List.range(0, sizes(n)).map(i => s"${n}Str[$i].toChar()")
                     }).mkString(",\n"))

--- a/compiler/lib/src/main/scala/codegen/CppWriter/StructCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/StructCppWriter.scala
@@ -489,13 +489,13 @@ case class StructCppWriter(
                       case (false, _: Type.String) =>
                         List(s"this->m_$n.toChar()")
                       case (false, t) if s.isPrimitive(t, tn) =>
-                        List(s"this->m_$n")
+                        List(promoteF32ToU64 (t) (s"this->m_$n"))
                       case (false, _) =>
                         List(s"${n}Str.toChar()")
                       case (true, _: Type.String) =>
                         List.range(0, sizes(n)).map(i => s"this->m_$n[$i].toChar()")
                       case (true, t) if s.isPrimitive(t, tn) =>
-                        List.range(0, sizes(n)).map(i => s"this->m_$n[$i]")
+                        List.range(0, sizes(n)).map(i => promoteF32ToU64 (t) (s"this->m_$n[$i]"))
                       case _ =>
                         List.range(0, sizes(n)).map(i => s"${n}Str[$i].toChar()")
                     }).mkString(",\n"))

--- a/compiler/scripts/fprime-gcc
+++ b/compiler/scripts/fprime-gcc
@@ -32,7 +32,7 @@ os=`uname`
 case "$os" in
   Darwin)
     os_type=DARWIN
-    os_flags='-Wno-nullability-completeness -ferror-limit=1'
+    os_flags='-ferror-limit=1'
     ;;
   Linux)
     os_type=LINUX

--- a/compiler/scripts/fprime-gcc
+++ b/compiler/scripts/fprime-gcc
@@ -18,6 +18,7 @@ fi
 
 flags="
 -Wall
+-Wconversion
 -Wdouble-promotion
 -Werror
 -Wextra
@@ -42,5 +43,4 @@ case "$os" in
     ;;
 esac
 
-# Removing -Wconversion because of many implicit casts of size type in F Prime
 g++ --std=c++11 $flags $os_flags -DTGT_OS_TYPE_$os_type -I $FPRIME -I $FPRIME/config -I $FPRIME/cmake/platform/types -I . $FPRIME_GCC_FLAGS $@

--- a/compiler/scripts/fprime-gcc
+++ b/compiler/scripts/fprime-gcc
@@ -23,6 +23,7 @@ flags="
 -Wold-style-cast
 -Wshadow
 -pedantic
+-Wdouble-promotion
 "
 
 unset os_flags

--- a/compiler/scripts/fprime-gcc
+++ b/compiler/scripts/fprime-gcc
@@ -18,12 +18,12 @@ fi
 
 flags="
 -Wall
+-Wdouble-promotion
 -Werror
 -Wextra
 -Wold-style-cast
 -Wshadow
 -pedantic
--Wdouble-promotion
 "
 
 unset os_flags

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32eArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32eArrayAc.ref.cpp
@@ -184,9 +184,9 @@ namespace M {
 
     sb.format(
       formatString,
-      static_cast<U64>(this->elements[0]),
-      static_cast<U64>(this->elements[1]),
-      static_cast<U64>(this->elements[2])
+      static_cast<F64>(this->elements[0]),
+      static_cast<F64>(this->elements[1]),
+      static_cast<F64>(this->elements[2])
     );
   }
 

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32eArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32eArrayAc.ref.cpp
@@ -184,9 +184,9 @@ namespace M {
 
     sb.format(
       formatString,
-      this->elements[0],
-      this->elements[1],
-      this->elements[2]
+      static_cast<U64>(this->elements[0]),
+      static_cast<U64>(this->elements[1]),
+      static_cast<U64>(this->elements[2])
     );
   }
 

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32fArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32fArrayAc.ref.cpp
@@ -184,9 +184,9 @@ namespace M {
 
     sb.format(
       formatString,
-      static_cast<U64>(this->elements[0]),
-      static_cast<U64>(this->elements[1]),
-      static_cast<U64>(this->elements[2])
+      static_cast<F64>(this->elements[0]),
+      static_cast<F64>(this->elements[1]),
+      static_cast<F64>(this->elements[2])
     );
   }
 

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32fArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32fArrayAc.ref.cpp
@@ -184,9 +184,9 @@ namespace M {
 
     sb.format(
       formatString,
-      this->elements[0],
-      this->elements[1],
-      this->elements[2]
+      static_cast<U64>(this->elements[0]),
+      static_cast<U64>(this->elements[1]),
+      static_cast<U64>(this->elements[2])
     );
   }
 

--- a/compiler/tools/fpp-to-cpp/test/array/S1SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/S1SerializableAc.ref.cpp
@@ -275,7 +275,7 @@ namespace M {
 
     sb.format(
       formatString,
-      this->m_mF32,
+      static_cast<U64>(this->m_mF32),
       this->m_mF64,
       this->m_mI16,
       this->m_mI32,

--- a/compiler/tools/fpp-to-cpp/test/array/S1SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/S1SerializableAc.ref.cpp
@@ -275,7 +275,7 @@ namespace M {
 
     sb.format(
       formatString,
-      static_cast<U64>(this->m_mF32),
+      static_cast<F64>(this->m_mF32),
       this->m_mF64,
       this->m_mI16,
       this->m_mI32,

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductsComponentAc.ref.cpp
@@ -110,12 +110,12 @@ Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -135,9 +135,9 @@ Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -168,14 +168,14 @@ Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       const Fw::StringBase *const sbPtr = array[i];
       FW_ASSERT(sbPtr != nullptr);
       status = sbPtr->serialize(this->m_dataBuffer, stringSize);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -196,9 +196,9 @@ Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = elt.serialize(this->m_dataBuffer, stringSize);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -224,12 +224,12 @@ Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -249,9 +249,9 @@ Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32Record;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -277,11 +277,11 @@ Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -3679,7 +3679,11 @@ void ActiveAsyncProductsComponentBase ::
   DpContainer container(id, buffer, this->getIdBase());
   // Convert global id to local id
   const FwDpIdType idBase = this->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
   const FwDpIdType localId = id - idBase;
   // Switch on the local id
   switch (localId) {

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.cpp
@@ -2534,7 +2534,7 @@ void ActiveEventsComponentBase ::
 #endif
       "EventActivityLowThrottled ",
       u32,
-      static_cast<U64>(f32),
+      static_cast<F64>(f32),
       b
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.cpp
@@ -2534,7 +2534,7 @@ void ActiveEventsComponentBase ::
 #endif
       "EventActivityLowThrottled ",
       u32,
-      f32,
+      static_cast<U64>(f32),
       b
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveGetProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveGetProductsComponentAc.ref.cpp
@@ -108,12 +108,12 @@ Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -133,9 +133,9 @@ Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -166,14 +166,14 @@ Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       const Fw::StringBase *const sbPtr = array[i];
       FW_ASSERT(sbPtr != nullptr);
       status = sbPtr->serialize(this->m_dataBuffer, stringSize);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -194,9 +194,9 @@ Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = elt.serialize(this->m_dataBuffer, stringSize);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -222,12 +222,12 @@ Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -247,9 +247,9 @@ Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32Record;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -275,11 +275,11 @@ Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveGuardedProductsComponentAc.ref.cpp
@@ -108,12 +108,12 @@ Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -133,9 +133,9 @@ Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -166,14 +166,14 @@ Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       const Fw::StringBase *const sbPtr = array[i];
       FW_ASSERT(sbPtr != nullptr);
       status = sbPtr->serialize(this->m_dataBuffer, stringSize);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -194,9 +194,9 @@ Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = elt.serialize(this->m_dataBuffer, stringSize);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -222,12 +222,12 @@ Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -247,9 +247,9 @@ Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32Record;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -275,11 +275,11 @@ Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -3580,7 +3580,11 @@ void ActiveGuardedProductsComponentBase ::
   DpContainer container(id, buffer, this->getIdBase());
   // Convert global id to local id
   const FwDpIdType idBase = this->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
   const FwDpIdType localId = id - idBase;
   // Switch on the local id
   switch (localId) {

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveOverflowComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveOverflowComponentAc.ref.cpp
@@ -1530,7 +1530,10 @@ void ActiveOverflowComponentBase ::
 
   // Declare buffer for serialAsyncHook
   U8 msgBuff[this->m_msgSize];
-  Fw::ExternalSerializeBuffer msgSerBuff(msgBuff, this->m_msgSize);
+  Fw::ExternalSerializeBuffer msgSerBuff(
+    msgBuff,
+    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+  );
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
@@ -1926,7 +1929,10 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
   doDispatch()
 {
   U8 msgBuff[this->m_msgSize];
-  Fw::ExternalSerializeBuffer msg(msgBuff,this->m_msgSize);
+  Fw::ExternalSerializeBuffer msg(
+    msgBuff,
+    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+  );
   FwQueuePriorityType priority = 0;
 
   Os::Queue::Status msgStatus = this->m_queue.receive(
@@ -2295,7 +2301,10 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
     case SERIALASYNCHOOK_SERIAL: {
       // Deserialize serialized buffer into new buffer
       U8 handBuff[this->m_msgSize];
-      Fw::ExternalSerializeBuffer serHandBuff(handBuff,this->m_msgSize);
+      Fw::ExternalSerializeBuffer serHandBuff(
+        handBuff,
+        static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+      );
       deserStatus = msg.deserialize(serHandBuff);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
@@ -4802,7 +4802,7 @@ void ActiveSerialComponentBase ::
 #endif
       "EventActivityLowThrottled ",
       u32,
-      static_cast<U64>(f32),
+      static_cast<F64>(f32),
       b
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
@@ -2878,7 +2878,10 @@ void ActiveSerialComponentBase ::
 
   // Declare buffer for serialAsync
   U8 msgBuff[this->m_msgSize];
-  Fw::ExternalSerializeBuffer msgSerBuff(msgBuff, this->m_msgSize);
+  Fw::ExternalSerializeBuffer msgSerBuff(
+    msgBuff,
+    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+  );
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
@@ -2928,7 +2931,10 @@ void ActiveSerialComponentBase ::
 
   // Declare buffer for serialAsyncAssert
   U8 msgBuff[this->m_msgSize];
-  Fw::ExternalSerializeBuffer msgSerBuff(msgBuff, this->m_msgSize);
+  Fw::ExternalSerializeBuffer msgSerBuff(
+    msgBuff,
+    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+  );
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
@@ -2978,7 +2984,10 @@ void ActiveSerialComponentBase ::
 
   // Declare buffer for serialAsyncBlockPriority
   U8 msgBuff[this->m_msgSize];
-  Fw::ExternalSerializeBuffer msgSerBuff(msgBuff, this->m_msgSize);
+  Fw::ExternalSerializeBuffer msgSerBuff(
+    msgBuff,
+    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+  );
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
@@ -3028,7 +3037,10 @@ void ActiveSerialComponentBase ::
 
   // Declare buffer for serialAsyncDropPriority
   U8 msgBuff[this->m_msgSize];
-  Fw::ExternalSerializeBuffer msgSerBuff(msgBuff, this->m_msgSize);
+  Fw::ExternalSerializeBuffer msgSerBuff(
+    msgBuff,
+    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+  );
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
@@ -5799,7 +5811,10 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
   doDispatch()
 {
   U8 msgBuff[this->m_msgSize];
-  Fw::ExternalSerializeBuffer msg(msgBuff,this->m_msgSize);
+  Fw::ExternalSerializeBuffer msg(
+    msgBuff,
+    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+  );
   FwQueuePriorityType priority = 0;
 
   Os::Queue::Status msgStatus = this->m_queue.receive(
@@ -6140,7 +6155,10 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
     case SERIALASYNC_SERIAL: {
       // Deserialize serialized buffer into new buffer
       U8 handBuff[this->m_msgSize];
-      Fw::ExternalSerializeBuffer serHandBuff(handBuff,this->m_msgSize);
+      Fw::ExternalSerializeBuffer serHandBuff(
+        handBuff,
+        static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+      );
       deserStatus = msg.deserialize(serHandBuff);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -6155,7 +6173,10 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
     case SERIALASYNCASSERT_SERIAL: {
       // Deserialize serialized buffer into new buffer
       U8 handBuff[this->m_msgSize];
-      Fw::ExternalSerializeBuffer serHandBuff(handBuff,this->m_msgSize);
+      Fw::ExternalSerializeBuffer serHandBuff(
+        handBuff,
+        static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+      );
       deserStatus = msg.deserialize(serHandBuff);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -6170,7 +6191,10 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
     case SERIALASYNCBLOCKPRIORITY_SERIAL: {
       // Deserialize serialized buffer into new buffer
       U8 handBuff[this->m_msgSize];
-      Fw::ExternalSerializeBuffer serHandBuff(handBuff,this->m_msgSize);
+      Fw::ExternalSerializeBuffer serHandBuff(
+        handBuff,
+        static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+      );
       deserStatus = msg.deserialize(serHandBuff);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -6185,7 +6209,10 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
     case SERIALASYNCDROPPRIORITY_SERIAL: {
       // Deserialize serialized buffer into new buffer
       U8 handBuff[this->m_msgSize];
-      Fw::ExternalSerializeBuffer serHandBuff(handBuff,this->m_msgSize);
+      Fw::ExternalSerializeBuffer serHandBuff(
+        handBuff,
+        static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+      );
       deserStatus = msg.deserialize(serHandBuff);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
@@ -4802,7 +4802,7 @@ void ActiveSerialComponentBase ::
 #endif
       "EventActivityLowThrottled ",
       u32,
-      f32,
+      static_cast<U64>(f32),
       b
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSyncProductsComponentAc.ref.cpp
@@ -108,12 +108,12 @@ Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -133,9 +133,9 @@ Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -166,14 +166,14 @@ Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       const Fw::StringBase *const sbPtr = array[i];
       FW_ASSERT(sbPtr != nullptr);
       status = sbPtr->serialize(this->m_dataBuffer, stringSize);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -194,9 +194,9 @@ Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = elt.serialize(this->m_dataBuffer, stringSize);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -222,12 +222,12 @@ Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -247,9 +247,9 @@ Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32Record;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -275,11 +275,11 @@ Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -3574,7 +3574,11 @@ void ActiveSyncProductsComponentBase ::
   DpContainer container(id, buffer, this->getIdBase());
   // Convert global id to local id
   const FwDpIdType idBase = this->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
   const FwDpIdType localId = id - idBase;
   // Switch on the local id
   switch (localId) {

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
@@ -4687,7 +4687,7 @@ namespace M {
 #endif
         "EventActivityLowThrottled ",
         u32,
-        f32,
+        static_cast<U64>(f32),
         b
       );
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
@@ -146,12 +146,12 @@ namespace M {
     if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
       const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
       status = this->m_dataBuffer.serialize(id);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
       status = this->m_dataBuffer.serializeSize(size);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
       for (FwSizeType i = 0; i < size; i++) {
         status = this->m_dataBuffer.serialize(array[i]);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
       }
       this->m_dataSize += sizeDelta;
     }
@@ -171,9 +171,9 @@ namespace M {
     if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
       const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
       status = this->m_dataBuffer.serialize(id);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
       status = this->m_dataBuffer.serialize(elt);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
       this->m_dataSize += sizeDelta;
     }
     else {
@@ -204,14 +204,14 @@ namespace M {
     if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
       const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
       status = this->m_dataBuffer.serialize(id);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
       status = this->m_dataBuffer.serializeSize(size);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
       for (FwSizeType i = 0; i < size; i++) {
         const Fw::StringBase *const sbPtr = array[i];
         FW_ASSERT(sbPtr != nullptr);
         status = sbPtr->serialize(this->m_dataBuffer, stringSize);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
       }
       this->m_dataSize += sizeDelta;
     }
@@ -232,9 +232,9 @@ namespace M {
     if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
       const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
       status = this->m_dataBuffer.serialize(id);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
       status = elt.serialize(this->m_dataBuffer, stringSize);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
       this->m_dataSize += sizeDelta;
     }
     else {
@@ -260,12 +260,12 @@ namespace M {
     if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
       const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
       status = this->m_dataBuffer.serialize(id);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
       status = this->m_dataBuffer.serializeSize(size);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
       for (FwSizeType i = 0; i < size; i++) {
         status = this->m_dataBuffer.serialize(array[i]);
-        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+        FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
       }
       this->m_dataSize += sizeDelta;
     }
@@ -285,9 +285,9 @@ namespace M {
     if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
       const FwDpIdType id = this->m_baseId + RecordId::U32Record;
       status = this->m_dataBuffer.serialize(id);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
       status = this->m_dataBuffer.serialize(elt);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
       this->m_dataSize += sizeDelta;
     }
     else {
@@ -313,11 +313,11 @@ namespace M {
     if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
       const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
       status = this->m_dataBuffer.serialize(id);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
       status = this->m_dataBuffer.serializeSize(size);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
       status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
       this->m_dataSize += sizeDelta;
     }
     else {
@@ -7459,7 +7459,11 @@ namespace M {
     DpContainer container(id, buffer, this->getIdBase());
     // Convert global id to local id
     const FwDpIdType idBase = this->getIdBase();
-    FW_ASSERT(id >= idBase, id, idBase);
+    FW_ASSERT(
+      id >= idBase,
+      static_cast<FwAssertArgType>(id),
+      static_cast<FwAssertArgType>(idBase)
+    );
     const FwDpIdType localId = id - idBase;
     // Switch on the local id
     switch (localId) {

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
@@ -4687,7 +4687,7 @@ namespace M {
 #endif
         "EventActivityLowThrottled ",
         u32,
-        static_cast<U64>(f32),
+        static_cast<F64>(f32),
         b
       );
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveEventsComponentAc.ref.cpp
@@ -1713,7 +1713,7 @@ void PassiveEventsComponentBase ::
 #endif
       "EventActivityLowThrottled ",
       u32,
-      static_cast<U64>(f32),
+      static_cast<F64>(f32),
       b
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveEventsComponentAc.ref.cpp
@@ -1713,7 +1713,7 @@ void PassiveEventsComponentBase ::
 #endif
       "EventActivityLowThrottled ",
       u32,
-      f32,
+      static_cast<U64>(f32),
       b
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveGetProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveGetProductsComponentAc.ref.cpp
@@ -52,12 +52,12 @@ Fw::SerializeStatus PassiveGetProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -77,9 +77,9 @@ Fw::SerializeStatus PassiveGetProductsComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -110,14 +110,14 @@ Fw::SerializeStatus PassiveGetProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       const Fw::StringBase *const sbPtr = array[i];
       FW_ASSERT(sbPtr != nullptr);
       status = sbPtr->serialize(this->m_dataBuffer, stringSize);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -138,9 +138,9 @@ Fw::SerializeStatus PassiveGetProductsComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = elt.serialize(this->m_dataBuffer, stringSize);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -166,12 +166,12 @@ Fw::SerializeStatus PassiveGetProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -191,9 +191,9 @@ Fw::SerializeStatus PassiveGetProductsComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32Record;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -219,11 +219,11 @@ Fw::SerializeStatus PassiveGetProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveGuardedProductsComponentAc.ref.cpp
@@ -52,12 +52,12 @@ Fw::SerializeStatus PassiveGuardedProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -77,9 +77,9 @@ Fw::SerializeStatus PassiveGuardedProductsComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -110,14 +110,14 @@ Fw::SerializeStatus PassiveGuardedProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       const Fw::StringBase *const sbPtr = array[i];
       FW_ASSERT(sbPtr != nullptr);
       status = sbPtr->serialize(this->m_dataBuffer, stringSize);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -138,9 +138,9 @@ Fw::SerializeStatus PassiveGuardedProductsComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = elt.serialize(this->m_dataBuffer, stringSize);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -166,12 +166,12 @@ Fw::SerializeStatus PassiveGuardedProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -191,9 +191,9 @@ Fw::SerializeStatus PassiveGuardedProductsComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32Record;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -219,11 +219,11 @@ Fw::SerializeStatus PassiveGuardedProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -2289,7 +2289,11 @@ void PassiveGuardedProductsComponentBase ::
   DpContainer container(id, buffer, this->getIdBase());
   // Convert global id to local id
   const FwDpIdType idBase = this->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
   const FwDpIdType localId = id - idBase;
   // Switch on the local id
   switch (localId) {

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
@@ -2887,7 +2887,7 @@ void PassiveSerialComponentBase ::
 #endif
       "EventActivityLowThrottled ",
       u32,
-      f32,
+      static_cast<U64>(f32),
       b
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
@@ -2887,7 +2887,7 @@ void PassiveSerialComponentBase ::
 #endif
       "EventActivityLowThrottled ",
       u32,
-      static_cast<U64>(f32),
+      static_cast<F64>(f32),
       b
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductsComponentAc.ref.cpp
@@ -52,12 +52,12 @@ Fw::SerializeStatus PassiveSyncProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -77,9 +77,9 @@ Fw::SerializeStatus PassiveSyncProductsComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -110,14 +110,14 @@ Fw::SerializeStatus PassiveSyncProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       const Fw::StringBase *const sbPtr = array[i];
       FW_ASSERT(sbPtr != nullptr);
       status = sbPtr->serialize(this->m_dataBuffer, stringSize);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -138,9 +138,9 @@ Fw::SerializeStatus PassiveSyncProductsComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = elt.serialize(this->m_dataBuffer, stringSize);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -166,12 +166,12 @@ Fw::SerializeStatus PassiveSyncProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -191,9 +191,9 @@ Fw::SerializeStatus PassiveSyncProductsComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32Record;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -219,11 +219,11 @@ Fw::SerializeStatus PassiveSyncProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -2283,7 +2283,11 @@ void PassiveSyncProductsComponentBase ::
   DpContainer container(id, buffer, this->getIdBase());
   // Convert global id to local id
   const FwDpIdType idBase = this->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
   const FwDpIdType localId = id - idBase;
   // Switch on the local id
   switch (localId) {

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
@@ -52,12 +52,12 @@ Fw::SerializeStatus PassiveTestComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -77,9 +77,9 @@ Fw::SerializeStatus PassiveTestComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -110,14 +110,14 @@ Fw::SerializeStatus PassiveTestComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       const Fw::StringBase *const sbPtr = array[i];
       FW_ASSERT(sbPtr != nullptr);
       status = sbPtr->serialize(this->m_dataBuffer, stringSize);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -138,9 +138,9 @@ Fw::SerializeStatus PassiveTestComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = elt.serialize(this->m_dataBuffer, stringSize);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -166,12 +166,12 @@ Fw::SerializeStatus PassiveTestComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -191,9 +191,9 @@ Fw::SerializeStatus PassiveTestComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32Record;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -219,11 +219,11 @@ Fw::SerializeStatus PassiveTestComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -4899,7 +4899,11 @@ void PassiveTestComponentBase ::
   DpContainer container(id, buffer, this->getIdBase());
   // Convert global id to local id
   const FwDpIdType idBase = this->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
   const FwDpIdType localId = id - idBase;
   // Switch on the local id
   switch (localId) {

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
@@ -3124,7 +3124,7 @@ void PassiveTestComponentBase ::
 #endif
       "EventActivityLowThrottled ",
       u32,
-      f32,
+      static_cast<U64>(f32),
       b
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
@@ -3124,7 +3124,7 @@ void PassiveTestComponentBase ::
 #endif
       "EventActivityLowThrottled ",
       u32,
-      static_cast<U64>(f32),
+      static_cast<F64>(f32),
       b
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductsComponentAc.ref.cpp
@@ -110,12 +110,12 @@ Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -135,9 +135,9 @@ Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -168,14 +168,14 @@ Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       const Fw::StringBase *const sbPtr = array[i];
       FW_ASSERT(sbPtr != nullptr);
       status = sbPtr->serialize(this->m_dataBuffer, stringSize);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -196,9 +196,9 @@ Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = elt.serialize(this->m_dataBuffer, stringSize);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -224,12 +224,12 @@ Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -249,9 +249,9 @@ Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32Record;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -277,11 +277,11 @@ Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -3679,7 +3679,11 @@ void QueuedAsyncProductsComponentBase ::
   DpContainer container(id, buffer, this->getIdBase());
   // Convert global id to local id
   const FwDpIdType idBase = this->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
   const FwDpIdType localId = id - idBase;
   // Switch on the local id
   switch (localId) {

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.cpp
@@ -2534,7 +2534,7 @@ void QueuedEventsComponentBase ::
 #endif
       "EventActivityLowThrottled ",
       u32,
-      f32,
+      static_cast<U64>(f32),
       b
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.cpp
@@ -2534,7 +2534,7 @@ void QueuedEventsComponentBase ::
 #endif
       "EventActivityLowThrottled ",
       u32,
-      static_cast<U64>(f32),
+      static_cast<F64>(f32),
       b
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedGetProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedGetProductsComponentAc.ref.cpp
@@ -108,12 +108,12 @@ Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -133,9 +133,9 @@ Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -166,14 +166,14 @@ Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       const Fw::StringBase *const sbPtr = array[i];
       FW_ASSERT(sbPtr != nullptr);
       status = sbPtr->serialize(this->m_dataBuffer, stringSize);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -194,9 +194,9 @@ Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = elt.serialize(this->m_dataBuffer, stringSize);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -222,12 +222,12 @@ Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -247,9 +247,9 @@ Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32Record;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -275,11 +275,11 @@ Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedGuardedProductsComponentAc.ref.cpp
@@ -108,12 +108,12 @@ Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -133,9 +133,9 @@ Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -166,14 +166,14 @@ Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       const Fw::StringBase *const sbPtr = array[i];
       FW_ASSERT(sbPtr != nullptr);
       status = sbPtr->serialize(this->m_dataBuffer, stringSize);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -194,9 +194,9 @@ Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = elt.serialize(this->m_dataBuffer, stringSize);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -222,12 +222,12 @@ Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -247,9 +247,9 @@ Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32Record;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -275,11 +275,11 @@ Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -3580,7 +3580,11 @@ void QueuedGuardedProductsComponentBase ::
   DpContainer container(id, buffer, this->getIdBase());
   // Convert global id to local id
   const FwDpIdType idBase = this->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
   const FwDpIdType localId = id - idBase;
   // Switch on the local id
   switch (localId) {

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedOverflowComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedOverflowComponentAc.ref.cpp
@@ -1530,7 +1530,10 @@ void QueuedOverflowComponentBase ::
 
   // Declare buffer for serialAsyncHook
   U8 msgBuff[this->m_msgSize];
-  Fw::ExternalSerializeBuffer msgSerBuff(msgBuff, this->m_msgSize);
+  Fw::ExternalSerializeBuffer msgSerBuff(
+    msgBuff,
+    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+  );
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
@@ -1926,7 +1929,10 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
   doDispatch()
 {
   U8 msgBuff[this->m_msgSize];
-  Fw::ExternalSerializeBuffer msg(msgBuff,this->m_msgSize);
+  Fw::ExternalSerializeBuffer msg(
+    msgBuff,
+    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+  );
   FwQueuePriorityType priority = 0;
 
   Os::Queue::Status msgStatus = this->m_queue.receive(
@@ -2300,7 +2306,10 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
     case SERIALASYNCHOOK_SERIAL: {
       // Deserialize serialized buffer into new buffer
       U8 handBuff[this->m_msgSize];
-      Fw::ExternalSerializeBuffer serHandBuff(handBuff,this->m_msgSize);
+      Fw::ExternalSerializeBuffer serHandBuff(
+        handBuff,
+        static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+      );
       deserStatus = msg.deserialize(serHandBuff);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
@@ -4802,7 +4802,7 @@ void QueuedSerialComponentBase ::
 #endif
       "EventActivityLowThrottled ",
       u32,
-      f32,
+      static_cast<U64>(f32),
       b
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
@@ -4802,7 +4802,7 @@ void QueuedSerialComponentBase ::
 #endif
       "EventActivityLowThrottled ",
       u32,
-      static_cast<U64>(f32),
+      static_cast<F64>(f32),
       b
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
@@ -2878,7 +2878,10 @@ void QueuedSerialComponentBase ::
 
   // Declare buffer for serialAsync
   U8 msgBuff[this->m_msgSize];
-  Fw::ExternalSerializeBuffer msgSerBuff(msgBuff, this->m_msgSize);
+  Fw::ExternalSerializeBuffer msgSerBuff(
+    msgBuff,
+    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+  );
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
@@ -2928,7 +2931,10 @@ void QueuedSerialComponentBase ::
 
   // Declare buffer for serialAsyncAssert
   U8 msgBuff[this->m_msgSize];
-  Fw::ExternalSerializeBuffer msgSerBuff(msgBuff, this->m_msgSize);
+  Fw::ExternalSerializeBuffer msgSerBuff(
+    msgBuff,
+    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+  );
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
@@ -2978,7 +2984,10 @@ void QueuedSerialComponentBase ::
 
   // Declare buffer for serialAsyncBlockPriority
   U8 msgBuff[this->m_msgSize];
-  Fw::ExternalSerializeBuffer msgSerBuff(msgBuff, this->m_msgSize);
+  Fw::ExternalSerializeBuffer msgSerBuff(
+    msgBuff,
+    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+  );
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
@@ -3028,7 +3037,10 @@ void QueuedSerialComponentBase ::
 
   // Declare buffer for serialAsyncDropPriority
   U8 msgBuff[this->m_msgSize];
-  Fw::ExternalSerializeBuffer msgSerBuff(msgBuff, this->m_msgSize);
+  Fw::ExternalSerializeBuffer msgSerBuff(
+    msgBuff,
+    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+  );
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
@@ -5799,7 +5811,10 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
   doDispatch()
 {
   U8 msgBuff[this->m_msgSize];
-  Fw::ExternalSerializeBuffer msg(msgBuff,this->m_msgSize);
+  Fw::ExternalSerializeBuffer msg(
+    msgBuff,
+    static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+  );
   FwQueuePriorityType priority = 0;
 
   Os::Queue::Status msgStatus = this->m_queue.receive(
@@ -6145,7 +6160,10 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
     case SERIALASYNC_SERIAL: {
       // Deserialize serialized buffer into new buffer
       U8 handBuff[this->m_msgSize];
-      Fw::ExternalSerializeBuffer serHandBuff(handBuff,this->m_msgSize);
+      Fw::ExternalSerializeBuffer serHandBuff(
+        handBuff,
+        static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+      );
       deserStatus = msg.deserialize(serHandBuff);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -6160,7 +6178,10 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
     case SERIALASYNCASSERT_SERIAL: {
       // Deserialize serialized buffer into new buffer
       U8 handBuff[this->m_msgSize];
-      Fw::ExternalSerializeBuffer serHandBuff(handBuff,this->m_msgSize);
+      Fw::ExternalSerializeBuffer serHandBuff(
+        handBuff,
+        static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+      );
       deserStatus = msg.deserialize(serHandBuff);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -6175,7 +6196,10 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
     case SERIALASYNCBLOCKPRIORITY_SERIAL: {
       // Deserialize serialized buffer into new buffer
       U8 handBuff[this->m_msgSize];
-      Fw::ExternalSerializeBuffer serHandBuff(handBuff,this->m_msgSize);
+      Fw::ExternalSerializeBuffer serHandBuff(
+        handBuff,
+        static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+      );
       deserStatus = msg.deserialize(serHandBuff);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -6190,7 +6214,10 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
     case SERIALASYNCDROPPRIORITY_SERIAL: {
       // Deserialize serialized buffer into new buffer
       U8 handBuff[this->m_msgSize];
-      Fw::ExternalSerializeBuffer serHandBuff(handBuff,this->m_msgSize);
+      Fw::ExternalSerializeBuffer serHandBuff(
+        handBuff,
+        static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
+      );
       deserStatus = msg.deserialize(serHandBuff);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSyncProductsComponentAc.ref.cpp
@@ -108,12 +108,12 @@ Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -133,9 +133,9 @@ Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -166,14 +166,14 @@ Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       const Fw::StringBase *const sbPtr = array[i];
       FW_ASSERT(sbPtr != nullptr);
       status = sbPtr->serialize(this->m_dataBuffer, stringSize);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -194,9 +194,9 @@ Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = elt.serialize(this->m_dataBuffer, stringSize);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -222,12 +222,12 @@ Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -247,9 +247,9 @@ Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32Record;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -275,11 +275,11 @@ Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -3574,7 +3574,11 @@ void QueuedSyncProductsComponentBase ::
   DpContainer container(id, buffer, this->getIdBase());
   // Convert global id to local id
   const FwDpIdType idBase = this->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
   const FwDpIdType localId = id - idBase;
   // Switch on the local id
   switch (localId) {

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
@@ -4685,7 +4685,7 @@ void QueuedTestComponentBase ::
 #endif
       "EventActivityLowThrottled ",
       u32,
-      f32,
+      static_cast<U64>(f32),
       b
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
@@ -4685,7 +4685,7 @@ void QueuedTestComponentBase ::
 #endif
       "EventActivityLowThrottled ",
       u32,
-      static_cast<U64>(f32),
+      static_cast<F64>(f32),
       b
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
@@ -144,12 +144,12 @@ Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -169,9 +169,9 @@ Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -202,14 +202,14 @@ Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       const Fw::StringBase *const sbPtr = array[i];
       FW_ASSERT(sbPtr != nullptr);
       status = sbPtr->serialize(this->m_dataBuffer, stringSize);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -230,9 +230,9 @@ Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = elt.serialize(this->m_dataBuffer, stringSize);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -258,12 +258,12 @@ Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
-      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+      FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
   }
@@ -283,9 +283,9 @@ Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32Record;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(elt);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -311,11 +311,11 @@ Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
-    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
+    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
   else {
@@ -7462,7 +7462,11 @@ void QueuedTestComponentBase ::
   DpContainer container(id, buffer, this->getIdBase());
   // Convert global id to local id
   const FwDpIdType idBase = this->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
   const FwDpIdType localId = id - idBase;
   // Switch on the local id
   switch (localId) {

--- a/compiler/tools/fpp-to-cpp/test/component/compile_base_cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/compile_base_cpp
@@ -32,6 +32,7 @@ fprime_gcc=../../../../../scripts/fprime-gcc
 include_flags="-I.. -I../.. -I../../fprime -I../../fprime/config"
 warning_flags="
 -Wno-unused-parameter
+-Wno-vla-extension
 "
 gcc_flags="$include_flags $warning_flags $LOCAL_CPP_FLAGS"
 

--- a/compiler/tools/fpp-to-cpp/test/component/compile_base_cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/compile_base_cpp
@@ -28,8 +28,10 @@ done
 
 fprime_gcc=../../../../../scripts/fprime-gcc
 
-## Set compiler flags
+# Set compiler flags
 include_flags="-I.. -I../.. -I../../fprime -I../../fprime/config"
+# F Prime components sometimes provide parameter arguments that are unused
+# F Prime components use variable-length arrays for managing buffers
 warning_flags="
 -Wno-unused-parameter
 -Wno-vla-extension

--- a/compiler/tools/fpp-to-cpp/test/component/compile_base_cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/compile_base_cpp
@@ -31,10 +31,7 @@ fprime_gcc=../../../../../scripts/fprime-gcc
 ## Set compiler flags
 include_flags="-I.. -I../.. -I../../fprime -I../../fprime/config"
 warning_flags="
--Wno-sign-conversion
 -Wno-unused-parameter
--Wno-vla-extension
--Wno-zero-length-array
 "
 gcc_flags="$include_flags $warning_flags $LOCAL_CPP_FLAGS"
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsTesterBase.ref.cpp
@@ -1577,7 +1577,11 @@ void ActiveEventsTesterBase ::
   args.resetDeser();
 
   const U32 idBase = this->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
 
   switch (id - idBase) {
     case ActiveEventsComponentBase::EVENTID_EVENTACTIVITYHIGH: {
@@ -1607,7 +1611,11 @@ void ActiveEventsTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 3, _numArgs, 3);
+      FW_ASSERT(
+        _numArgs == 3,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(3)
+      );
 #endif
 
       U32 _event_arg_u32;
@@ -1620,7 +1628,11 @@ void ActiveEventsTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == sizeof(U32), _argSize, sizeof(U32));
+        FW_ASSERT(
+          _argSize == sizeof(U32),
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(sizeof(U32))
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_u32);
@@ -1639,7 +1651,11 @@ void ActiveEventsTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == sizeof(F32), _argSize, sizeof(F32));
+        FW_ASSERT(
+          _argSize == sizeof(F32),
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(sizeof(F32))
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_f32);
@@ -1658,7 +1674,11 @@ void ActiveEventsTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == sizeof(U8), _argSize, sizeof(U8));
+        FW_ASSERT(
+          _argSize == sizeof(U8),
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(sizeof(U8))
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_b);
@@ -1682,7 +1702,11 @@ void ActiveEventsTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 2, _numArgs, 2);
+      FW_ASSERT(
+        _numArgs == 2,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(2)
+      );
 #endif
 
       Fw::LogStringArg _event_arg_str1;
@@ -1695,7 +1719,11 @@ void ActiveEventsTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == Fw::LogStringArg::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(Fw::LogStringArg::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_str1);
@@ -1714,7 +1742,11 @@ void ActiveEventsTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == Fw::LogStringArg::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(Fw::LogStringArg::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_str2);
@@ -1738,7 +1770,11 @@ void ActiveEventsTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 1, _numArgs, 1);
+      FW_ASSERT(
+        _numArgs == 1,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(1)
+      );
 #endif
 
       E _event_arg_e;
@@ -1751,7 +1787,11 @@ void ActiveEventsTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == E::SERIALIZED_SIZE, _argSize, E::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == E::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(E::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_e);
@@ -1775,7 +1815,11 @@ void ActiveEventsTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 1 + 1, _numArgs, 1 + 1);
+      FW_ASSERT(
+        _numArgs == 1 + 1,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(1 + 1)
+      );
 
       // For FATAL, there is a stack size of 4 and a dummy entry
       U8 stackArgLen;
@@ -1784,7 +1828,10 @@ void ActiveEventsTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
       );
-      FW_ASSERT(stackArgLen == 4, stackArgLen);
+      FW_ASSERT(
+        stackArgLen == 4,
+        static_cast<FwAssertArgType>(stackArgLen)
+      );
 
       U32 dummyStackArg;
       _status = args.deserialize(dummyStackArg);
@@ -1792,7 +1839,10 @@ void ActiveEventsTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
       );
-      FW_ASSERT(dummyStackArg == 0, dummyStackArg);
+      FW_ASSERT(
+        dummyStackArg == 0,
+        static_cast<FwAssertArgType>(dummyStackArg)
+      );
 #endif
 
       A _event_arg_a;
@@ -1805,7 +1855,11 @@ void ActiveEventsTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == A::SERIALIZED_SIZE, _argSize, A::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == A::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(A::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_a);
@@ -1829,7 +1883,11 @@ void ActiveEventsTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 1, _numArgs, 1);
+      FW_ASSERT(
+        _numArgs == 1,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(1)
+      );
 #endif
 
       S _event_arg_s;
@@ -1842,7 +1900,11 @@ void ActiveEventsTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == S::SERIALIZED_SIZE, _argSize, S::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == S::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(S::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_s);
@@ -1870,7 +1932,7 @@ void ActiveEventsTesterBase ::
     }
 
     default: {
-      FW_ASSERT(0, id);
+      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
     }
   }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsTesterBase.ref.cpp
@@ -1610,7 +1610,7 @@ void ActiveEventsTesterBase ::
       FW_ASSERT(_numArgs == 3, _numArgs, 3);
 #endif
 
-      U32 u32;
+      U32 _event_arg_u32;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -1623,13 +1623,13 @@ void ActiveEventsTesterBase ::
         FW_ASSERT(_argSize == sizeof(U32), _argSize, sizeof(U32));
       }
 #endif
-      _status = args.deserialize(u32);
+      _status = args.deserialize(_event_arg_u32);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
 
-      F32 f32;
+      F32 _event_arg_f32;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -1642,13 +1642,13 @@ void ActiveEventsTesterBase ::
         FW_ASSERT(_argSize == sizeof(F32), _argSize, sizeof(F32));
       }
 #endif
-      _status = args.deserialize(f32);
+      _status = args.deserialize(_event_arg_f32);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
 
-      bool b;
+      bool _event_arg_b;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -1661,12 +1661,12 @@ void ActiveEventsTesterBase ::
         FW_ASSERT(_argSize == sizeof(U8), _argSize, sizeof(U8));
       }
 #endif
-      _status = args.deserialize(b);
+      _status = args.deserialize(_event_arg_b);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_ACTIVITY_LO_EventActivityLowThrottled(u32, f32, b);
+      this->logIn_ACTIVITY_LO_EventActivityLowThrottled(_event_arg_u32, _event_arg_f32, _event_arg_b);
       break;
     }
 
@@ -1685,7 +1685,7 @@ void ActiveEventsTesterBase ::
       FW_ASSERT(_numArgs == 2, _numArgs, 2);
 #endif
 
-      Fw::LogStringArg str1;
+      Fw::LogStringArg _event_arg_str1;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -1698,13 +1698,13 @@ void ActiveEventsTesterBase ::
         FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(str1);
+      _status = args.deserialize(_event_arg_str1);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
 
-      Fw::LogStringArg str2;
+      Fw::LogStringArg _event_arg_str2;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -1717,12 +1717,12 @@ void ActiveEventsTesterBase ::
         FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(str2);
+      _status = args.deserialize(_event_arg_str2);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_COMMAND_EventCommand(str1, str2);
+      this->logIn_COMMAND_EventCommand(_event_arg_str1, _event_arg_str2);
       break;
     }
 
@@ -1741,7 +1741,7 @@ void ActiveEventsTesterBase ::
       FW_ASSERT(_numArgs == 1, _numArgs, 1);
 #endif
 
-      E e;
+      E _event_arg_e;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -1754,12 +1754,12 @@ void ActiveEventsTesterBase ::
         FW_ASSERT(_argSize == E::SERIALIZED_SIZE, _argSize, E::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(e);
+      _status = args.deserialize(_event_arg_e);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_DIAGNOSTIC_EventDiagnostic(e);
+      this->logIn_DIAGNOSTIC_EventDiagnostic(_event_arg_e);
       break;
     }
 
@@ -1795,7 +1795,7 @@ void ActiveEventsTesterBase ::
       FW_ASSERT(dummyStackArg == 0, dummyStackArg);
 #endif
 
-      A a;
+      A _event_arg_a;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -1808,12 +1808,12 @@ void ActiveEventsTesterBase ::
         FW_ASSERT(_argSize == A::SERIALIZED_SIZE, _argSize, A::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(a);
+      _status = args.deserialize(_event_arg_a);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_FATAL_EventFatalThrottled(a);
+      this->logIn_FATAL_EventFatalThrottled(_event_arg_a);
       break;
     }
 
@@ -1832,7 +1832,7 @@ void ActiveEventsTesterBase ::
       FW_ASSERT(_numArgs == 1, _numArgs, 1);
 #endif
 
-      S s;
+      S _event_arg_s;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -1845,12 +1845,12 @@ void ActiveEventsTesterBase ::
         FW_ASSERT(_argSize == S::SERIALIZED_SIZE, _argSize, S::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(s);
+      _status = args.deserialize(_event_arg_s);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_WARNING_HI_EventWarningHigh(s);
+      this->logIn_WARNING_HI_EventWarningHigh(_event_arg_s);
       break;
     }
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsTesterBase.ref.cpp
@@ -2147,7 +2147,11 @@ Fw::ParamValid ActiveParamsTesterBase ::
   val.resetSer();
 
   const U32 idBase = _testerBase->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
 
   switch (id - idBase) {
     case ActiveParamsComponentBase::PARAMID_PARAMU32: {
@@ -2211,7 +2215,7 @@ Fw::ParamValid ActiveParamsTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, id);
+      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
   }
 
@@ -2231,7 +2235,11 @@ void ActiveParamsTesterBase ::
   val.resetSer();
 
   const U32 idBase = _testerBase->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
 
   switch (id - idBase) {
     case ActiveParamsComponentBase::PARAMID_PARAMU32: {
@@ -2319,7 +2327,7 @@ void ActiveParamsTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, id);
+      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.cpp
@@ -2833,7 +2833,11 @@ void ActiveSerialTesterBase ::
   args.resetDeser();
 
   const U32 idBase = this->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
 
   switch (id - idBase) {
     case ActiveSerialComponentBase::EVENTID_EVENTACTIVITYHIGH: {
@@ -2863,7 +2867,11 @@ void ActiveSerialTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 3, _numArgs, 3);
+      FW_ASSERT(
+        _numArgs == 3,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(3)
+      );
 #endif
 
       U32 _event_arg_u32;
@@ -2876,7 +2884,11 @@ void ActiveSerialTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == sizeof(U32), _argSize, sizeof(U32));
+        FW_ASSERT(
+          _argSize == sizeof(U32),
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(sizeof(U32))
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_u32);
@@ -2895,7 +2907,11 @@ void ActiveSerialTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == sizeof(F32), _argSize, sizeof(F32));
+        FW_ASSERT(
+          _argSize == sizeof(F32),
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(sizeof(F32))
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_f32);
@@ -2914,7 +2930,11 @@ void ActiveSerialTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == sizeof(U8), _argSize, sizeof(U8));
+        FW_ASSERT(
+          _argSize == sizeof(U8),
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(sizeof(U8))
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_b);
@@ -2938,7 +2958,11 @@ void ActiveSerialTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 2, _numArgs, 2);
+      FW_ASSERT(
+        _numArgs == 2,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(2)
+      );
 #endif
 
       Fw::LogStringArg _event_arg_str1;
@@ -2951,7 +2975,11 @@ void ActiveSerialTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == Fw::LogStringArg::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(Fw::LogStringArg::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_str1);
@@ -2970,7 +2998,11 @@ void ActiveSerialTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == Fw::LogStringArg::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(Fw::LogStringArg::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_str2);
@@ -2994,7 +3026,11 @@ void ActiveSerialTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 1, _numArgs, 1);
+      FW_ASSERT(
+        _numArgs == 1,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(1)
+      );
 #endif
 
       E _event_arg_e;
@@ -3007,7 +3043,11 @@ void ActiveSerialTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == E::SERIALIZED_SIZE, _argSize, E::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == E::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(E::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_e);
@@ -3031,7 +3071,11 @@ void ActiveSerialTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 1 + 1, _numArgs, 1 + 1);
+      FW_ASSERT(
+        _numArgs == 1 + 1,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(1 + 1)
+      );
 
       // For FATAL, there is a stack size of 4 and a dummy entry
       U8 stackArgLen;
@@ -3040,7 +3084,10 @@ void ActiveSerialTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
       );
-      FW_ASSERT(stackArgLen == 4, stackArgLen);
+      FW_ASSERT(
+        stackArgLen == 4,
+        static_cast<FwAssertArgType>(stackArgLen)
+      );
 
       U32 dummyStackArg;
       _status = args.deserialize(dummyStackArg);
@@ -3048,7 +3095,10 @@ void ActiveSerialTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
       );
-      FW_ASSERT(dummyStackArg == 0, dummyStackArg);
+      FW_ASSERT(
+        dummyStackArg == 0,
+        static_cast<FwAssertArgType>(dummyStackArg)
+      );
 #endif
 
       A _event_arg_a;
@@ -3061,7 +3111,11 @@ void ActiveSerialTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == A::SERIALIZED_SIZE, _argSize, A::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == A::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(A::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_a);
@@ -3085,7 +3139,11 @@ void ActiveSerialTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 1, _numArgs, 1);
+      FW_ASSERT(
+        _numArgs == 1,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(1)
+      );
 #endif
 
       S _event_arg_s;
@@ -3098,7 +3156,11 @@ void ActiveSerialTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == S::SERIALIZED_SIZE, _argSize, S::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == S::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(S::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_s);
@@ -3126,7 +3188,7 @@ void ActiveSerialTesterBase ::
     }
 
     default: {
-      FW_ASSERT(0, id);
+      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
     }
   }
@@ -3236,7 +3298,11 @@ void ActiveSerialTesterBase ::
   val.resetDeser();
 
   const U32 idBase = this->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
 
   switch (id - idBase) {
     case ActiveSerialComponentBase::CHANNELID_CHANNELU32FORMAT: {
@@ -3383,7 +3449,7 @@ void ActiveSerialTesterBase ::
     }
 
     default: {
-      FW_ASSERT(0, id);
+      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
     }
   }
@@ -4113,7 +4179,11 @@ Fw::ParamValid ActiveSerialTesterBase ::
   val.resetSer();
 
   const U32 idBase = _testerBase->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
 
   switch (id - idBase) {
     case ActiveSerialComponentBase::PARAMID_PARAMU32: {
@@ -4177,7 +4247,7 @@ Fw::ParamValid ActiveSerialTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, id);
+      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
   }
 
@@ -4197,7 +4267,11 @@ void ActiveSerialTesterBase ::
   val.resetSer();
 
   const U32 idBase = _testerBase->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
 
   switch (id - idBase) {
     case ActiveSerialComponentBase::PARAMID_PARAMU32: {
@@ -4285,7 +4359,7 @@ void ActiveSerialTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, id);
+      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.cpp
@@ -2866,7 +2866,7 @@ void ActiveSerialTesterBase ::
       FW_ASSERT(_numArgs == 3, _numArgs, 3);
 #endif
 
-      U32 u32;
+      U32 _event_arg_u32;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -2879,13 +2879,13 @@ void ActiveSerialTesterBase ::
         FW_ASSERT(_argSize == sizeof(U32), _argSize, sizeof(U32));
       }
 #endif
-      _status = args.deserialize(u32);
+      _status = args.deserialize(_event_arg_u32);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
 
-      F32 f32;
+      F32 _event_arg_f32;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -2898,13 +2898,13 @@ void ActiveSerialTesterBase ::
         FW_ASSERT(_argSize == sizeof(F32), _argSize, sizeof(F32));
       }
 #endif
-      _status = args.deserialize(f32);
+      _status = args.deserialize(_event_arg_f32);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
 
-      bool b;
+      bool _event_arg_b;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -2917,12 +2917,12 @@ void ActiveSerialTesterBase ::
         FW_ASSERT(_argSize == sizeof(U8), _argSize, sizeof(U8));
       }
 #endif
-      _status = args.deserialize(b);
+      _status = args.deserialize(_event_arg_b);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_ACTIVITY_LO_EventActivityLowThrottled(u32, f32, b);
+      this->logIn_ACTIVITY_LO_EventActivityLowThrottled(_event_arg_u32, _event_arg_f32, _event_arg_b);
       break;
     }
 
@@ -2941,7 +2941,7 @@ void ActiveSerialTesterBase ::
       FW_ASSERT(_numArgs == 2, _numArgs, 2);
 #endif
 
-      Fw::LogStringArg str1;
+      Fw::LogStringArg _event_arg_str1;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -2954,13 +2954,13 @@ void ActiveSerialTesterBase ::
         FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(str1);
+      _status = args.deserialize(_event_arg_str1);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
 
-      Fw::LogStringArg str2;
+      Fw::LogStringArg _event_arg_str2;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -2973,12 +2973,12 @@ void ActiveSerialTesterBase ::
         FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(str2);
+      _status = args.deserialize(_event_arg_str2);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_COMMAND_EventCommand(str1, str2);
+      this->logIn_COMMAND_EventCommand(_event_arg_str1, _event_arg_str2);
       break;
     }
 
@@ -2997,7 +2997,7 @@ void ActiveSerialTesterBase ::
       FW_ASSERT(_numArgs == 1, _numArgs, 1);
 #endif
 
-      E e;
+      E _event_arg_e;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -3010,12 +3010,12 @@ void ActiveSerialTesterBase ::
         FW_ASSERT(_argSize == E::SERIALIZED_SIZE, _argSize, E::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(e);
+      _status = args.deserialize(_event_arg_e);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_DIAGNOSTIC_EventDiagnostic(e);
+      this->logIn_DIAGNOSTIC_EventDiagnostic(_event_arg_e);
       break;
     }
 
@@ -3051,7 +3051,7 @@ void ActiveSerialTesterBase ::
       FW_ASSERT(dummyStackArg == 0, dummyStackArg);
 #endif
 
-      A a;
+      A _event_arg_a;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -3064,12 +3064,12 @@ void ActiveSerialTesterBase ::
         FW_ASSERT(_argSize == A::SERIALIZED_SIZE, _argSize, A::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(a);
+      _status = args.deserialize(_event_arg_a);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_FATAL_EventFatalThrottled(a);
+      this->logIn_FATAL_EventFatalThrottled(_event_arg_a);
       break;
     }
 
@@ -3088,7 +3088,7 @@ void ActiveSerialTesterBase ::
       FW_ASSERT(_numArgs == 1, _numArgs, 1);
 #endif
 
-      S s;
+      S _event_arg_s;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -3101,12 +3101,12 @@ void ActiveSerialTesterBase ::
         FW_ASSERT(_argSize == S::SERIALIZED_SIZE, _argSize, S::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(s);
+      _status = args.deserialize(_event_arg_s);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_WARNING_HI_EventWarningHigh(s);
+      this->logIn_WARNING_HI_EventWarningHigh(_event_arg_s);
       break;
     }
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryTesterBase.ref.cpp
@@ -1556,7 +1556,11 @@ void ActiveTelemetryTesterBase ::
   val.resetDeser();
 
   const U32 idBase = this->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
 
   switch (id - idBase) {
     case ActiveTelemetryComponentBase::CHANNELID_CHANNELU32FORMAT: {
@@ -1703,7 +1707,7 @@ void ActiveTelemetryTesterBase ::
     }
 
     default: {
-      FW_ASSERT(0, id);
+      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
     }
   }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.cpp
@@ -2540,7 +2540,7 @@ namespace M {
         FW_ASSERT(_numArgs == 3, _numArgs, 3);
 #endif
 
-        U32 u32;
+        U32 _event_arg_u32;
 #if FW_AMPCS_COMPATIBLE
         {
           // Deserialize the argument size
@@ -2553,13 +2553,13 @@ namespace M {
           FW_ASSERT(_argSize == sizeof(U32), _argSize, sizeof(U32));
         }
 #endif
-        _status = args.deserialize(u32);
+        _status = args.deserialize(_event_arg_u32);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
 
-        F32 f32;
+        F32 _event_arg_f32;
 #if FW_AMPCS_COMPATIBLE
         {
           // Deserialize the argument size
@@ -2572,13 +2572,13 @@ namespace M {
           FW_ASSERT(_argSize == sizeof(F32), _argSize, sizeof(F32));
         }
 #endif
-        _status = args.deserialize(f32);
+        _status = args.deserialize(_event_arg_f32);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
 
-        bool b;
+        bool _event_arg_b;
 #if FW_AMPCS_COMPATIBLE
         {
           // Deserialize the argument size
@@ -2591,12 +2591,12 @@ namespace M {
           FW_ASSERT(_argSize == sizeof(U8), _argSize, sizeof(U8));
         }
 #endif
-        _status = args.deserialize(b);
+        _status = args.deserialize(_event_arg_b);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        this->logIn_ACTIVITY_LO_EventActivityLowThrottled(u32, f32, b);
+        this->logIn_ACTIVITY_LO_EventActivityLowThrottled(_event_arg_u32, _event_arg_f32, _event_arg_b);
         break;
       }
 
@@ -2615,7 +2615,7 @@ namespace M {
         FW_ASSERT(_numArgs == 2, _numArgs, 2);
 #endif
 
-        Fw::LogStringArg str1;
+        Fw::LogStringArg _event_arg_str1;
 #if FW_AMPCS_COMPATIBLE
         {
           // Deserialize the argument size
@@ -2628,13 +2628,13 @@ namespace M {
           FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
         }
 #endif
-        _status = args.deserialize(str1);
+        _status = args.deserialize(_event_arg_str1);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
 
-        Fw::LogStringArg str2;
+        Fw::LogStringArg _event_arg_str2;
 #if FW_AMPCS_COMPATIBLE
         {
           // Deserialize the argument size
@@ -2647,12 +2647,12 @@ namespace M {
           FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
         }
 #endif
-        _status = args.deserialize(str2);
+        _status = args.deserialize(_event_arg_str2);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        this->logIn_COMMAND_EventCommand(str1, str2);
+        this->logIn_COMMAND_EventCommand(_event_arg_str1, _event_arg_str2);
         break;
       }
 
@@ -2671,7 +2671,7 @@ namespace M {
         FW_ASSERT(_numArgs == 1, _numArgs, 1);
 #endif
 
-        E e;
+        E _event_arg_e;
 #if FW_AMPCS_COMPATIBLE
         {
           // Deserialize the argument size
@@ -2684,12 +2684,12 @@ namespace M {
           FW_ASSERT(_argSize == E::SERIALIZED_SIZE, _argSize, E::SERIALIZED_SIZE);
         }
 #endif
-        _status = args.deserialize(e);
+        _status = args.deserialize(_event_arg_e);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        this->logIn_DIAGNOSTIC_EventDiagnostic(e);
+        this->logIn_DIAGNOSTIC_EventDiagnostic(_event_arg_e);
         break;
       }
 
@@ -2725,7 +2725,7 @@ namespace M {
         FW_ASSERT(dummyStackArg == 0, dummyStackArg);
 #endif
 
-        A a;
+        A _event_arg_a;
 #if FW_AMPCS_COMPATIBLE
         {
           // Deserialize the argument size
@@ -2738,12 +2738,12 @@ namespace M {
           FW_ASSERT(_argSize == A::SERIALIZED_SIZE, _argSize, A::SERIALIZED_SIZE);
         }
 #endif
-        _status = args.deserialize(a);
+        _status = args.deserialize(_event_arg_a);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        this->logIn_FATAL_EventFatalThrottled(a);
+        this->logIn_FATAL_EventFatalThrottled(_event_arg_a);
         break;
       }
 
@@ -2762,7 +2762,7 @@ namespace M {
         FW_ASSERT(_numArgs == 1, _numArgs, 1);
 #endif
 
-        S s;
+        S _event_arg_s;
 #if FW_AMPCS_COMPATIBLE
         {
           // Deserialize the argument size
@@ -2775,12 +2775,12 @@ namespace M {
           FW_ASSERT(_argSize == S::SERIALIZED_SIZE, _argSize, S::SERIALIZED_SIZE);
         }
 #endif
-        _status = args.deserialize(s);
+        _status = args.deserialize(_event_arg_s);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        this->logIn_WARNING_HI_EventWarningHigh(s);
+        this->logIn_WARNING_HI_EventWarningHigh(_event_arg_s);
         break;
       }
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.cpp
@@ -2507,7 +2507,11 @@ namespace M {
     args.resetDeser();
 
     const U32 idBase = this->getIdBase();
-    FW_ASSERT(id >= idBase, id, idBase);
+    FW_ASSERT(
+      id >= idBase,
+      static_cast<FwAssertArgType>(id),
+      static_cast<FwAssertArgType>(idBase)
+    );
 
     switch (id - idBase) {
       case ActiveTestComponentBase::EVENTID_EVENTACTIVITYHIGH: {
@@ -2537,7 +2541,11 @@ namespace M {
           static_cast<FwAssertArgType>(_status)
         );
         // Verify they match expected.
-        FW_ASSERT(_numArgs == 3, _numArgs, 3);
+        FW_ASSERT(
+          _numArgs == 3,
+          static_cast<FwAssertArgType>(_numArgs),
+          static_cast<FwAssertArgType>(3)
+        );
 #endif
 
         U32 _event_arg_u32;
@@ -2550,7 +2558,11 @@ namespace M {
             _status == Fw::FW_SERIALIZE_OK,
             static_cast<FwAssertArgType>(_status)
           );
-          FW_ASSERT(_argSize == sizeof(U32), _argSize, sizeof(U32));
+          FW_ASSERT(
+            _argSize == sizeof(U32),
+            static_cast<FwAssertArgType>(_argSize),
+            static_cast<FwAssertArgType>(sizeof(U32))
+          );
         }
 #endif
         _status = args.deserialize(_event_arg_u32);
@@ -2569,7 +2581,11 @@ namespace M {
             _status == Fw::FW_SERIALIZE_OK,
             static_cast<FwAssertArgType>(_status)
           );
-          FW_ASSERT(_argSize == sizeof(F32), _argSize, sizeof(F32));
+          FW_ASSERT(
+            _argSize == sizeof(F32),
+            static_cast<FwAssertArgType>(_argSize),
+            static_cast<FwAssertArgType>(sizeof(F32))
+          );
         }
 #endif
         _status = args.deserialize(_event_arg_f32);
@@ -2588,7 +2604,11 @@ namespace M {
             _status == Fw::FW_SERIALIZE_OK,
             static_cast<FwAssertArgType>(_status)
           );
-          FW_ASSERT(_argSize == sizeof(U8), _argSize, sizeof(U8));
+          FW_ASSERT(
+            _argSize == sizeof(U8),
+            static_cast<FwAssertArgType>(_argSize),
+            static_cast<FwAssertArgType>(sizeof(U8))
+          );
         }
 #endif
         _status = args.deserialize(_event_arg_b);
@@ -2612,7 +2632,11 @@ namespace M {
           static_cast<FwAssertArgType>(_status)
         );
         // Verify they match expected.
-        FW_ASSERT(_numArgs == 2, _numArgs, 2);
+        FW_ASSERT(
+          _numArgs == 2,
+          static_cast<FwAssertArgType>(_numArgs),
+          static_cast<FwAssertArgType>(2)
+        );
 #endif
 
         Fw::LogStringArg _event_arg_str1;
@@ -2625,7 +2649,11 @@ namespace M {
             _status == Fw::FW_SERIALIZE_OK,
             static_cast<FwAssertArgType>(_status)
           );
-          FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
+          FW_ASSERT(
+            _argSize == Fw::LogStringArg::SERIALIZED_SIZE,
+            static_cast<FwAssertArgType>(_argSize),
+            static_cast<FwAssertArgType>(Fw::LogStringArg::SERIALIZED_SIZE)
+          );
         }
 #endif
         _status = args.deserialize(_event_arg_str1);
@@ -2644,7 +2672,11 @@ namespace M {
             _status == Fw::FW_SERIALIZE_OK,
             static_cast<FwAssertArgType>(_status)
           );
-          FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
+          FW_ASSERT(
+            _argSize == Fw::LogStringArg::SERIALIZED_SIZE,
+            static_cast<FwAssertArgType>(_argSize),
+            static_cast<FwAssertArgType>(Fw::LogStringArg::SERIALIZED_SIZE)
+          );
         }
 #endif
         _status = args.deserialize(_event_arg_str2);
@@ -2668,7 +2700,11 @@ namespace M {
           static_cast<FwAssertArgType>(_status)
         );
         // Verify they match expected.
-        FW_ASSERT(_numArgs == 1, _numArgs, 1);
+        FW_ASSERT(
+          _numArgs == 1,
+          static_cast<FwAssertArgType>(_numArgs),
+          static_cast<FwAssertArgType>(1)
+        );
 #endif
 
         E _event_arg_e;
@@ -2681,7 +2717,11 @@ namespace M {
             _status == Fw::FW_SERIALIZE_OK,
             static_cast<FwAssertArgType>(_status)
           );
-          FW_ASSERT(_argSize == E::SERIALIZED_SIZE, _argSize, E::SERIALIZED_SIZE);
+          FW_ASSERT(
+            _argSize == E::SERIALIZED_SIZE,
+            static_cast<FwAssertArgType>(_argSize),
+            static_cast<FwAssertArgType>(E::SERIALIZED_SIZE)
+          );
         }
 #endif
         _status = args.deserialize(_event_arg_e);
@@ -2705,7 +2745,11 @@ namespace M {
           static_cast<FwAssertArgType>(_status)
         );
         // Verify they match expected.
-        FW_ASSERT(_numArgs == 1 + 1, _numArgs, 1 + 1);
+        FW_ASSERT(
+          _numArgs == 1 + 1,
+          static_cast<FwAssertArgType>(_numArgs),
+          static_cast<FwAssertArgType>(1 + 1)
+        );
 
         // For FATAL, there is a stack size of 4 and a dummy entry
         U8 stackArgLen;
@@ -2714,7 +2758,10 @@ namespace M {
             _status == Fw::FW_SERIALIZE_OK,
             static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(stackArgLen == 4, stackArgLen);
+        FW_ASSERT(
+          stackArgLen == 4,
+          static_cast<FwAssertArgType>(stackArgLen)
+        );
 
         U32 dummyStackArg;
         _status = args.deserialize(dummyStackArg);
@@ -2722,7 +2769,10 @@ namespace M {
             _status == Fw::FW_SERIALIZE_OK,
             static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(dummyStackArg == 0, dummyStackArg);
+        FW_ASSERT(
+          dummyStackArg == 0,
+          static_cast<FwAssertArgType>(dummyStackArg)
+        );
 #endif
 
         A _event_arg_a;
@@ -2735,7 +2785,11 @@ namespace M {
             _status == Fw::FW_SERIALIZE_OK,
             static_cast<FwAssertArgType>(_status)
           );
-          FW_ASSERT(_argSize == A::SERIALIZED_SIZE, _argSize, A::SERIALIZED_SIZE);
+          FW_ASSERT(
+            _argSize == A::SERIALIZED_SIZE,
+            static_cast<FwAssertArgType>(_argSize),
+            static_cast<FwAssertArgType>(A::SERIALIZED_SIZE)
+          );
         }
 #endif
         _status = args.deserialize(_event_arg_a);
@@ -2759,7 +2813,11 @@ namespace M {
           static_cast<FwAssertArgType>(_status)
         );
         // Verify they match expected.
-        FW_ASSERT(_numArgs == 1, _numArgs, 1);
+        FW_ASSERT(
+          _numArgs == 1,
+          static_cast<FwAssertArgType>(_numArgs),
+          static_cast<FwAssertArgType>(1)
+        );
 #endif
 
         S _event_arg_s;
@@ -2772,7 +2830,11 @@ namespace M {
             _status == Fw::FW_SERIALIZE_OK,
             static_cast<FwAssertArgType>(_status)
           );
-          FW_ASSERT(_argSize == S::SERIALIZED_SIZE, _argSize, S::SERIALIZED_SIZE);
+          FW_ASSERT(
+            _argSize == S::SERIALIZED_SIZE,
+            static_cast<FwAssertArgType>(_argSize),
+            static_cast<FwAssertArgType>(S::SERIALIZED_SIZE)
+          );
         }
 #endif
         _status = args.deserialize(_event_arg_s);
@@ -2800,7 +2862,7 @@ namespace M {
       }
 
       default: {
-        FW_ASSERT(0, id);
+        FW_ASSERT(0, static_cast<FwAssertArgType>(id));
         break;
       }
     }
@@ -2910,7 +2972,11 @@ namespace M {
     val.resetDeser();
 
     const U32 idBase = this->getIdBase();
-    FW_ASSERT(id >= idBase, id, idBase);
+    FW_ASSERT(
+      id >= idBase,
+      static_cast<FwAssertArgType>(id),
+      static_cast<FwAssertArgType>(idBase)
+    );
 
     switch (id - idBase) {
       case ActiveTestComponentBase::CHANNELID_CHANNELU32FORMAT: {
@@ -3057,7 +3123,7 @@ namespace M {
       }
 
       default: {
-        FW_ASSERT(0, id);
+        FW_ASSERT(0, static_cast<FwAssertArgType>(id));
         break;
       }
     }
@@ -3843,7 +3909,11 @@ namespace M {
     val.resetSer();
 
     const U32 idBase = _testerBase->getIdBase();
-    FW_ASSERT(id >= idBase, id, idBase);
+    FW_ASSERT(
+      id >= idBase,
+      static_cast<FwAssertArgType>(id),
+      static_cast<FwAssertArgType>(idBase)
+    );
 
     switch (id - idBase) {
       case ActiveTestComponentBase::PARAMID_PARAMU32: {
@@ -3907,7 +3977,7 @@ namespace M {
       };
 
       default:
-        FW_ASSERT(0, id);
+        FW_ASSERT(0, static_cast<FwAssertArgType>(id));
         break;
     }
 
@@ -3927,7 +3997,11 @@ namespace M {
     val.resetSer();
 
     const U32 idBase = _testerBase->getIdBase();
-    FW_ASSERT(id >= idBase, id, idBase);
+    FW_ASSERT(
+      id >= idBase,
+      static_cast<FwAssertArgType>(id),
+      static_cast<FwAssertArgType>(idBase)
+    );
 
     switch (id - idBase) {
       case ActiveTestComponentBase::PARAMID_PARAMU32: {
@@ -4015,7 +4089,7 @@ namespace M {
       };
 
       default:
-        FW_ASSERT(0, id);
+        FW_ASSERT(0, static_cast<FwAssertArgType>(id));
         break;
     }
   }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsTesterBase.ref.cpp
@@ -1204,7 +1204,11 @@ void PassiveEventsTesterBase ::
   args.resetDeser();
 
   const U32 idBase = this->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
 
   switch (id - idBase) {
     case PassiveEventsComponentBase::EVENTID_EVENTACTIVITYHIGH: {
@@ -1234,7 +1238,11 @@ void PassiveEventsTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 3, _numArgs, 3);
+      FW_ASSERT(
+        _numArgs == 3,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(3)
+      );
 #endif
 
       U32 _event_arg_u32;
@@ -1247,7 +1255,11 @@ void PassiveEventsTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == sizeof(U32), _argSize, sizeof(U32));
+        FW_ASSERT(
+          _argSize == sizeof(U32),
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(sizeof(U32))
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_u32);
@@ -1266,7 +1278,11 @@ void PassiveEventsTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == sizeof(F32), _argSize, sizeof(F32));
+        FW_ASSERT(
+          _argSize == sizeof(F32),
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(sizeof(F32))
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_f32);
@@ -1285,7 +1301,11 @@ void PassiveEventsTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == sizeof(U8), _argSize, sizeof(U8));
+        FW_ASSERT(
+          _argSize == sizeof(U8),
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(sizeof(U8))
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_b);
@@ -1309,7 +1329,11 @@ void PassiveEventsTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 2, _numArgs, 2);
+      FW_ASSERT(
+        _numArgs == 2,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(2)
+      );
 #endif
 
       Fw::LogStringArg _event_arg_str1;
@@ -1322,7 +1346,11 @@ void PassiveEventsTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == Fw::LogStringArg::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(Fw::LogStringArg::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_str1);
@@ -1341,7 +1369,11 @@ void PassiveEventsTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == Fw::LogStringArg::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(Fw::LogStringArg::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_str2);
@@ -1365,7 +1397,11 @@ void PassiveEventsTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 1, _numArgs, 1);
+      FW_ASSERT(
+        _numArgs == 1,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(1)
+      );
 #endif
 
       E _event_arg_e;
@@ -1378,7 +1414,11 @@ void PassiveEventsTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == E::SERIALIZED_SIZE, _argSize, E::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == E::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(E::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_e);
@@ -1402,7 +1442,11 @@ void PassiveEventsTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 1 + 1, _numArgs, 1 + 1);
+      FW_ASSERT(
+        _numArgs == 1 + 1,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(1 + 1)
+      );
 
       // For FATAL, there is a stack size of 4 and a dummy entry
       U8 stackArgLen;
@@ -1411,7 +1455,10 @@ void PassiveEventsTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
       );
-      FW_ASSERT(stackArgLen == 4, stackArgLen);
+      FW_ASSERT(
+        stackArgLen == 4,
+        static_cast<FwAssertArgType>(stackArgLen)
+      );
 
       U32 dummyStackArg;
       _status = args.deserialize(dummyStackArg);
@@ -1419,7 +1466,10 @@ void PassiveEventsTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
       );
-      FW_ASSERT(dummyStackArg == 0, dummyStackArg);
+      FW_ASSERT(
+        dummyStackArg == 0,
+        static_cast<FwAssertArgType>(dummyStackArg)
+      );
 #endif
 
       A _event_arg_a;
@@ -1432,7 +1482,11 @@ void PassiveEventsTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == A::SERIALIZED_SIZE, _argSize, A::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == A::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(A::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_a);
@@ -1456,7 +1510,11 @@ void PassiveEventsTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 1, _numArgs, 1);
+      FW_ASSERT(
+        _numArgs == 1,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(1)
+      );
 #endif
 
       S _event_arg_s;
@@ -1469,7 +1527,11 @@ void PassiveEventsTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == S::SERIALIZED_SIZE, _argSize, S::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == S::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(S::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_s);
@@ -1497,7 +1559,7 @@ void PassiveEventsTesterBase ::
     }
 
     default: {
-      FW_ASSERT(0, id);
+      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
     }
   }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsTesterBase.ref.cpp
@@ -1237,7 +1237,7 @@ void PassiveEventsTesterBase ::
       FW_ASSERT(_numArgs == 3, _numArgs, 3);
 #endif
 
-      U32 u32;
+      U32 _event_arg_u32;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -1250,13 +1250,13 @@ void PassiveEventsTesterBase ::
         FW_ASSERT(_argSize == sizeof(U32), _argSize, sizeof(U32));
       }
 #endif
-      _status = args.deserialize(u32);
+      _status = args.deserialize(_event_arg_u32);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
 
-      F32 f32;
+      F32 _event_arg_f32;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -1269,13 +1269,13 @@ void PassiveEventsTesterBase ::
         FW_ASSERT(_argSize == sizeof(F32), _argSize, sizeof(F32));
       }
 #endif
-      _status = args.deserialize(f32);
+      _status = args.deserialize(_event_arg_f32);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
 
-      bool b;
+      bool _event_arg_b;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -1288,12 +1288,12 @@ void PassiveEventsTesterBase ::
         FW_ASSERT(_argSize == sizeof(U8), _argSize, sizeof(U8));
       }
 #endif
-      _status = args.deserialize(b);
+      _status = args.deserialize(_event_arg_b);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_ACTIVITY_LO_EventActivityLowThrottled(u32, f32, b);
+      this->logIn_ACTIVITY_LO_EventActivityLowThrottled(_event_arg_u32, _event_arg_f32, _event_arg_b);
       break;
     }
 
@@ -1312,7 +1312,7 @@ void PassiveEventsTesterBase ::
       FW_ASSERT(_numArgs == 2, _numArgs, 2);
 #endif
 
-      Fw::LogStringArg str1;
+      Fw::LogStringArg _event_arg_str1;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -1325,13 +1325,13 @@ void PassiveEventsTesterBase ::
         FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(str1);
+      _status = args.deserialize(_event_arg_str1);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
 
-      Fw::LogStringArg str2;
+      Fw::LogStringArg _event_arg_str2;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -1344,12 +1344,12 @@ void PassiveEventsTesterBase ::
         FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(str2);
+      _status = args.deserialize(_event_arg_str2);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_COMMAND_EventCommand(str1, str2);
+      this->logIn_COMMAND_EventCommand(_event_arg_str1, _event_arg_str2);
       break;
     }
 
@@ -1368,7 +1368,7 @@ void PassiveEventsTesterBase ::
       FW_ASSERT(_numArgs == 1, _numArgs, 1);
 #endif
 
-      E e;
+      E _event_arg_e;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -1381,12 +1381,12 @@ void PassiveEventsTesterBase ::
         FW_ASSERT(_argSize == E::SERIALIZED_SIZE, _argSize, E::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(e);
+      _status = args.deserialize(_event_arg_e);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_DIAGNOSTIC_EventDiagnostic(e);
+      this->logIn_DIAGNOSTIC_EventDiagnostic(_event_arg_e);
       break;
     }
 
@@ -1422,7 +1422,7 @@ void PassiveEventsTesterBase ::
       FW_ASSERT(dummyStackArg == 0, dummyStackArg);
 #endif
 
-      A a;
+      A _event_arg_a;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -1435,12 +1435,12 @@ void PassiveEventsTesterBase ::
         FW_ASSERT(_argSize == A::SERIALIZED_SIZE, _argSize, A::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(a);
+      _status = args.deserialize(_event_arg_a);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_FATAL_EventFatalThrottled(a);
+      this->logIn_FATAL_EventFatalThrottled(_event_arg_a);
       break;
     }
 
@@ -1459,7 +1459,7 @@ void PassiveEventsTesterBase ::
       FW_ASSERT(_numArgs == 1, _numArgs, 1);
 #endif
 
-      S s;
+      S _event_arg_s;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -1472,12 +1472,12 @@ void PassiveEventsTesterBase ::
         FW_ASSERT(_argSize == S::SERIALIZED_SIZE, _argSize, S::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(s);
+      _status = args.deserialize(_event_arg_s);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_WARNING_HI_EventWarningHigh(s);
+      this->logIn_WARNING_HI_EventWarningHigh(_event_arg_s);
       break;
     }
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsTesterBase.ref.cpp
@@ -1774,7 +1774,11 @@ Fw::ParamValid PassiveParamsTesterBase ::
   val.resetSer();
 
   const U32 idBase = _testerBase->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
 
   switch (id - idBase) {
     case PassiveParamsComponentBase::PARAMID_PARAMU32: {
@@ -1838,7 +1842,7 @@ Fw::ParamValid PassiveParamsTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, id);
+      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
   }
 
@@ -1858,7 +1862,11 @@ void PassiveParamsTesterBase ::
   val.resetSer();
 
   const U32 idBase = _testerBase->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
 
   switch (id - idBase) {
     case PassiveParamsComponentBase::PARAMID_PARAMU32: {
@@ -1946,7 +1954,7 @@ void PassiveParamsTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, id);
+      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.cpp
@@ -2053,7 +2053,11 @@ void PassiveSerialTesterBase ::
   args.resetDeser();
 
   const U32 idBase = this->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
 
   switch (id - idBase) {
     case PassiveSerialComponentBase::EVENTID_EVENTACTIVITYHIGH: {
@@ -2083,7 +2087,11 @@ void PassiveSerialTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 3, _numArgs, 3);
+      FW_ASSERT(
+        _numArgs == 3,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(3)
+      );
 #endif
 
       U32 _event_arg_u32;
@@ -2096,7 +2104,11 @@ void PassiveSerialTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == sizeof(U32), _argSize, sizeof(U32));
+        FW_ASSERT(
+          _argSize == sizeof(U32),
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(sizeof(U32))
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_u32);
@@ -2115,7 +2127,11 @@ void PassiveSerialTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == sizeof(F32), _argSize, sizeof(F32));
+        FW_ASSERT(
+          _argSize == sizeof(F32),
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(sizeof(F32))
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_f32);
@@ -2134,7 +2150,11 @@ void PassiveSerialTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == sizeof(U8), _argSize, sizeof(U8));
+        FW_ASSERT(
+          _argSize == sizeof(U8),
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(sizeof(U8))
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_b);
@@ -2158,7 +2178,11 @@ void PassiveSerialTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 2, _numArgs, 2);
+      FW_ASSERT(
+        _numArgs == 2,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(2)
+      );
 #endif
 
       Fw::LogStringArg _event_arg_str1;
@@ -2171,7 +2195,11 @@ void PassiveSerialTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == Fw::LogStringArg::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(Fw::LogStringArg::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_str1);
@@ -2190,7 +2218,11 @@ void PassiveSerialTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == Fw::LogStringArg::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(Fw::LogStringArg::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_str2);
@@ -2214,7 +2246,11 @@ void PassiveSerialTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 1, _numArgs, 1);
+      FW_ASSERT(
+        _numArgs == 1,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(1)
+      );
 #endif
 
       E _event_arg_e;
@@ -2227,7 +2263,11 @@ void PassiveSerialTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == E::SERIALIZED_SIZE, _argSize, E::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == E::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(E::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_e);
@@ -2251,7 +2291,11 @@ void PassiveSerialTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 1 + 1, _numArgs, 1 + 1);
+      FW_ASSERT(
+        _numArgs == 1 + 1,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(1 + 1)
+      );
 
       // For FATAL, there is a stack size of 4 and a dummy entry
       U8 stackArgLen;
@@ -2260,7 +2304,10 @@ void PassiveSerialTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
       );
-      FW_ASSERT(stackArgLen == 4, stackArgLen);
+      FW_ASSERT(
+        stackArgLen == 4,
+        static_cast<FwAssertArgType>(stackArgLen)
+      );
 
       U32 dummyStackArg;
       _status = args.deserialize(dummyStackArg);
@@ -2268,7 +2315,10 @@ void PassiveSerialTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
       );
-      FW_ASSERT(dummyStackArg == 0, dummyStackArg);
+      FW_ASSERT(
+        dummyStackArg == 0,
+        static_cast<FwAssertArgType>(dummyStackArg)
+      );
 #endif
 
       A _event_arg_a;
@@ -2281,7 +2331,11 @@ void PassiveSerialTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == A::SERIALIZED_SIZE, _argSize, A::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == A::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(A::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_a);
@@ -2305,7 +2359,11 @@ void PassiveSerialTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 1, _numArgs, 1);
+      FW_ASSERT(
+        _numArgs == 1,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(1)
+      );
 #endif
 
       S _event_arg_s;
@@ -2318,7 +2376,11 @@ void PassiveSerialTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == S::SERIALIZED_SIZE, _argSize, S::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == S::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(S::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_s);
@@ -2346,7 +2408,7 @@ void PassiveSerialTesterBase ::
     }
 
     default: {
-      FW_ASSERT(0, id);
+      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
     }
   }
@@ -2456,7 +2518,11 @@ void PassiveSerialTesterBase ::
   val.resetDeser();
 
   const U32 idBase = this->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
 
   switch (id - idBase) {
     case PassiveSerialComponentBase::CHANNELID_CHANNELU32FORMAT: {
@@ -2603,7 +2669,7 @@ void PassiveSerialTesterBase ::
     }
 
     default: {
-      FW_ASSERT(0, id);
+      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
     }
   }
@@ -3333,7 +3399,11 @@ Fw::ParamValid PassiveSerialTesterBase ::
   val.resetSer();
 
   const U32 idBase = _testerBase->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
 
   switch (id - idBase) {
     case PassiveSerialComponentBase::PARAMID_PARAMU32: {
@@ -3397,7 +3467,7 @@ Fw::ParamValid PassiveSerialTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, id);
+      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
   }
 
@@ -3417,7 +3487,11 @@ void PassiveSerialTesterBase ::
   val.resetSer();
 
   const U32 idBase = _testerBase->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
 
   switch (id - idBase) {
     case PassiveSerialComponentBase::PARAMID_PARAMU32: {
@@ -3505,7 +3579,7 @@ void PassiveSerialTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, id);
+      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.cpp
@@ -2086,7 +2086,7 @@ void PassiveSerialTesterBase ::
       FW_ASSERT(_numArgs == 3, _numArgs, 3);
 #endif
 
-      U32 u32;
+      U32 _event_arg_u32;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -2099,13 +2099,13 @@ void PassiveSerialTesterBase ::
         FW_ASSERT(_argSize == sizeof(U32), _argSize, sizeof(U32));
       }
 #endif
-      _status = args.deserialize(u32);
+      _status = args.deserialize(_event_arg_u32);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
 
-      F32 f32;
+      F32 _event_arg_f32;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -2118,13 +2118,13 @@ void PassiveSerialTesterBase ::
         FW_ASSERT(_argSize == sizeof(F32), _argSize, sizeof(F32));
       }
 #endif
-      _status = args.deserialize(f32);
+      _status = args.deserialize(_event_arg_f32);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
 
-      bool b;
+      bool _event_arg_b;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -2137,12 +2137,12 @@ void PassiveSerialTesterBase ::
         FW_ASSERT(_argSize == sizeof(U8), _argSize, sizeof(U8));
       }
 #endif
-      _status = args.deserialize(b);
+      _status = args.deserialize(_event_arg_b);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_ACTIVITY_LO_EventActivityLowThrottled(u32, f32, b);
+      this->logIn_ACTIVITY_LO_EventActivityLowThrottled(_event_arg_u32, _event_arg_f32, _event_arg_b);
       break;
     }
 
@@ -2161,7 +2161,7 @@ void PassiveSerialTesterBase ::
       FW_ASSERT(_numArgs == 2, _numArgs, 2);
 #endif
 
-      Fw::LogStringArg str1;
+      Fw::LogStringArg _event_arg_str1;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -2174,13 +2174,13 @@ void PassiveSerialTesterBase ::
         FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(str1);
+      _status = args.deserialize(_event_arg_str1);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
 
-      Fw::LogStringArg str2;
+      Fw::LogStringArg _event_arg_str2;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -2193,12 +2193,12 @@ void PassiveSerialTesterBase ::
         FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(str2);
+      _status = args.deserialize(_event_arg_str2);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_COMMAND_EventCommand(str1, str2);
+      this->logIn_COMMAND_EventCommand(_event_arg_str1, _event_arg_str2);
       break;
     }
 
@@ -2217,7 +2217,7 @@ void PassiveSerialTesterBase ::
       FW_ASSERT(_numArgs == 1, _numArgs, 1);
 #endif
 
-      E e;
+      E _event_arg_e;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -2230,12 +2230,12 @@ void PassiveSerialTesterBase ::
         FW_ASSERT(_argSize == E::SERIALIZED_SIZE, _argSize, E::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(e);
+      _status = args.deserialize(_event_arg_e);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_DIAGNOSTIC_EventDiagnostic(e);
+      this->logIn_DIAGNOSTIC_EventDiagnostic(_event_arg_e);
       break;
     }
 
@@ -2271,7 +2271,7 @@ void PassiveSerialTesterBase ::
       FW_ASSERT(dummyStackArg == 0, dummyStackArg);
 #endif
 
-      A a;
+      A _event_arg_a;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -2284,12 +2284,12 @@ void PassiveSerialTesterBase ::
         FW_ASSERT(_argSize == A::SERIALIZED_SIZE, _argSize, A::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(a);
+      _status = args.deserialize(_event_arg_a);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_FATAL_EventFatalThrottled(a);
+      this->logIn_FATAL_EventFatalThrottled(_event_arg_a);
       break;
     }
 
@@ -2308,7 +2308,7 @@ void PassiveSerialTesterBase ::
       FW_ASSERT(_numArgs == 1, _numArgs, 1);
 #endif
 
-      S s;
+      S _event_arg_s;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -2321,12 +2321,12 @@ void PassiveSerialTesterBase ::
         FW_ASSERT(_argSize == S::SERIALIZED_SIZE, _argSize, S::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(s);
+      _status = args.deserialize(_event_arg_s);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_WARNING_HI_EventWarningHigh(s);
+      this->logIn_WARNING_HI_EventWarningHigh(_event_arg_s);
       break;
     }
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryTesterBase.ref.cpp
@@ -1183,7 +1183,11 @@ void PassiveTelemetryTesterBase ::
   val.resetDeser();
 
   const U32 idBase = this->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
 
   switch (id - idBase) {
     case PassiveTelemetryComponentBase::CHANNELID_CHANNELU32FORMAT: {
@@ -1330,7 +1334,7 @@ void PassiveTelemetryTesterBase ::
     }
 
     default: {
-      FW_ASSERT(0, id);
+      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
     }
   }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.cpp
@@ -2022,7 +2022,7 @@ void PassiveTestTesterBase ::
       FW_ASSERT(_numArgs == 3, _numArgs, 3);
 #endif
 
-      U32 u32;
+      U32 _event_arg_u32;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -2035,13 +2035,13 @@ void PassiveTestTesterBase ::
         FW_ASSERT(_argSize == sizeof(U32), _argSize, sizeof(U32));
       }
 #endif
-      _status = args.deserialize(u32);
+      _status = args.deserialize(_event_arg_u32);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
 
-      F32 f32;
+      F32 _event_arg_f32;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -2054,13 +2054,13 @@ void PassiveTestTesterBase ::
         FW_ASSERT(_argSize == sizeof(F32), _argSize, sizeof(F32));
       }
 #endif
-      _status = args.deserialize(f32);
+      _status = args.deserialize(_event_arg_f32);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
 
-      bool b;
+      bool _event_arg_b;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -2073,12 +2073,12 @@ void PassiveTestTesterBase ::
         FW_ASSERT(_argSize == sizeof(U8), _argSize, sizeof(U8));
       }
 #endif
-      _status = args.deserialize(b);
+      _status = args.deserialize(_event_arg_b);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_ACTIVITY_LO_EventActivityLowThrottled(u32, f32, b);
+      this->logIn_ACTIVITY_LO_EventActivityLowThrottled(_event_arg_u32, _event_arg_f32, _event_arg_b);
       break;
     }
 
@@ -2097,7 +2097,7 @@ void PassiveTestTesterBase ::
       FW_ASSERT(_numArgs == 2, _numArgs, 2);
 #endif
 
-      Fw::LogStringArg str1;
+      Fw::LogStringArg _event_arg_str1;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -2110,13 +2110,13 @@ void PassiveTestTesterBase ::
         FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(str1);
+      _status = args.deserialize(_event_arg_str1);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
 
-      Fw::LogStringArg str2;
+      Fw::LogStringArg _event_arg_str2;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -2129,12 +2129,12 @@ void PassiveTestTesterBase ::
         FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(str2);
+      _status = args.deserialize(_event_arg_str2);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_COMMAND_EventCommand(str1, str2);
+      this->logIn_COMMAND_EventCommand(_event_arg_str1, _event_arg_str2);
       break;
     }
 
@@ -2153,7 +2153,7 @@ void PassiveTestTesterBase ::
       FW_ASSERT(_numArgs == 1, _numArgs, 1);
 #endif
 
-      E e;
+      E _event_arg_e;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -2166,12 +2166,12 @@ void PassiveTestTesterBase ::
         FW_ASSERT(_argSize == E::SERIALIZED_SIZE, _argSize, E::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(e);
+      _status = args.deserialize(_event_arg_e);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_DIAGNOSTIC_EventDiagnostic(e);
+      this->logIn_DIAGNOSTIC_EventDiagnostic(_event_arg_e);
       break;
     }
 
@@ -2207,7 +2207,7 @@ void PassiveTestTesterBase ::
       FW_ASSERT(dummyStackArg == 0, dummyStackArg);
 #endif
 
-      A a;
+      A _event_arg_a;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -2220,12 +2220,12 @@ void PassiveTestTesterBase ::
         FW_ASSERT(_argSize == A::SERIALIZED_SIZE, _argSize, A::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(a);
+      _status = args.deserialize(_event_arg_a);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_FATAL_EventFatalThrottled(a);
+      this->logIn_FATAL_EventFatalThrottled(_event_arg_a);
       break;
     }
 
@@ -2244,7 +2244,7 @@ void PassiveTestTesterBase ::
       FW_ASSERT(_numArgs == 1, _numArgs, 1);
 #endif
 
-      S s;
+      S _event_arg_s;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -2257,12 +2257,12 @@ void PassiveTestTesterBase ::
         FW_ASSERT(_argSize == S::SERIALIZED_SIZE, _argSize, S::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(s);
+      _status = args.deserialize(_event_arg_s);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_WARNING_HI_EventWarningHigh(s);
+      this->logIn_WARNING_HI_EventWarningHigh(_event_arg_s);
       break;
     }
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.cpp
@@ -1989,7 +1989,11 @@ void PassiveTestTesterBase ::
   args.resetDeser();
 
   const U32 idBase = this->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
 
   switch (id - idBase) {
     case PassiveTestComponentBase::EVENTID_EVENTACTIVITYHIGH: {
@@ -2019,7 +2023,11 @@ void PassiveTestTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 3, _numArgs, 3);
+      FW_ASSERT(
+        _numArgs == 3,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(3)
+      );
 #endif
 
       U32 _event_arg_u32;
@@ -2032,7 +2040,11 @@ void PassiveTestTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == sizeof(U32), _argSize, sizeof(U32));
+        FW_ASSERT(
+          _argSize == sizeof(U32),
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(sizeof(U32))
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_u32);
@@ -2051,7 +2063,11 @@ void PassiveTestTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == sizeof(F32), _argSize, sizeof(F32));
+        FW_ASSERT(
+          _argSize == sizeof(F32),
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(sizeof(F32))
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_f32);
@@ -2070,7 +2086,11 @@ void PassiveTestTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == sizeof(U8), _argSize, sizeof(U8));
+        FW_ASSERT(
+          _argSize == sizeof(U8),
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(sizeof(U8))
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_b);
@@ -2094,7 +2114,11 @@ void PassiveTestTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 2, _numArgs, 2);
+      FW_ASSERT(
+        _numArgs == 2,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(2)
+      );
 #endif
 
       Fw::LogStringArg _event_arg_str1;
@@ -2107,7 +2131,11 @@ void PassiveTestTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == Fw::LogStringArg::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(Fw::LogStringArg::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_str1);
@@ -2126,7 +2154,11 @@ void PassiveTestTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == Fw::LogStringArg::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(Fw::LogStringArg::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_str2);
@@ -2150,7 +2182,11 @@ void PassiveTestTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 1, _numArgs, 1);
+      FW_ASSERT(
+        _numArgs == 1,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(1)
+      );
 #endif
 
       E _event_arg_e;
@@ -2163,7 +2199,11 @@ void PassiveTestTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == E::SERIALIZED_SIZE, _argSize, E::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == E::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(E::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_e);
@@ -2187,7 +2227,11 @@ void PassiveTestTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 1 + 1, _numArgs, 1 + 1);
+      FW_ASSERT(
+        _numArgs == 1 + 1,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(1 + 1)
+      );
 
       // For FATAL, there is a stack size of 4 and a dummy entry
       U8 stackArgLen;
@@ -2196,7 +2240,10 @@ void PassiveTestTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
       );
-      FW_ASSERT(stackArgLen == 4, stackArgLen);
+      FW_ASSERT(
+        stackArgLen == 4,
+        static_cast<FwAssertArgType>(stackArgLen)
+      );
 
       U32 dummyStackArg;
       _status = args.deserialize(dummyStackArg);
@@ -2204,7 +2251,10 @@ void PassiveTestTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
       );
-      FW_ASSERT(dummyStackArg == 0, dummyStackArg);
+      FW_ASSERT(
+        dummyStackArg == 0,
+        static_cast<FwAssertArgType>(dummyStackArg)
+      );
 #endif
 
       A _event_arg_a;
@@ -2217,7 +2267,11 @@ void PassiveTestTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == A::SERIALIZED_SIZE, _argSize, A::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == A::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(A::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_a);
@@ -2241,7 +2295,11 @@ void PassiveTestTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 1, _numArgs, 1);
+      FW_ASSERT(
+        _numArgs == 1,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(1)
+      );
 #endif
 
       S _event_arg_s;
@@ -2254,7 +2312,11 @@ void PassiveTestTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == S::SERIALIZED_SIZE, _argSize, S::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == S::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(S::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_s);
@@ -2282,7 +2344,7 @@ void PassiveTestTesterBase ::
     }
 
     default: {
-      FW_ASSERT(0, id);
+      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
     }
   }
@@ -2392,7 +2454,11 @@ void PassiveTestTesterBase ::
   val.resetDeser();
 
   const U32 idBase = this->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
 
   switch (id - idBase) {
     case PassiveTestComponentBase::CHANNELID_CHANNELU32FORMAT: {
@@ -2539,7 +2605,7 @@ void PassiveTestTesterBase ::
     }
 
     default: {
-      FW_ASSERT(0, id);
+      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
     }
   }
@@ -3325,7 +3391,11 @@ Fw::ParamValid PassiveTestTesterBase ::
   val.resetSer();
 
   const U32 idBase = _testerBase->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
 
   switch (id - idBase) {
     case PassiveTestComponentBase::PARAMID_PARAMU32: {
@@ -3389,7 +3459,7 @@ Fw::ParamValid PassiveTestTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, id);
+      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
   }
 
@@ -3409,7 +3479,11 @@ void PassiveTestTesterBase ::
   val.resetSer();
 
   const U32 idBase = _testerBase->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
 
   switch (id - idBase) {
     case PassiveTestComponentBase::PARAMID_PARAMU32: {
@@ -3497,7 +3571,7 @@ void PassiveTestTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, id);
+      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsTesterBase.ref.cpp
@@ -1610,7 +1610,7 @@ void QueuedEventsTesterBase ::
       FW_ASSERT(_numArgs == 3, _numArgs, 3);
 #endif
 
-      U32 u32;
+      U32 _event_arg_u32;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -1623,13 +1623,13 @@ void QueuedEventsTesterBase ::
         FW_ASSERT(_argSize == sizeof(U32), _argSize, sizeof(U32));
       }
 #endif
-      _status = args.deserialize(u32);
+      _status = args.deserialize(_event_arg_u32);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
 
-      F32 f32;
+      F32 _event_arg_f32;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -1642,13 +1642,13 @@ void QueuedEventsTesterBase ::
         FW_ASSERT(_argSize == sizeof(F32), _argSize, sizeof(F32));
       }
 #endif
-      _status = args.deserialize(f32);
+      _status = args.deserialize(_event_arg_f32);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
 
-      bool b;
+      bool _event_arg_b;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -1661,12 +1661,12 @@ void QueuedEventsTesterBase ::
         FW_ASSERT(_argSize == sizeof(U8), _argSize, sizeof(U8));
       }
 #endif
-      _status = args.deserialize(b);
+      _status = args.deserialize(_event_arg_b);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_ACTIVITY_LO_EventActivityLowThrottled(u32, f32, b);
+      this->logIn_ACTIVITY_LO_EventActivityLowThrottled(_event_arg_u32, _event_arg_f32, _event_arg_b);
       break;
     }
 
@@ -1685,7 +1685,7 @@ void QueuedEventsTesterBase ::
       FW_ASSERT(_numArgs == 2, _numArgs, 2);
 #endif
 
-      Fw::LogStringArg str1;
+      Fw::LogStringArg _event_arg_str1;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -1698,13 +1698,13 @@ void QueuedEventsTesterBase ::
         FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(str1);
+      _status = args.deserialize(_event_arg_str1);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
 
-      Fw::LogStringArg str2;
+      Fw::LogStringArg _event_arg_str2;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -1717,12 +1717,12 @@ void QueuedEventsTesterBase ::
         FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(str2);
+      _status = args.deserialize(_event_arg_str2);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_COMMAND_EventCommand(str1, str2);
+      this->logIn_COMMAND_EventCommand(_event_arg_str1, _event_arg_str2);
       break;
     }
 
@@ -1741,7 +1741,7 @@ void QueuedEventsTesterBase ::
       FW_ASSERT(_numArgs == 1, _numArgs, 1);
 #endif
 
-      E e;
+      E _event_arg_e;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -1754,12 +1754,12 @@ void QueuedEventsTesterBase ::
         FW_ASSERT(_argSize == E::SERIALIZED_SIZE, _argSize, E::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(e);
+      _status = args.deserialize(_event_arg_e);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_DIAGNOSTIC_EventDiagnostic(e);
+      this->logIn_DIAGNOSTIC_EventDiagnostic(_event_arg_e);
       break;
     }
 
@@ -1795,7 +1795,7 @@ void QueuedEventsTesterBase ::
       FW_ASSERT(dummyStackArg == 0, dummyStackArg);
 #endif
 
-      A a;
+      A _event_arg_a;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -1808,12 +1808,12 @@ void QueuedEventsTesterBase ::
         FW_ASSERT(_argSize == A::SERIALIZED_SIZE, _argSize, A::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(a);
+      _status = args.deserialize(_event_arg_a);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_FATAL_EventFatalThrottled(a);
+      this->logIn_FATAL_EventFatalThrottled(_event_arg_a);
       break;
     }
 
@@ -1832,7 +1832,7 @@ void QueuedEventsTesterBase ::
       FW_ASSERT(_numArgs == 1, _numArgs, 1);
 #endif
 
-      S s;
+      S _event_arg_s;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -1845,12 +1845,12 @@ void QueuedEventsTesterBase ::
         FW_ASSERT(_argSize == S::SERIALIZED_SIZE, _argSize, S::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(s);
+      _status = args.deserialize(_event_arg_s);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_WARNING_HI_EventWarningHigh(s);
+      this->logIn_WARNING_HI_EventWarningHigh(_event_arg_s);
       break;
     }
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsTesterBase.ref.cpp
@@ -1577,7 +1577,11 @@ void QueuedEventsTesterBase ::
   args.resetDeser();
 
   const U32 idBase = this->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
 
   switch (id - idBase) {
     case QueuedEventsComponentBase::EVENTID_EVENTACTIVITYHIGH: {
@@ -1607,7 +1611,11 @@ void QueuedEventsTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 3, _numArgs, 3);
+      FW_ASSERT(
+        _numArgs == 3,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(3)
+      );
 #endif
 
       U32 _event_arg_u32;
@@ -1620,7 +1628,11 @@ void QueuedEventsTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == sizeof(U32), _argSize, sizeof(U32));
+        FW_ASSERT(
+          _argSize == sizeof(U32),
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(sizeof(U32))
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_u32);
@@ -1639,7 +1651,11 @@ void QueuedEventsTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == sizeof(F32), _argSize, sizeof(F32));
+        FW_ASSERT(
+          _argSize == sizeof(F32),
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(sizeof(F32))
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_f32);
@@ -1658,7 +1674,11 @@ void QueuedEventsTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == sizeof(U8), _argSize, sizeof(U8));
+        FW_ASSERT(
+          _argSize == sizeof(U8),
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(sizeof(U8))
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_b);
@@ -1682,7 +1702,11 @@ void QueuedEventsTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 2, _numArgs, 2);
+      FW_ASSERT(
+        _numArgs == 2,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(2)
+      );
 #endif
 
       Fw::LogStringArg _event_arg_str1;
@@ -1695,7 +1719,11 @@ void QueuedEventsTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == Fw::LogStringArg::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(Fw::LogStringArg::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_str1);
@@ -1714,7 +1742,11 @@ void QueuedEventsTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == Fw::LogStringArg::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(Fw::LogStringArg::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_str2);
@@ -1738,7 +1770,11 @@ void QueuedEventsTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 1, _numArgs, 1);
+      FW_ASSERT(
+        _numArgs == 1,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(1)
+      );
 #endif
 
       E _event_arg_e;
@@ -1751,7 +1787,11 @@ void QueuedEventsTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == E::SERIALIZED_SIZE, _argSize, E::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == E::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(E::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_e);
@@ -1775,7 +1815,11 @@ void QueuedEventsTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 1 + 1, _numArgs, 1 + 1);
+      FW_ASSERT(
+        _numArgs == 1 + 1,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(1 + 1)
+      );
 
       // For FATAL, there is a stack size of 4 and a dummy entry
       U8 stackArgLen;
@@ -1784,7 +1828,10 @@ void QueuedEventsTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
       );
-      FW_ASSERT(stackArgLen == 4, stackArgLen);
+      FW_ASSERT(
+        stackArgLen == 4,
+        static_cast<FwAssertArgType>(stackArgLen)
+      );
 
       U32 dummyStackArg;
       _status = args.deserialize(dummyStackArg);
@@ -1792,7 +1839,10 @@ void QueuedEventsTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
       );
-      FW_ASSERT(dummyStackArg == 0, dummyStackArg);
+      FW_ASSERT(
+        dummyStackArg == 0,
+        static_cast<FwAssertArgType>(dummyStackArg)
+      );
 #endif
 
       A _event_arg_a;
@@ -1805,7 +1855,11 @@ void QueuedEventsTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == A::SERIALIZED_SIZE, _argSize, A::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == A::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(A::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_a);
@@ -1829,7 +1883,11 @@ void QueuedEventsTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 1, _numArgs, 1);
+      FW_ASSERT(
+        _numArgs == 1,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(1)
+      );
 #endif
 
       S _event_arg_s;
@@ -1842,7 +1900,11 @@ void QueuedEventsTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == S::SERIALIZED_SIZE, _argSize, S::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == S::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(S::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_s);
@@ -1870,7 +1932,7 @@ void QueuedEventsTesterBase ::
     }
 
     default: {
-      FW_ASSERT(0, id);
+      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
     }
   }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsTesterBase.ref.cpp
@@ -2147,7 +2147,11 @@ Fw::ParamValid QueuedParamsTesterBase ::
   val.resetSer();
 
   const U32 idBase = _testerBase->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
 
   switch (id - idBase) {
     case QueuedParamsComponentBase::PARAMID_PARAMU32: {
@@ -2211,7 +2215,7 @@ Fw::ParamValid QueuedParamsTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, id);
+      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
   }
 
@@ -2231,7 +2235,11 @@ void QueuedParamsTesterBase ::
   val.resetSer();
 
   const U32 idBase = _testerBase->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
 
   switch (id - idBase) {
     case QueuedParamsComponentBase::PARAMID_PARAMU32: {
@@ -2319,7 +2327,7 @@ void QueuedParamsTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, id);
+      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.cpp
@@ -2833,7 +2833,11 @@ void QueuedSerialTesterBase ::
   args.resetDeser();
 
   const U32 idBase = this->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
 
   switch (id - idBase) {
     case QueuedSerialComponentBase::EVENTID_EVENTACTIVITYHIGH: {
@@ -2863,7 +2867,11 @@ void QueuedSerialTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 3, _numArgs, 3);
+      FW_ASSERT(
+        _numArgs == 3,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(3)
+      );
 #endif
 
       U32 _event_arg_u32;
@@ -2876,7 +2884,11 @@ void QueuedSerialTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == sizeof(U32), _argSize, sizeof(U32));
+        FW_ASSERT(
+          _argSize == sizeof(U32),
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(sizeof(U32))
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_u32);
@@ -2895,7 +2907,11 @@ void QueuedSerialTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == sizeof(F32), _argSize, sizeof(F32));
+        FW_ASSERT(
+          _argSize == sizeof(F32),
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(sizeof(F32))
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_f32);
@@ -2914,7 +2930,11 @@ void QueuedSerialTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == sizeof(U8), _argSize, sizeof(U8));
+        FW_ASSERT(
+          _argSize == sizeof(U8),
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(sizeof(U8))
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_b);
@@ -2938,7 +2958,11 @@ void QueuedSerialTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 2, _numArgs, 2);
+      FW_ASSERT(
+        _numArgs == 2,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(2)
+      );
 #endif
 
       Fw::LogStringArg _event_arg_str1;
@@ -2951,7 +2975,11 @@ void QueuedSerialTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == Fw::LogStringArg::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(Fw::LogStringArg::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_str1);
@@ -2970,7 +2998,11 @@ void QueuedSerialTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == Fw::LogStringArg::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(Fw::LogStringArg::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_str2);
@@ -2994,7 +3026,11 @@ void QueuedSerialTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 1, _numArgs, 1);
+      FW_ASSERT(
+        _numArgs == 1,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(1)
+      );
 #endif
 
       E _event_arg_e;
@@ -3007,7 +3043,11 @@ void QueuedSerialTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == E::SERIALIZED_SIZE, _argSize, E::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == E::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(E::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_e);
@@ -3031,7 +3071,11 @@ void QueuedSerialTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 1 + 1, _numArgs, 1 + 1);
+      FW_ASSERT(
+        _numArgs == 1 + 1,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(1 + 1)
+      );
 
       // For FATAL, there is a stack size of 4 and a dummy entry
       U8 stackArgLen;
@@ -3040,7 +3084,10 @@ void QueuedSerialTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
       );
-      FW_ASSERT(stackArgLen == 4, stackArgLen);
+      FW_ASSERT(
+        stackArgLen == 4,
+        static_cast<FwAssertArgType>(stackArgLen)
+      );
 
       U32 dummyStackArg;
       _status = args.deserialize(dummyStackArg);
@@ -3048,7 +3095,10 @@ void QueuedSerialTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
       );
-      FW_ASSERT(dummyStackArg == 0, dummyStackArg);
+      FW_ASSERT(
+        dummyStackArg == 0,
+        static_cast<FwAssertArgType>(dummyStackArg)
+      );
 #endif
 
       A _event_arg_a;
@@ -3061,7 +3111,11 @@ void QueuedSerialTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == A::SERIALIZED_SIZE, _argSize, A::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == A::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(A::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_a);
@@ -3085,7 +3139,11 @@ void QueuedSerialTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 1, _numArgs, 1);
+      FW_ASSERT(
+        _numArgs == 1,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(1)
+      );
 #endif
 
       S _event_arg_s;
@@ -3098,7 +3156,11 @@ void QueuedSerialTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == S::SERIALIZED_SIZE, _argSize, S::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == S::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(S::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_s);
@@ -3126,7 +3188,7 @@ void QueuedSerialTesterBase ::
     }
 
     default: {
-      FW_ASSERT(0, id);
+      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
     }
   }
@@ -3236,7 +3298,11 @@ void QueuedSerialTesterBase ::
   val.resetDeser();
 
   const U32 idBase = this->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
 
   switch (id - idBase) {
     case QueuedSerialComponentBase::CHANNELID_CHANNELU32FORMAT: {
@@ -3383,7 +3449,7 @@ void QueuedSerialTesterBase ::
     }
 
     default: {
-      FW_ASSERT(0, id);
+      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
     }
   }
@@ -4113,7 +4179,11 @@ Fw::ParamValid QueuedSerialTesterBase ::
   val.resetSer();
 
   const U32 idBase = _testerBase->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
 
   switch (id - idBase) {
     case QueuedSerialComponentBase::PARAMID_PARAMU32: {
@@ -4177,7 +4247,7 @@ Fw::ParamValid QueuedSerialTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, id);
+      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
   }
 
@@ -4197,7 +4267,11 @@ void QueuedSerialTesterBase ::
   val.resetSer();
 
   const U32 idBase = _testerBase->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
 
   switch (id - idBase) {
     case QueuedSerialComponentBase::PARAMID_PARAMU32: {
@@ -4285,7 +4359,7 @@ void QueuedSerialTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, id);
+      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.cpp
@@ -2866,7 +2866,7 @@ void QueuedSerialTesterBase ::
       FW_ASSERT(_numArgs == 3, _numArgs, 3);
 #endif
 
-      U32 u32;
+      U32 _event_arg_u32;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -2879,13 +2879,13 @@ void QueuedSerialTesterBase ::
         FW_ASSERT(_argSize == sizeof(U32), _argSize, sizeof(U32));
       }
 #endif
-      _status = args.deserialize(u32);
+      _status = args.deserialize(_event_arg_u32);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
 
-      F32 f32;
+      F32 _event_arg_f32;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -2898,13 +2898,13 @@ void QueuedSerialTesterBase ::
         FW_ASSERT(_argSize == sizeof(F32), _argSize, sizeof(F32));
       }
 #endif
-      _status = args.deserialize(f32);
+      _status = args.deserialize(_event_arg_f32);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
 
-      bool b;
+      bool _event_arg_b;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -2917,12 +2917,12 @@ void QueuedSerialTesterBase ::
         FW_ASSERT(_argSize == sizeof(U8), _argSize, sizeof(U8));
       }
 #endif
-      _status = args.deserialize(b);
+      _status = args.deserialize(_event_arg_b);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_ACTIVITY_LO_EventActivityLowThrottled(u32, f32, b);
+      this->logIn_ACTIVITY_LO_EventActivityLowThrottled(_event_arg_u32, _event_arg_f32, _event_arg_b);
       break;
     }
 
@@ -2941,7 +2941,7 @@ void QueuedSerialTesterBase ::
       FW_ASSERT(_numArgs == 2, _numArgs, 2);
 #endif
 
-      Fw::LogStringArg str1;
+      Fw::LogStringArg _event_arg_str1;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -2954,13 +2954,13 @@ void QueuedSerialTesterBase ::
         FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(str1);
+      _status = args.deserialize(_event_arg_str1);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
 
-      Fw::LogStringArg str2;
+      Fw::LogStringArg _event_arg_str2;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -2973,12 +2973,12 @@ void QueuedSerialTesterBase ::
         FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(str2);
+      _status = args.deserialize(_event_arg_str2);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_COMMAND_EventCommand(str1, str2);
+      this->logIn_COMMAND_EventCommand(_event_arg_str1, _event_arg_str2);
       break;
     }
 
@@ -2997,7 +2997,7 @@ void QueuedSerialTesterBase ::
       FW_ASSERT(_numArgs == 1, _numArgs, 1);
 #endif
 
-      E e;
+      E _event_arg_e;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -3010,12 +3010,12 @@ void QueuedSerialTesterBase ::
         FW_ASSERT(_argSize == E::SERIALIZED_SIZE, _argSize, E::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(e);
+      _status = args.deserialize(_event_arg_e);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_DIAGNOSTIC_EventDiagnostic(e);
+      this->logIn_DIAGNOSTIC_EventDiagnostic(_event_arg_e);
       break;
     }
 
@@ -3051,7 +3051,7 @@ void QueuedSerialTesterBase ::
       FW_ASSERT(dummyStackArg == 0, dummyStackArg);
 #endif
 
-      A a;
+      A _event_arg_a;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -3064,12 +3064,12 @@ void QueuedSerialTesterBase ::
         FW_ASSERT(_argSize == A::SERIALIZED_SIZE, _argSize, A::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(a);
+      _status = args.deserialize(_event_arg_a);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_FATAL_EventFatalThrottled(a);
+      this->logIn_FATAL_EventFatalThrottled(_event_arg_a);
       break;
     }
 
@@ -3088,7 +3088,7 @@ void QueuedSerialTesterBase ::
       FW_ASSERT(_numArgs == 1, _numArgs, 1);
 #endif
 
-      S s;
+      S _event_arg_s;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -3101,12 +3101,12 @@ void QueuedSerialTesterBase ::
         FW_ASSERT(_argSize == S::SERIALIZED_SIZE, _argSize, S::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(s);
+      _status = args.deserialize(_event_arg_s);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_WARNING_HI_EventWarningHigh(s);
+      this->logIn_WARNING_HI_EventWarningHigh(_event_arg_s);
       break;
     }
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryTesterBase.ref.cpp
@@ -1556,7 +1556,11 @@ void QueuedTelemetryTesterBase ::
   val.resetDeser();
 
   const U32 idBase = this->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
 
   switch (id - idBase) {
     case QueuedTelemetryComponentBase::CHANNELID_CHANNELU32FORMAT: {
@@ -1703,7 +1707,7 @@ void QueuedTelemetryTesterBase ::
     }
 
     default: {
-      FW_ASSERT(0, id);
+      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
     }
   }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.cpp
@@ -2505,7 +2505,11 @@ void QueuedTestTesterBase ::
   args.resetDeser();
 
   const U32 idBase = this->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
 
   switch (id - idBase) {
     case QueuedTestComponentBase::EVENTID_EVENTACTIVITYHIGH: {
@@ -2535,7 +2539,11 @@ void QueuedTestTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 3, _numArgs, 3);
+      FW_ASSERT(
+        _numArgs == 3,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(3)
+      );
 #endif
 
       U32 _event_arg_u32;
@@ -2548,7 +2556,11 @@ void QueuedTestTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == sizeof(U32), _argSize, sizeof(U32));
+        FW_ASSERT(
+          _argSize == sizeof(U32),
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(sizeof(U32))
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_u32);
@@ -2567,7 +2579,11 @@ void QueuedTestTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == sizeof(F32), _argSize, sizeof(F32));
+        FW_ASSERT(
+          _argSize == sizeof(F32),
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(sizeof(F32))
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_f32);
@@ -2586,7 +2602,11 @@ void QueuedTestTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == sizeof(U8), _argSize, sizeof(U8));
+        FW_ASSERT(
+          _argSize == sizeof(U8),
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(sizeof(U8))
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_b);
@@ -2610,7 +2630,11 @@ void QueuedTestTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 2, _numArgs, 2);
+      FW_ASSERT(
+        _numArgs == 2,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(2)
+      );
 #endif
 
       Fw::LogStringArg _event_arg_str1;
@@ -2623,7 +2647,11 @@ void QueuedTestTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == Fw::LogStringArg::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(Fw::LogStringArg::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_str1);
@@ -2642,7 +2670,11 @@ void QueuedTestTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == Fw::LogStringArg::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(Fw::LogStringArg::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_str2);
@@ -2666,7 +2698,11 @@ void QueuedTestTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 1, _numArgs, 1);
+      FW_ASSERT(
+        _numArgs == 1,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(1)
+      );
 #endif
 
       E _event_arg_e;
@@ -2679,7 +2715,11 @@ void QueuedTestTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == E::SERIALIZED_SIZE, _argSize, E::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == E::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(E::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_e);
@@ -2703,7 +2743,11 @@ void QueuedTestTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 1 + 1, _numArgs, 1 + 1);
+      FW_ASSERT(
+        _numArgs == 1 + 1,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(1 + 1)
+      );
 
       // For FATAL, there is a stack size of 4 and a dummy entry
       U8 stackArgLen;
@@ -2712,7 +2756,10 @@ void QueuedTestTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
       );
-      FW_ASSERT(stackArgLen == 4, stackArgLen);
+      FW_ASSERT(
+        stackArgLen == 4,
+        static_cast<FwAssertArgType>(stackArgLen)
+      );
 
       U32 dummyStackArg;
       _status = args.deserialize(dummyStackArg);
@@ -2720,7 +2767,10 @@ void QueuedTestTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
       );
-      FW_ASSERT(dummyStackArg == 0, dummyStackArg);
+      FW_ASSERT(
+        dummyStackArg == 0,
+        static_cast<FwAssertArgType>(dummyStackArg)
+      );
 #endif
 
       A _event_arg_a;
@@ -2733,7 +2783,11 @@ void QueuedTestTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == A::SERIALIZED_SIZE, _argSize, A::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == A::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(A::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_a);
@@ -2757,7 +2811,11 @@ void QueuedTestTesterBase ::
         static_cast<FwAssertArgType>(_status)
       );
       // Verify they match expected.
-      FW_ASSERT(_numArgs == 1, _numArgs, 1);
+      FW_ASSERT(
+        _numArgs == 1,
+        static_cast<FwAssertArgType>(_numArgs),
+        static_cast<FwAssertArgType>(1)
+      );
 #endif
 
       S _event_arg_s;
@@ -2770,7 +2828,11 @@ void QueuedTestTesterBase ::
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
         );
-        FW_ASSERT(_argSize == S::SERIALIZED_SIZE, _argSize, S::SERIALIZED_SIZE);
+        FW_ASSERT(
+          _argSize == S::SERIALIZED_SIZE,
+          static_cast<FwAssertArgType>(_argSize),
+          static_cast<FwAssertArgType>(S::SERIALIZED_SIZE)
+        );
       }
 #endif
       _status = args.deserialize(_event_arg_s);
@@ -2798,7 +2860,7 @@ void QueuedTestTesterBase ::
     }
 
     default: {
-      FW_ASSERT(0, id);
+      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
     }
   }
@@ -2908,7 +2970,11 @@ void QueuedTestTesterBase ::
   val.resetDeser();
 
   const U32 idBase = this->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
 
   switch (id - idBase) {
     case QueuedTestComponentBase::CHANNELID_CHANNELU32FORMAT: {
@@ -3055,7 +3121,7 @@ void QueuedTestTesterBase ::
     }
 
     default: {
-      FW_ASSERT(0, id);
+      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
     }
   }
@@ -3841,7 +3907,11 @@ Fw::ParamValid QueuedTestTesterBase ::
   val.resetSer();
 
   const U32 idBase = _testerBase->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
 
   switch (id - idBase) {
     case QueuedTestComponentBase::PARAMID_PARAMU32: {
@@ -3905,7 +3975,7 @@ Fw::ParamValid QueuedTestTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, id);
+      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
   }
 
@@ -3925,7 +3995,11 @@ void QueuedTestTesterBase ::
   val.resetSer();
 
   const U32 idBase = _testerBase->getIdBase();
-  FW_ASSERT(id >= idBase, id, idBase);
+  FW_ASSERT(
+    id >= idBase,
+    static_cast<FwAssertArgType>(id),
+    static_cast<FwAssertArgType>(idBase)
+  );
 
   switch (id - idBase) {
     case QueuedTestComponentBase::PARAMID_PARAMU32: {
@@ -4013,7 +4087,7 @@ void QueuedTestTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, id);
+      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.cpp
@@ -2538,7 +2538,7 @@ void QueuedTestTesterBase ::
       FW_ASSERT(_numArgs == 3, _numArgs, 3);
 #endif
 
-      U32 u32;
+      U32 _event_arg_u32;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -2551,13 +2551,13 @@ void QueuedTestTesterBase ::
         FW_ASSERT(_argSize == sizeof(U32), _argSize, sizeof(U32));
       }
 #endif
-      _status = args.deserialize(u32);
+      _status = args.deserialize(_event_arg_u32);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
 
-      F32 f32;
+      F32 _event_arg_f32;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -2570,13 +2570,13 @@ void QueuedTestTesterBase ::
         FW_ASSERT(_argSize == sizeof(F32), _argSize, sizeof(F32));
       }
 #endif
-      _status = args.deserialize(f32);
+      _status = args.deserialize(_event_arg_f32);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
 
-      bool b;
+      bool _event_arg_b;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -2589,12 +2589,12 @@ void QueuedTestTesterBase ::
         FW_ASSERT(_argSize == sizeof(U8), _argSize, sizeof(U8));
       }
 #endif
-      _status = args.deserialize(b);
+      _status = args.deserialize(_event_arg_b);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_ACTIVITY_LO_EventActivityLowThrottled(u32, f32, b);
+      this->logIn_ACTIVITY_LO_EventActivityLowThrottled(_event_arg_u32, _event_arg_f32, _event_arg_b);
       break;
     }
 
@@ -2613,7 +2613,7 @@ void QueuedTestTesterBase ::
       FW_ASSERT(_numArgs == 2, _numArgs, 2);
 #endif
 
-      Fw::LogStringArg str1;
+      Fw::LogStringArg _event_arg_str1;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -2626,13 +2626,13 @@ void QueuedTestTesterBase ::
         FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(str1);
+      _status = args.deserialize(_event_arg_str1);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
 
-      Fw::LogStringArg str2;
+      Fw::LogStringArg _event_arg_str2;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -2645,12 +2645,12 @@ void QueuedTestTesterBase ::
         FW_ASSERT(_argSize == Fw::LogStringArg::SERIALIZED_SIZE, _argSize, Fw::LogStringArg::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(str2);
+      _status = args.deserialize(_event_arg_str2);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_COMMAND_EventCommand(str1, str2);
+      this->logIn_COMMAND_EventCommand(_event_arg_str1, _event_arg_str2);
       break;
     }
 
@@ -2669,7 +2669,7 @@ void QueuedTestTesterBase ::
       FW_ASSERT(_numArgs == 1, _numArgs, 1);
 #endif
 
-      E e;
+      E _event_arg_e;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -2682,12 +2682,12 @@ void QueuedTestTesterBase ::
         FW_ASSERT(_argSize == E::SERIALIZED_SIZE, _argSize, E::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(e);
+      _status = args.deserialize(_event_arg_e);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_DIAGNOSTIC_EventDiagnostic(e);
+      this->logIn_DIAGNOSTIC_EventDiagnostic(_event_arg_e);
       break;
     }
 
@@ -2723,7 +2723,7 @@ void QueuedTestTesterBase ::
       FW_ASSERT(dummyStackArg == 0, dummyStackArg);
 #endif
 
-      A a;
+      A _event_arg_a;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -2736,12 +2736,12 @@ void QueuedTestTesterBase ::
         FW_ASSERT(_argSize == A::SERIALIZED_SIZE, _argSize, A::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(a);
+      _status = args.deserialize(_event_arg_a);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_FATAL_EventFatalThrottled(a);
+      this->logIn_FATAL_EventFatalThrottled(_event_arg_a);
       break;
     }
 
@@ -2760,7 +2760,7 @@ void QueuedTestTesterBase ::
       FW_ASSERT(_numArgs == 1, _numArgs, 1);
 #endif
 
-      S s;
+      S _event_arg_s;
 #if FW_AMPCS_COMPATIBLE
       {
         // Deserialize the argument size
@@ -2773,12 +2773,12 @@ void QueuedTestTesterBase ::
         FW_ASSERT(_argSize == S::SERIALIZED_SIZE, _argSize, S::SERIALIZED_SIZE);
       }
 #endif
-      _status = args.deserialize(s);
+      _status = args.deserialize(_event_arg_s);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
-      this->logIn_WARNING_HI_EventWarningHigh(s);
+      this->logIn_WARNING_HI_EventWarningHigh(_event_arg_s);
       break;
     }
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/check-cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/check-cpp
@@ -6,7 +6,6 @@ fprime_gcc=../../../../../scripts/fprime-gcc
 export FPRIME_GCC_FLAGS="-I../../fprime"
 warning_flags="
 -Wno-return-type
--Wno-sign-conversion
 -Wno-unused-parameter
 "
 include_flags="

--- a/compiler/tools/fpp-to-cpp/test/struct/FormatSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/FormatSerializableAc.ref.cpp
@@ -353,13 +353,13 @@ void Format ::
     this->m_m8,
     this->m_m9,
     this->m_m10,
-    static_cast<U64>(this->m_m11),
-    static_cast<U64>(this->m_m12),
-    static_cast<U64>(this->m_m13),
-    static_cast<U64>(this->m_m14),
-    static_cast<U64>(this->m_m15),
-    static_cast<U64>(this->m_m16),
-    static_cast<U64>(this->m_m17)
+    static_cast<F64>(this->m_m11),
+    static_cast<F64>(this->m_m12),
+    static_cast<F64>(this->m_m13),
+    static_cast<F64>(this->m_m14),
+    static_cast<F64>(this->m_m15),
+    static_cast<F64>(this->m_m16),
+    static_cast<F64>(this->m_m17)
   );
 }
 

--- a/compiler/tools/fpp-to-cpp/test/struct/FormatSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/FormatSerializableAc.ref.cpp
@@ -353,13 +353,13 @@ void Format ::
     this->m_m8,
     this->m_m9,
     this->m_m10,
-    this->m_m11,
-    this->m_m12,
-    this->m_m13,
-    this->m_m14,
-    this->m_m15,
-    this->m_m16,
-    this->m_m17
+    static_cast<U64>(this->m_m11),
+    static_cast<U64>(this->m_m12),
+    static_cast<U64>(this->m_m13),
+    static_cast<U64>(this->m_m14),
+    static_cast<U64>(this->m_m15),
+    static_cast<U64>(this->m_m16),
+    static_cast<U64>(this->m_m17)
   );
 }
 

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules1SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules1SerializableAc.ref.cpp
@@ -136,7 +136,7 @@ namespace M {
     sb.format(
       formatString,
       this->m_x,
-      this->m_y
+      static_cast<U64>(this->m_y)
     );
   }
 

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules1SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules1SerializableAc.ref.cpp
@@ -136,7 +136,7 @@ namespace M {
     sb.format(
       formatString,
       this->m_x,
-      static_cast<U64>(this->m_y)
+      static_cast<F64>(this->m_y)
     );
   }
 

--- a/compiler/tools/fpp-to-cpp/test/struct/PrimitiveSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/PrimitiveSerializableAc.ref.cpp
@@ -328,9 +328,9 @@ void Primitive ::
 
   sb.format(
     formatString,
-    this->m_mF32[0],
-    this->m_mF32[1],
-    this->m_mF32[2],
+    static_cast<U64>(this->m_mF32[0]),
+    static_cast<U64>(this->m_mF32[1]),
+    static_cast<U64>(this->m_mF32[2]),
     this->m_mF64,
     this->m_mI16,
     this->m_mI32,

--- a/compiler/tools/fpp-to-cpp/test/struct/PrimitiveSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/PrimitiveSerializableAc.ref.cpp
@@ -328,9 +328,9 @@ void Primitive ::
 
   sb.format(
     formatString,
-    static_cast<U64>(this->m_mF32[0]),
-    static_cast<U64>(this->m_mF32[1]),
-    static_cast<U64>(this->m_mF32[2]),
+    static_cast<F64>(this->m_mF32[0]),
+    static_cast<F64>(this->m_mF32[1]),
+    static_cast<F64>(this->m_mF32[2]),
     this->m_mF64,
     this->m_mI16,
     this->m_mI32,

--- a/docs/fpp-spec.html
+++ b/docs/fpp-spec.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.20">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>The F Prime Prime (FPP) Language Specification, Unreleased, after v2.3.0</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
@@ -140,7 +140,7 @@ p a>code:hover{color:rgba(0,0,0,.9)}
 #content::before{content:none}
 #header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
 #header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
-#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
+#header>h1:only-child{border-bottom:1px solid #dddddf;padding-bottom:8px}
 #header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
 #header .details span:first-child{margin-left:-.125em}
 #header .details span.email a{color:rgba(0,0,0,.85)}
@@ -162,6 +162,7 @@ p a>code:hover{color:rgba(0,0,0,.9)}
 #toctitle{color:#7a2518;font-size:1.2em}
 @media screen and (min-width:768px){#toctitle{font-size:1.375em}
 body.toc2{padding-left:15em;padding-right:0}
+body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
 #toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
 #toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
 #toc.toc2>ul{font-size:.9em;margin-bottom:0}
@@ -327,7 +328,7 @@ a.image{text-decoration:none;display:inline-block}
 a.image object{pointer-events:none}
 sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
 sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+sup.footnote a:active,sup.footnoteref a:active,#footnotes .footnote a:first-of-type:active{text-decoration:underline}
 #footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
 #footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
 #footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
@@ -11152,7 +11153,7 @@ equivalent.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2025-02-18 16:14:41 -0800
+Last updated 2025-02-20 10:06:58 -0800
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-users-guide.html
+++ b/docs/fpp-users-guide.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.20">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>The F Prime Prime (FPP) User&#8217;s Guide, Unreleased, after v2.3.0</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
@@ -140,7 +140,7 @@ p a>code:hover{color:rgba(0,0,0,.9)}
 #content::before{content:none}
 #header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
 #header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
-#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
+#header>h1:only-child{border-bottom:1px solid #dddddf;padding-bottom:8px}
 #header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
 #header .details span:first-child{margin-left:-.125em}
 #header .details span.email a{color:rgba(0,0,0,.85)}
@@ -162,6 +162,7 @@ p a>code:hover{color:rgba(0,0,0,.9)}
 #toctitle{color:#7a2518;font-size:1.2em}
 @media screen and (min-width:768px){#toctitle{font-size:1.375em}
 body.toc2{padding-left:15em;padding-right:0}
+body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
 #toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
 #toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
 #toc.toc2>ul{font-size:.9em;margin-bottom:0}
@@ -327,7 +328,7 @@ a.image{text-decoration:none;display:inline-block}
 a.image object{pointer-events:none}
 sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
 sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+sup.footnote a:active,sup.footnoteref a:active,#footnotes .footnote a:first-of-type:active{text-decoration:underline}
 #footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
 #footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
 #footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
@@ -714,6 +715,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#Analyzing-and-Translating-Models_Generating-C-Plus-Plus_Types-Ports-State-Machines-and-Components">14.3.2. Types, Ports, State Machines, and Components</a></li>
 <li><a href="#Analyzing-and-Translating-Models_Generating-C-Plus-Plus_Component-Implementation-and-Unit-Test-Code">14.3.3. Component Implementation and Unit Test Code</a></li>
 <li><a href="#Analyzing-and-Translating-Models_Generating-C-Plus-Plus_Topology-Definitions">14.3.4. Topology Definitions</a></li>
+<li><a href="#Analyzing-and-Translating-Models_Generating-C-Plus-Plus_Compiling-the-Generated-Code">14.3.5. Compiling the Generated Code</a></li>
 </ul>
 </li>
 <li><a href="#Analyzing-and-Translating-Models_Identifying-Generated-Files">14.4. Identifying Generated Files</a>
@@ -13200,6 +13202,35 @@ The <code>-g</code> option is ignored, because
 the include guard prefix comes from the name of the topology.</p>
 </div>
 </div>
+<div class="sect3">
+<h4 id="Analyzing-and-Translating-Models_Generating-C-Plus-Plus_Compiling-the-Generated-Code">14.3.5. Compiling the Generated Code</h4>
+<div class="paragraph">
+<p>The generated C&#43;&#43; is intended to compile with the following gcc
+and clang compiler flags:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>--std=c++11
+-Wall
+-Wconversion
+-Wdouble-promotion
+-Werror
+-Wextra
+-Wno-unused-parameter
+-Wold-style-cast
+-Wshadow
+-pedantic</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>When using clang, the following flags must also be set:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>-Wno-vla-extension</pre>
+</div>
+</div>
+</div>
 </div>
 <div class="sect2">
 <h3 id="Analyzing-and-Translating-Models_Identifying-Generated-Files">14.4. Identifying Generated Files</h3>
@@ -14859,7 +14890,7 @@ function, you may.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2025-02-18 16:15:01 -0800
+Last updated 2025-02-20 09:49:49 -0800
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/users-guide/Analyzing-and-Translating-Models.adoc
+++ b/docs/users-guide/Analyzing-and-Translating-Models.adoc
@@ -702,7 +702,6 @@ the include guard prefix comes from the name of the topology.
 The generated {cpp} is intended to compile with the following gcc
 and clang compiler flags:
 
-[source]
 ----
 --std=c++11
 -Wall
@@ -718,7 +717,6 @@ and clang compiler flags:
 
 When using clang, the following flags must also be set:
 
-[source]
 ----
 -Wno-vla-extension
 ----


### PR DESCRIPTION
* Add casts to avoid double promotion warnings
* In unit test code
  * Rename variables to avoid shadowing
  * Add casts to avoid conversion warnings
* Update the fpp-to-cpp compilation tests to enable these warnings
* Update the User's Guide to state the gcc/clang flags that are supported

Closes #621.