### PR TITLE
Add type aliases to JSON dictionary

### DIFF
--- a/compiler/lib/src/main/scala/analysis/Semantics/Type.scala
+++ b/compiler/lib/src/main/scala/analysis/Semantics/Type.scala
@@ -197,7 +197,7 @@ object Type {
     override def getDefNodeId = Some(node._2.id)
     override def toString = node._2.data.name
     override def isCanonical = false
-    override def isDisplayable = aliasType.getUnderlyingType.isDisplayable
+    override def isDisplayable = getUnderlyingType.isDisplayable
     override def getUnderlyingType = aliasType.getUnderlyingType
   }
 

--- a/compiler/lib/src/main/scala/analysis/Semantics/Type.scala
+++ b/compiler/lib/src/main/scala/analysis/Semantics/Type.scala
@@ -197,6 +197,7 @@ object Type {
     override def getDefNodeId = Some(node._2.id)
     override def toString = node._2.data.name
     override def isCanonical = false
+    override def isDisplayable = aliasType.getUnderlyingType.isDisplayable
     override def getUnderlyingType = aliasType.getUnderlyingType
   }
 

--- a/compiler/tools/fpp-to-dict/test/dictionary.schema.json
+++ b/compiler/tools/fpp-to-dict/test/dictionary.schema.json
@@ -279,6 +279,9 @@
                             },
                             "underlyingType": {
                                 "$ref": "#/$defs/typeDescriptor"
+                            },
+                            "annotation": {
+                                "type": "string"
                             }
                         },
                         "required": [

--- a/compiler/tools/fpp-to-dict/test/dictionary.schema.json
+++ b/compiler/tools/fpp-to-dict/test/dictionary.schema.json
@@ -261,6 +261,32 @@
                             "members",
                             "default"
                         ]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "kind": {
+                                "type": "string",
+                                "enum": [
+                                    "alias"
+                                ]
+                            },
+                            "qualifiedName": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "$ref": "#/$defs/typeDescriptor"
+                            },
+                            "underlyingType": {
+                                "$ref": "#/$defs/typeDescriptor"
+                            }
+                        },
+                        "required": [
+                            "kind",
+                            "qualifiedName",
+                            "type",
+                            "underlyingType"
+                        ]
                     }
                 ]
             }

--- a/compiler/tools/fpp-to-dict/test/top/BasicDpTopologyDictionary.ref.json
+++ b/compiler/tools/fpp-to-dict/test/top/BasicDpTopologyDictionary.ref.json
@@ -45,10 +45,8 @@
       "members" : {
         "u16Field" : {
           "type" : {
-            "name" : "U16",
-            "kind" : "integer",
-            "size" : 16,
-            "signed" : false
+            "name" : "FppTest.DpTestComponent.AliasU16",
+            "kind" : "qualifiedIdentifier"
           },
           "index" : 0,
           "annotation" : "A U16 field"
@@ -58,6 +56,22 @@
         "u16Field" : 0
       },
       "annotation" : "Data for a DataRecord"
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FppTest.DpTestComponent.AliasU16",
+      "type" : {
+        "name" : "U16",
+        "kind" : "integer",
+        "size" : 16,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U16",
+        "kind" : "integer",
+        "size" : 16,
+        "signed" : false
+      }
     }
   ],
   "commands" : [

--- a/compiler/tools/fpp-to-dict/test/top/BasicDpTopologyDictionary.ref.json
+++ b/compiler/tools/fpp-to-dict/test/top/BasicDpTopologyDictionary.ref.json
@@ -9,6 +9,41 @@
   },
   "typeDefinitions" : [
     {
+      "kind" : "alias",
+      "qualifiedName" : "FppTest.DpTestComponent.AliasU16",
+      "type" : {
+        "name" : "U16",
+        "kind" : "integer",
+        "size" : 16,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U16",
+        "kind" : "integer",
+        "size" : 16,
+        "signed" : false
+      },
+      "annotation" : "Alias of type U16"
+    },
+    {
+      "kind" : "struct",
+      "qualifiedName" : "FppTest.DpTestComponent.Data",
+      "members" : {
+        "u16Field" : {
+          "type" : {
+            "name" : "FppTest.DpTestComponent.AliasU16",
+            "kind" : "qualifiedIdentifier"
+          },
+          "index" : 0,
+          "annotation" : "A U16 field"
+        }
+      },
+      "default" : {
+        "u16Field" : 0
+      },
+      "annotation" : "Data for a DataRecord"
+    },
+    {
       "kind" : "struct",
       "qualifiedName" : "FppTest.DpTestComponent.Complex",
       "members" : {
@@ -38,40 +73,6 @@
         "f2" : 0
       },
       "annotation" : "Data for a ComplexRecord"
-    },
-    {
-      "kind" : "struct",
-      "qualifiedName" : "FppTest.DpTestComponent.Data",
-      "members" : {
-        "u16Field" : {
-          "type" : {
-            "name" : "FppTest.DpTestComponent.AliasU16",
-            "kind" : "qualifiedIdentifier"
-          },
-          "index" : 0,
-          "annotation" : "A U16 field"
-        }
-      },
-      "default" : {
-        "u16Field" : 0
-      },
-      "annotation" : "Data for a DataRecord"
-    },
-    {
-      "kind" : "alias",
-      "qualifiedName" : "FppTest.DpTestComponent.AliasU16",
-      "type" : {
-        "name" : "U16",
-        "kind" : "integer",
-        "size" : 16,
-        "signed" : false
-      },
-      "underlyingType" : {
-        "name" : "U16",
-        "kind" : "integer",
-        "size" : 16,
-        "signed" : false
-      }
     }
   ],
   "commands" : [

--- a/compiler/tools/fpp-to-dict/test/top/FirstTopTopologyDictionary.ref.json
+++ b/compiler/tools/fpp-to-dict/test/top/FirstTopTopologyDictionary.ref.json
@@ -11,22 +11,6 @@
   },
   "typeDefinitions" : [
     {
-      "kind" : "alias",
-      "qualifiedName" : "Module1.AliasT1",
-      "type" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
-      },
-      "underlyingType" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
-      }
-    },
-    {
       "kind" : "struct",
       "qualifiedName" : "Module1.S2",
       "members" : {
@@ -77,17 +61,20 @@
     },
     {
       "kind" : "alias",
-      "qualifiedName" : "Module1.AliasT2",
+      "qualifiedName" : "Module1.AliasT1",
       "type" : {
-        "name" : "Module1.AliasT1",
-        "kind" : "qualifiedIdentifier"
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
       },
       "underlyingType" : {
         "name" : "U32",
         "kind" : "integer",
         "size" : 32,
         "signed" : false
-      }
+      },
+      "annotation" : "Alias of type U32"
     },
     {
       "kind" : "struct",
@@ -194,6 +181,21 @@
         "i32" : 0,
         "u16" : 0
       }
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "Module1.AliasT2",
+      "type" : {
+        "name" : "Module1.AliasT1",
+        "kind" : "qualifiedIdentifier"
+      },
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      },
+      "annotation" : "Alias of type AliasT1 (with underlying type U32)"
     },
     {
       "kind" : "struct",

--- a/compiler/tools/fpp-to-dict/test/top/FirstTopTopologyDictionary.ref.json
+++ b/compiler/tools/fpp-to-dict/test/top/FirstTopTopologyDictionary.ref.json
@@ -11,6 +11,22 @@
   },
   "typeDefinitions" : [
     {
+      "kind" : "alias",
+      "qualifiedName" : "Module1.AliasT1",
+      "type" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      }
+    },
+    {
       "kind" : "struct",
       "qualifiedName" : "Module1.S2",
       "members" : {
@@ -58,6 +74,20 @@
         }
       ],
       "default" : "Module1.E2.PASS"
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "Module1.AliasT2",
+      "type" : {
+        "name" : "Module1.AliasT1",
+        "kind" : "qualifiedIdentifier"
+      },
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      }
     },
     {
       "kind" : "struct",
@@ -208,6 +238,20 @@
         "B"
       ],
       "annotation" : "An array of 2 String values"
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "Module1.AliasT3",
+      "type" : {
+        "name" : "string",
+        "kind" : "string",
+        "size" : 20
+      },
+      "underlyingType" : {
+        "name" : "string",
+        "kind" : "string",
+        "size" : 20
+      }
     },
     {
       "kind" : "enum",
@@ -441,9 +485,8 @@
         {
           "name" : "val",
           "type" : {
-            "name" : "string",
-            "kind" : "string",
-            "size" : 20
+            "name" : "Module1.AliasT3",
+            "kind" : "qualifiedIdentifier"
           },
           "ref" : false
         }
@@ -602,9 +645,8 @@
     {
       "name" : "Module1.myFirstC1.Param3",
       "type" : {
-        "name" : "string",
-        "kind" : "string",
-        "size" : 20
+        "name" : "Module1.AliasT3",
+        "kind" : "qualifiedIdentifier"
       },
       "id" : 771,
       "annotation" : "Parameter of type string"
@@ -806,10 +848,8 @@
     {
       "name" : "Module1.myFirstC1.Record1",
       "type" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
+        "name" : "Module1.AliasT2",
+        "kind" : "qualifiedIdentifier"
       },
       "array" : false,
       "id" : 768,

--- a/compiler/tools/fpp-to-dict/test/top/SecondTopTopologyDictionary.ref.json
+++ b/compiler/tools/fpp-to-dict/test/top/SecondTopTopologyDictionary.ref.json
@@ -11,22 +11,6 @@
   },
   "typeDefinitions" : [
     {
-      "kind" : "alias",
-      "qualifiedName" : "Module1.AliasT1",
-      "type" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
-      },
-      "underlyingType" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
-      }
-    },
-    {
       "kind" : "struct",
       "qualifiedName" : "Module1.S2",
       "members" : {
@@ -77,17 +61,20 @@
     },
     {
       "kind" : "alias",
-      "qualifiedName" : "Module1.AliasT2",
+      "qualifiedName" : "Module1.AliasT1",
       "type" : {
-        "name" : "Module1.AliasT1",
-        "kind" : "qualifiedIdentifier"
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
       },
       "underlyingType" : {
         "name" : "U32",
         "kind" : "integer",
         "size" : 32,
         "signed" : false
-      }
+      },
+      "annotation" : "Alias of type U32"
     },
     {
       "kind" : "struct",
@@ -194,6 +181,21 @@
         "i32" : 0,
         "u16" : 0
       }
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "Module1.AliasT2",
+      "type" : {
+        "name" : "Module1.AliasT1",
+        "kind" : "qualifiedIdentifier"
+      },
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      },
+      "annotation" : "Alias of type AliasT1 (with underlying type U32)"
     },
     {
       "kind" : "struct",

--- a/compiler/tools/fpp-to-dict/test/top/SecondTopTopologyDictionary.ref.json
+++ b/compiler/tools/fpp-to-dict/test/top/SecondTopTopologyDictionary.ref.json
@@ -11,6 +11,22 @@
   },
   "typeDefinitions" : [
     {
+      "kind" : "alias",
+      "qualifiedName" : "Module1.AliasT1",
+      "type" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      }
+    },
+    {
       "kind" : "struct",
       "qualifiedName" : "Module1.S2",
       "members" : {
@@ -58,6 +74,20 @@
         }
       ],
       "default" : "Module1.E2.PASS"
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "Module1.AliasT2",
+      "type" : {
+        "name" : "Module1.AliasT1",
+        "kind" : "qualifiedIdentifier"
+      },
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      }
     },
     {
       "kind" : "struct",
@@ -208,6 +238,20 @@
         "B"
       ],
       "annotation" : "An array of 2 String values"
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "Module1.AliasT3",
+      "type" : {
+        "name" : "string",
+        "kind" : "string",
+        "size" : 20
+      },
+      "underlyingType" : {
+        "name" : "string",
+        "kind" : "string",
+        "size" : 20
+      }
     },
     {
       "kind" : "enum",
@@ -441,9 +485,8 @@
         {
           "name" : "val",
           "type" : {
-            "name" : "string",
-            "kind" : "string",
-            "size" : 20
+            "name" : "Module1.AliasT3",
+            "kind" : "qualifiedIdentifier"
           },
           "ref" : false
         }
@@ -602,9 +645,8 @@
     {
       "name" : "Module1.mySecondC1.Param3",
       "type" : {
-        "name" : "string",
-        "kind" : "string",
-        "size" : 20
+        "name" : "Module1.AliasT3",
+        "kind" : "qualifiedIdentifier"
       },
       "id" : 1283,
       "annotation" : "Parameter of type string"
@@ -806,10 +848,8 @@
     {
       "name" : "Module1.mySecondC1.Record1",
       "type" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
+        "name" : "Module1.AliasT2",
+        "kind" : "qualifiedIdentifier"
       },
       "array" : false,
       "id" : 1280,

--- a/compiler/tools/fpp-to-dict/test/top/dataProducts.fpp
+++ b/compiler/tools/fpp-to-dict/test/top/dataProducts.fpp
@@ -2,6 +2,9 @@ module FppTest {
 
   @ A component for testing  data product code gen
   active component DpTestComponent {
+
+    type AliasU16 = U16
+
     output port pOut: Ports.P
     sync input port pIn: Ports.P
 
@@ -12,7 +15,7 @@ module FppTest {
     @ Data for a DataRecord
     struct Data {
       @ A U16 field
-      u16Field: U16
+      u16Field: AliasU16
     }
 
     @ Data for a ComplexRecord

--- a/compiler/tools/fpp-to-dict/test/top/dataProducts.fpp
+++ b/compiler/tools/fpp-to-dict/test/top/dataProducts.fpp
@@ -3,6 +3,7 @@ module FppTest {
   @ A component for testing  data product code gen
   active component DpTestComponent {
 
+    @ Alias of type U16
     type AliasU16 = U16
 
     output port pOut: Ports.P

--- a/compiler/tools/fpp-to-dict/test/top/multipleTops.fpp
+++ b/compiler/tools/fpp-to-dict/test/top/multipleTops.fpp
@@ -1,5 +1,9 @@
 module Module1 {
 
+  type AliasT1 = U32
+  type AliasT2 = AliasT1
+  type AliasT3 = string size 20
+
   # enums
   enum E1: U32 {
     X = 0
@@ -94,7 +98,7 @@ module Module1 {
       save opcode 0x83
 
     @ Parameter of type string
-    param Param3: string size 20
+    param Param3: AliasT3
 
     @ Parameter of type F32
     param Param4: F32
@@ -141,7 +145,7 @@ module Module1 {
 
     # Records
     @ Record with single U32 value
-    product record Record1: U32
+    product record Record1: AliasT2
 
     @ Record with a single F64x4 value
     product record Record2: F64x4

--- a/compiler/tools/fpp-to-dict/test/top/multipleTops.fpp
+++ b/compiler/tools/fpp-to-dict/test/top/multipleTops.fpp
@@ -1,6 +1,8 @@
 module Module1 {
 
+  @ Alias of type U32
   type AliasT1 = U32
+  @ Alias of type AliasT1 (with underlying type U32)
   type AliasT2 = AliasT1
   type AliasT3 = string size 20
 


### PR DESCRIPTION
Adds type aliases to the JSON dictionary. Also addresses #626 by setting the `isDisplayable` property of AliasType according to it's underlying type.

Closes #563 and #626.