### PR TITLE
Update User's Guide

### DIFF
--- a/docs/fpp-users-guide.html
+++ b/docs/fpp-users-guide.html
@@ -15017,17 +15017,16 @@ with no padding.</p>
 each member is serialized using these rules.</p>
 </li>
 <li>
-<p>Each member array is serialized as described above
-for a value of array type.</p>
+<p>Each member array is serialized as stated in rule 5.</p>
 </li>
 </ol>
 </div>
 </li>
 <li>
-<p>A value of <a href="#Defining-Enums">enum type</a> is serialized according
-to its <a href="#Defining-Enums_The-Representation-Type">representation type</a>.
-The representation type is serialized as described above
-for primitive integer values.</p>
+<p>A value of <a href="#Defining-Enums">enum type</a> is converted to a primitive
+integer value of the <a href="#Defining-Enums_The-Representation-Type">representation
+type</a> specified in the enum definition.
+This value is serialized as stated in rule 1.</p>
 </li>
 <li>
 <p>A value of <a href="#Defining-Types_Abstract-Type-Definitions">abstract type</a> is
@@ -15042,7 +15041,7 @@ serialized according to its
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2025-03-05 15:19:45 -0800
+Last updated 2025-03-05 15:45:55 -0800
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-users-guide.html
+++ b/docs/fpp-users-guide.html
@@ -742,7 +742,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#Writing-C-Plus-Plus-Implementations_Implementing-Deployments_Public-Symbols">15.3.3. Public Symbols</a></li>
 </ul>
 </li>
-<li><a href="#Writing-C-Plus-Plus-Implementations_Serialization-of-Values">15.4. Serialization of Values</a></li>
+<li><a href="#Writing-C-Plus-Plus-Implementations_Serialization-of-FPP-Values">15.4. Serialization of FPP Values</a></li>
 </ul>
 </li>
 </ul>
@@ -14382,7 +14382,8 @@ It is up to you to provide that header file.</p>
 </div>
 <div class="paragraph">
 <p><strong>General implementations:</strong>
-In general, when implementing an abstract type <code>T</code> in C&#43;&#43;, you should define
+In the most common case, when implementing an abstract type <code>T</code> in C&#43;&#43;, you
+should define
 a class that extends <code>Fw::Serializable</code> from the F Prime framework.
 Your class definition should include the following:</p>
 </div>
@@ -14428,6 +14429,10 @@ of a byte string serialized from the class.</p>
 </div>
 </li>
 </ul>
+</div>
+<div class="paragraph">
+<p>For more on serialization, see the section on
+<a href="#Writing-C-Plus-Plus-Implementations_Serialization-of-FPP-Values">serialization of FPP values</a>.</p>
 </div>
 <div class="paragraph">
 <p>Here is a minimal complete implementation of an abstract type <code>T</code>.
@@ -14906,9 +14911,129 @@ function, you may.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="Writing-C-Plus-Plus-Implementations_Serialization-of-Values">15.4. Serialization of Values</h3>
+<h3 id="Writing-C-Plus-Plus-Implementations_Serialization-of-FPP-Values">15.4. Serialization of FPP Values</h3>
 <div class="paragraph">
-<p>TODO</p>
+<p>Every value represented in FPP can be <strong>serialized</strong>, i.e., converted into a
+machine-independent sequence of bytes.
+Serialization provides a consistent way to store data (e.g.,
+to onboard storage) and to transmit data (e.g., to or from the ground).
+The F Prime framework also uses serialization to pass data through asynchronous
+port invocations.
+The data is serialized when it is put on a message queue
+and then <strong>deserialized</strong> (i.e., converted from a byte sequence to
+data represented in C&#43;&#43;)
+when it is taken off the queue for processing.</p>
+</div>
+<div class="paragraph">
+<p>F Prime uses the following conventions for serializing data:</p>
+</div>
+<div class="olist arabic">
+<ol class="arabic">
+<li>
+<p>Values of primitive integer type are serialized as follows:</p>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p>A value of unsigned integer type (<code>U8</code>, <code>U16</code>, <code>U32</code>, or <code>U64</code>)
+is serialized in big-endian order (most significant byte first),
+using the number of bytes implied by the bit width.
+For example, the <code>U16</code> value 10 (decimal) is serialized as the
+two bytes <code>00</code> <code>0A</code> (hex).</p>
+</li>
+<li>
+<p>A value of signed integer type (<code>I8</code>, <code>I16</code>, <code>I32</code>, or <code>I64</code>)
+is serialized by (1) converting the value to an unsigned value of the same bit
+width and (2) serializing the unsigned value as stated above.
+If the value is nonnegative, then the converted value in step 1 is
+the same as the initial value.
+Otherwise the converted value is the two&#8217;s complement of the initial value.
+For example:</p>
+<div class="olist lowerroman">
+<ol class="lowerroman" type="i">
+<li>
+<p>The <code>I16</code> value 10 (decimal) is serialized as two bytes
+in big-endian order, yielding the bytes <code>00</code> <code>0A</code> (hex).</p>
+</li>
+<li>
+<p>The <code>I16</code> value -10 (decimal) is serialized by
+(1) computing the <code>U16</code> value 2<sup>16</sup> - 10 = 65526
+and (2) serializing that value as two bytes in big-endian order,
+yielding the bytes <code>FF</code> <code>F6</code> (hex).</p>
+</li>
+</ol>
+</div>
+</li>
+</ol>
+</div>
+</li>
+<li>
+<p>A value of floating-point type (<code>F32</code> or <code>F64</code>)
+is serialized in big-endian order according to the IEEE
+standard for representing these values.</p>
+</li>
+<li>
+<p>A value of Boolean type is serialized as a single byte.
+The byte values used to represent <code>true</code> and <code>false</code>
+are <code>FW_SERIALIZE_TRUE_VALUE</code> and <code>FW_SERIALIZE_FALSE_VALUE</code>,
+which are defined in the F Prime configuration header <code>FpConfig.h</code>.</p>
+</li>
+<li>
+<p>A value of string type is serialized as a size followed
+by the string characters.</p>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p>The size is serialized as described above for primitive
+integer types.
+The F Prime type definition <code>FwSizeStoreType</code> specifies the type to use
+for the size.
+This type definition is user-configurable; it is found in the
+F Prime configuration header <code>FpConfig.h</code>.</p>
+</li>
+<li>
+<p>There is one byte for each string character, and there is
+no null terminator.</p>
+</li>
+</ol>
+</div>
+</li>
+<li>
+<p>A value of <a href="#Defining-Types_Array-Type-Definitions">array type</a>
+is serialized as a sequence of serialized values, one for each array
+element, in array order.
+Each value is serialized using these rules.</p>
+</li>
+<li>
+<p>A value of <a href="#Defining-Types_Struct-Type-Definitions">struct type</a>
+is serialized member-by-member, in the order
+that the members appear in the FPP struct definition,
+with no padding.</p>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p>Except for
+<a href="#Defining-Types_Struct-Type-Definitions_Member-Arrays">member arrays</a>,
+each member is serialized using these rules.</p>
+</li>
+<li>
+<p>Each member array is serialized as described above
+for a value of array type.</p>
+</li>
+</ol>
+</div>
+</li>
+<li>
+<p>A value of <a href="#Defining-Enums">enum type</a> is serialized according
+to its <a href="#Defining-Enums_The-Representation-Type">representation type</a>.
+The representation type is serialized as described above
+for primitive integer values.</p>
+</li>
+<li>
+<p>A value of <a href="#Defining-Types_Abstract-Type-Definitions">abstract type</a> is
+serialized according to its
+<a href="#Writing-C-Plus-Plus-Implementations_Implementing-Abstract-Types">C&#43;&#43; implementation</a>.</p>
+</li>
+</ol>
 </div>
 </div>
 </div>
@@ -14916,7 +15041,7 @@ function, you may.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2025-03-05 11:07:09 -0800
+Last updated 2025-03-05 15:04:54 -0800
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-users-guide.html
+++ b/docs/fpp-users-guide.html
@@ -14382,8 +14382,8 @@ It is up to you to provide that header file.</p>
 </div>
 <div class="paragraph">
 <p><strong>General implementations:</strong>
-In the most common case, when implementing an abstract type <code>T</code> in C&#43;&#43;, you
-should define
+In most cases, when implementing an abstract type <code>T</code> in C&#43;&#43;, you
+will define
 a class that extends <code>Fw::Serializable</code> from the F Prime framework.
 Your class definition should include the following:</p>
 </div>
@@ -14921,11 +14921,11 @@ The F Prime framework also uses serialization to pass data through asynchronous
 port invocations.
 The data is serialized when it is put on a message queue
 and then <strong>deserialized</strong> (i.e., converted from a byte sequence to
-data represented in C&#43;&#43;)
+a C&#43;&#43; representation)
 when it is taken off the queue for processing.</p>
 </div>
 <div class="paragraph">
-<p>F Prime uses the following conventions for serializing data:</p>
+<p>F Prime uses the following rules for serializing data:</p>
 </div>
 <div class="olist arabic">
 <ol class="arabic">
@@ -14942,11 +14942,11 @@ two bytes <code>00</code> <code>0A</code> (hex).</p>
 </li>
 <li>
 <p>A value of signed integer type (<code>I8</code>, <code>I16</code>, <code>I32</code>, or <code>I64</code>)
-is serialized by (1) converting the value to an unsigned value of the same bit
-width and (2) serializing the unsigned value as stated above.
-If the value is nonnegative, then the converted value in step 1 is
-the same as the initial value.
-Otherwise the converted value is the two&#8217;s complement of the initial value.
+is serialized by first converting the value to an unsigned value of the same bit
+width and then serializing the unsigned value as stated in rule 1.a.
+If the value is nonnegative, then the unsigned value is
+the same as the signed value.
+Otherwise the unsigned value is the two&#8217;s complement of the signed value.
 For example:</p>
 <div class="olist lowerroman">
 <ol class="lowerroman" type="i">
@@ -14979,11 +14979,11 @@ which are defined in the F Prime configuration header <code>FpConfig.h</code>.</
 </li>
 <li>
 <p>A value of string type is serialized as a size followed
-by the string characters.</p>
+by the string characters in string order.</p>
 <div class="olist loweralpha">
 <ol class="loweralpha" type="a">
 <li>
-<p>The size is serialized as described above for primitive
+<p>The size is serialized according to rule 1 for primitive
 integer types.
 The F Prime type definition <code>FwSizeStoreType</code> specifies the type to use
 for the size.
@@ -14991,8 +14991,9 @@ This type definition is user-configurable; it is found in the
 F Prime configuration header <code>FpConfig.h</code>.</p>
 </li>
 <li>
-<p>There is one byte for each string character, and there is
-no null terminator.</p>
+<p>There is one byte for each character of the string, and there is
+no null terminator.
+Each string character is serialized as an <code>I8</code> value according to rule 1.b.</p>
 </li>
 </ol>
 </div>
@@ -15041,7 +15042,7 @@ serialized according to its
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2025-03-05 15:04:54 -0800
+Last updated 2025-03-05 15:19:45 -0800
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-users-guide.html
+++ b/docs/fpp-users-guide.html
@@ -742,6 +742,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#Writing-C-Plus-Plus-Implementations_Implementing-Deployments_Public-Symbols">15.3.3. Public Symbols</a></li>
 </ul>
 </li>
+<li><a href="#Writing-C-Plus-Plus-Implementations_Serialization-of-Values">15.4. Serialization of Values</a></li>
 </ul>
 </li>
 </ul>
@@ -14328,7 +14329,9 @@ we won&#8217;t cover it further here.
 Similarly, implementing libraries is unrelated to FPP, so we
 won&#8217;t cover it in this manual.
 Here we focus on items (1), (2), and (5): implementing abstract types,
-implementing external state machines, and implementing deployments.</p>
+implementing external state machines, and implementing deployments.
+We also discuss <strong>serialization</strong> of data values, i.e., representing
+FPP data values as binary data for storage and transmission.</p>
 </div>
 <div class="sect2">
 <h3 id="Writing-C-Plus-Plus-Implementations_Implementing-Abstract-Types">15.1. Implementing Abstract Types</h3>
@@ -14378,9 +14381,10 @@ a header file <code>T.hpp</code> must exist in the current directory.
 It is up to you to provide that header file.</p>
 </div>
 <div class="paragraph">
-<p>When implementing an abstract type <code>T</code> in C&#43;&#43;, you must define
+<p><strong>General implementations:</strong>
+In general, when implementing an abstract type <code>T</code> in C&#43;&#43;, you should define
 a class that extends <code>Fw::Serializable</code> from the F Prime framework.
-Your class definition must include the following:</p>
+Your class definition should include the following:</p>
 </div>
 <div class="ulist">
 <ul>
@@ -14470,6 +14474,22 @@ struct T final : public Fw::Serializable { // Extend Fw::Serializable
 
 #endif</pre>
 </div>
+</div>
+<div class="paragraph">
+<p><strong>Serializable buffers used in ports:</strong>
+In some cases, you may want to define an abstract type <code>T</code> that represents
+a data buffer and that is used only in <a href="#Defining-Ports">port definitions</a>.
+In this case you can implement
+<code>T</code> as a class that extends <code>Fw::SerializeBufferBase</code>.
+Instead of implementing the <code>serialize</code> and <code>deserialize</code> functions
+directly, you override functions that get the address and the capacity
+(allocated size) of the buffer; the base class <code>Fw::SerializeBufferBase</code>
+uses these functions to implement <code>serialize</code> and <code>deserialize</code>.
+For an example of how to do this, see the files <code>Fw/Cmd/CmdArgBuffer.hpp</code>
+and <code>Fw/Cmd/CmdArgBuffer.cpp</code> in the F Prime repository.
+Be careful, though: if you implement an abstract type <code>T</code> this way
+and you try to use the type <code>T</code> outside of a port definition,
+the generated C&#43;&#43; may not compile.</p>
 </div>
 <div class="paragraph">
 <p><strong>Built-in types:</strong>
@@ -14885,12 +14905,18 @@ function, you may.</p>
 </div>
 </div>
 </div>
+<div class="sect2">
+<h3 id="Writing-C-Plus-Plus-Implementations_Serialization-of-Values">15.4. Serialization of Values</h3>
+<div class="paragraph">
+<p>TODO</p>
+</div>
+</div>
 </div>
 </div>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2025-02-20 09:49:49 -0800
+Last updated 2025-03-05 11:07:09 -0800
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/users-guide/Writing-C-Plus-Plus-Implementations.adoc
+++ b/docs/users-guide/Writing-C-Plus-Plus-Implementations.adoc
@@ -71,7 +71,8 @@ a header file `T.hpp` must exist in the current directory.
 It is up to you to provide that header file.
 
 *General implementations:*
-In general, when implementing an abstract type `T` in {cpp}, you should define
+In the most common case, when implementing an abstract type `T` in {cpp}, you 
+should define
 a class that extends `Fw::Serializable` from the F Prime framework.
 Your class definition should include the following:
 
@@ -103,6 +104,10 @@ of a byte string serialized from the class.
 ----
 bool operator==(const T& that) const;
 ----
+
+For more on serialization, see the section on 
+<<Writing-C-Plus-Plus-Implementations_Serialization-of-FPP-Values,
+serialization of FPP values>>.
 
 Here is a minimal complete implementation of an abstract type `T`.
 It has one member variable `x` of type `U32` and no methods other than
@@ -508,6 +513,90 @@ put the code for _I_ into the correct place in _T_ `TopologyAc.cpp`.
 However, if you wish to write the custom code directly into your main
 function, you may.
 
-=== Serialization of Values
+=== Serialization of FPP Values
 
-TODO
+Every value represented in FPP can be *serialized*, i.e., converted into a 
+machine-independent sequence of bytes.
+Serialization provides a consistent way to store data (e.g.,
+to onboard storage) and to transmit data (e.g., to or from the ground).
+The F Prime framework also uses serialization to pass data through asynchronous
+port invocations.
+The data is serialized when it is put on a message queue
+and then *deserialized* (i.e., converted from a byte sequence to
+data represented in {cpp})
+when it is taken off the queue for processing.
+
+F Prime uses the following conventions for serializing data:
+
+. Values of primitive integer type are serialized as follows:
+
+.. A value of unsigned integer type (`U8`, `U16`, `U32`, or `U64`)
+is serialized in big-endian order (most significant byte first),
+using the number of bytes implied by the bit width.
+For example, the `U16` value 10 (decimal) is serialized as the
+two bytes `00` `0A` (hex).
+
+.. A value of signed integer type (`I8`, `I16`, `I32`, or `I64`)
+is serialized by (1) converting the value to an unsigned value of the same bit
+width and (2) serializing the unsigned value as stated above.
+If the value is nonnegative, then the converted value in step 1 is
+the same as the initial value.
+Otherwise the converted value is the two's complement of the initial value.
+For example:
+
+... The `I16` value 10 (decimal) is serialized as two bytes
+in big-endian order, yielding the bytes `00` `0A` (hex).
+
+... The `I16` value -10 (decimal) is serialized by
+(1) computing the `U16` value 2^16^ - 10 = 65526
+and (2) serializing that value as two bytes in big-endian order,
+yielding the bytes `FF` `F6` (hex).
+
+. A value of floating-point type (`F32` or `F64`)
+is serialized in big-endian order according to the IEEE
+standard for representing these values.
+
+. A value of Boolean type is serialized as a single byte.
+The byte values used to represent `true` and `false`
+are `FW_SERIALIZE_TRUE_VALUE` and `FW_SERIALIZE_FALSE_VALUE`,
+which are defined in the F Prime configuration header `FpConfig.h`.
+
+. A value of string type is serialized as a size followed
+by the string characters.
+
+.. The size is serialized as described above for primitive
+integer types.
+The F Prime type definition `FwSizeStoreType` specifies the type to use
+for the size.
+This type definition is user-configurable; it is found in the
+F Prime configuration header `FpConfig.h`.
+
+.. There is one byte for each string character, and there is
+no null terminator.
+
+. A value of <<Defining-Types_Array-Type-Definitions,array type>>
+is serialized as a sequence of serialized values, one for each array
+element, in array order.
+Each value is serialized using these rules.
+
+. A value of <<Defining-Types_Struct-Type-Definitions,struct type>>
+is serialized member-by-member, in the order
+that the members appear in the FPP struct definition,
+with no padding.
+
+.. Except for 
+<<Defining-Types_Struct-Type-Definitions_Member-Arrays,member arrays>>,
+each member is serialized using these rules.
+
+.. Each member array is serialized as described above
+for a value of array type.
+
+. A value of <<Defining-Enums,enum type>> is serialized according
+to its <<Defining-Enums_The-Representation-Type,representation type>>.
+The representation type is serialized as described above
+for primitive integer values.
+
+. A value of <<Defining-Types_Abstract-Type-Definitions,abstract type>> is
+serialized according to its 
+<<Writing-C-Plus-Plus-Implementations_Implementing-Abstract-Types,
+{cpp} implementation>>.

--- a/docs/users-guide/Writing-C-Plus-Plus-Implementations.adoc
+++ b/docs/users-guide/Writing-C-Plus-Plus-Implementations.adoc
@@ -589,13 +589,12 @@ with no padding.
 <<Defining-Types_Struct-Type-Definitions_Member-Arrays,member arrays>>,
 each member is serialized using these rules.
 
-.. Each member array is serialized as described above
-for a value of array type.
+.. Each member array is serialized as stated in rule 5.
 
-. A value of <<Defining-Enums,enum type>> is serialized according
-to its <<Defining-Enums_The-Representation-Type,representation type>>.
-The representation type is serialized as described above
-for primitive integer values.
+. A value of <<Defining-Enums,enum type>> is converted to a primitive 
+integer value of the <<Defining-Enums_The-Representation-Type,representation 
+type>> specified in the enum definition.
+This value is serialized as stated in rule 1.
 
 . A value of <<Defining-Types_Abstract-Type-Definitions,abstract type>> is
 serialized according to its 

--- a/docs/users-guide/Writing-C-Plus-Plus-Implementations.adoc
+++ b/docs/users-guide/Writing-C-Plus-Plus-Implementations.adoc
@@ -71,8 +71,8 @@ a header file `T.hpp` must exist in the current directory.
 It is up to you to provide that header file.
 
 *General implementations:*
-In the most common case, when implementing an abstract type `T` in {cpp}, you 
-should define
+In most cases, when implementing an abstract type `T` in {cpp}, you 
+will define
 a class that extends `Fw::Serializable` from the F Prime framework.
 Your class definition should include the following:
 
@@ -523,10 +523,10 @@ The F Prime framework also uses serialization to pass data through asynchronous
 port invocations.
 The data is serialized when it is put on a message queue
 and then *deserialized* (i.e., converted from a byte sequence to
-data represented in {cpp})
+a {cpp} representation)
 when it is taken off the queue for processing.
 
-F Prime uses the following conventions for serializing data:
+F Prime uses the following rules for serializing data:
 
 . Values of primitive integer type are serialized as follows:
 
@@ -537,11 +537,11 @@ For example, the `U16` value 10 (decimal) is serialized as the
 two bytes `00` `0A` (hex).
 
 .. A value of signed integer type (`I8`, `I16`, `I32`, or `I64`)
-is serialized by (1) converting the value to an unsigned value of the same bit
-width and (2) serializing the unsigned value as stated above.
-If the value is nonnegative, then the converted value in step 1 is
-the same as the initial value.
-Otherwise the converted value is the two's complement of the initial value.
+is serialized by first converting the value to an unsigned value of the same bit
+width and then serializing the unsigned value as stated in rule 1.a.
+If the value is nonnegative, then the unsigned value is
+the same as the signed value.
+Otherwise the unsigned value is the two's complement of the signed value.
 For example:
 
 ... The `I16` value 10 (decimal) is serialized as two bytes
@@ -562,17 +562,18 @@ are `FW_SERIALIZE_TRUE_VALUE` and `FW_SERIALIZE_FALSE_VALUE`,
 which are defined in the F Prime configuration header `FpConfig.h`.
 
 . A value of string type is serialized as a size followed
-by the string characters.
+by the string characters in string order.
 
-.. The size is serialized as described above for primitive
+.. The size is serialized according to rule 1 for primitive
 integer types.
 The F Prime type definition `FwSizeStoreType` specifies the type to use
 for the size.
 This type definition is user-configurable; it is found in the
 F Prime configuration header `FpConfig.h`.
 
-.. There is one byte for each string character, and there is
+.. There is one byte for each character of the string, and there is
 no null terminator.
+Each string character is serialized as an `I8` value according to rule 1.b.
 
 . A value of <<Defining-Types_Array-Type-Definitions,array type>>
 is serialized as a sequence of serialized values, one for each array

--- a/docs/users-guide/Writing-C-Plus-Plus-Implementations.adoc
+++ b/docs/users-guide/Writing-C-Plus-Plus-Implementations.adoc
@@ -28,6 +28,8 @@ Similarly, implementing libraries is unrelated to FPP, so we
 won't cover it in this manual.
 Here we focus on items (1), (2), and (5): implementing abstract types,
 implementing external state machines, and implementing deployments.
+We also discuss *serialization* of data values, i.e., representing
+FPP data values as binary data for storage and transmission.
 
 === Implementing Abstract Types
 
@@ -68,9 +70,10 @@ This line says that in order to compile `AArrayAc.cpp`,
 a header file `T.hpp` must exist in the current directory.
 It is up to you to provide that header file.
 
-When implementing an abstract type `T` in {cpp}, you must define
+*General implementations:*
+In general, when implementing an abstract type `T` in {cpp}, you should define
 a class that extends `Fw::Serializable` from the F Prime framework.
-Your class definition must include the following:
+Your class definition should include the following:
 
 * An implementation of the virtual function
 +
@@ -144,6 +147,21 @@ struct T final : public Fw::Serializable { // Extend Fw::Serializable
 
 #endif
 ----
+
+*Serializable buffers used in ports:*
+In some cases, you may want to define an abstract type `T` that represents
+a data buffer and that is used only in <<Defining-Ports,port definitions>>.
+In this case you can implement
+`T` as a class that extends `Fw::SerializeBufferBase`.
+Instead of implementing the `serialize` and `deserialize` functions
+directly, you override functions that get the address and the capacity
+(allocated size) of the buffer; the base class `Fw::SerializeBufferBase`
+uses these functions to implement `serialize` and `deserialize`.
+For an example of how to do this, see the files `Fw/Cmd/CmdArgBuffer.hpp`
+and `Fw/Cmd/CmdArgBuffer.cpp` in the F Prime repository.
+Be careful, though: if you implement an abstract type `T` this way
+and you try to use the type `T` outside of a port definition,
+the generated {cpp} may not compile.
 
 *Built-in types:*
 The following types are abstract in the FPP model but are known to
@@ -489,3 +507,7 @@ up the custom {cpp} code for _I_, and the FPP translator will automatically
 put the code for _I_ into the correct place in _T_ `TopologyAc.cpp`.
 However, if you wish to write the custom code directly into your main
 function, you may.
+
+=== Serialization of Values
+
+TODO


### PR DESCRIPTION
* Document the use of `Fw::SerializeBufferBase` to implement abstract types.
* Document the rules for serializing FPP values.

Closes #646. Closes #648.