### PR TITLE
Mark Generated C/C++ files as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Mark generated reference files as vendored
+*.ref.cpp linguist-vendored
+*.ref.hpp linguist-vendored
+*.ref.h linguist-vendored
+

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.tasty
 *~
 .*
+!.gitattributes
 __SHADOW__
 __pycache__
 dist/


### PR DESCRIPTION
Before:
```
$ github-linguist
86.58%  11423656   C++
10.58%  1395476    Scala
1.39%   183882     Fortran
1.32%   173503     Shell
0.08%   10088      Emacs Lisp
0.03%   4287       Vim Script
0.02%   3215       Python
```

After:
```
$ github-linguist
76.57%  1395476    Scala
10.09%  183882     Fortran
9.52%   173503     Shell
2.85%   52011      C++
0.55%   10088      Emacs Lisp
0.24%   4287       Vim Script
0.18%   3215       Python
```

I believe the remaining C++ files are our `.hpp` for abstract type definitions. We can also mark the `.fpp` files as any language other than Fortran if we wanted to (though the language must exist according to github-linguist unfortunately).