### PR TITLE
Fix regression in fpp-filenames and fpp-depend

### DIFF
--- a/compiler/lib/src/main/scala/codegen/ComputeGeneratedFiles.scala
+++ b/compiler/lib/src/main/scala/codegen/ComputeGeneratedFiles.scala
@@ -10,12 +10,7 @@ object ComputeGeneratedFiles {
   /** Computes autocoded files (XML, C++ and JSON Dictionary) */
   def getAutocodeFiles(tul: List[Ast.TransUnit]): Result.Result[List[String]] =
     for {
-      // Perform analysis only up to the point we need
       a <- enterSymbols(tul)
-      a <- CheckUses.visitList(a, tul, CheckUses.transUnit)
-      _ <- CheckUseDefCycles.visitList(a, tul, CheckUseDefCycles.transUnit)
-      a <- CheckTypeUses.visitList(a, tul, CheckTypeUses.transUnit)
-
       xmlFiles <- getXmlFiles(a, tul)
       cppFiles <- getAutocodeCppFiles(a, tul)
       dictFiles <- getDictionaryJsonFiles(a, tul)

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComputeAutocodeCppFiles.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComputeAutocodeCppFiles.scala
@@ -34,16 +34,7 @@ object ComputeAutocodeCppFiles extends ComputeCppFiles {
     val name = s.getName(Symbol.AliasType(aNode))
     val loc = Locations.get(node.id)
     val fileName = ComputeCppFiles.FileNames.getAliasType(name)
-    val t = s.a.typeMap(node.id)
-
-    for {
-      s <- addHppMapping(s, fileName, Some(loc), "hpp")
-      // Only add C header if its supported
-      s <- s.isTypeSupportedInC(t) match {
-        case true => addHppMapping(s, fileName, Some(loc), "h")
-        case false => Right(s)
-      }
-    } yield s
+    addHppMapping(s, fileName, Some(loc), "hpp")
   }
 
   override def defArrayAnnotatedNode(

--- a/compiler/tools/fpp-depend/test/filenames_auto_generated_output.ref.txt
+++ b/compiler/tools/fpp-depend/test/filenames_auto_generated_output.ref.txt
@@ -32,8 +32,6 @@ TTopologyAppAi.xml
 TTopologyDictionary.json
 T_PTlmPacketsAc.cpp
 T_PTlmPacketsAc.hpp
-WithCDefinitionAliasAc.h
 WithCDefinitionAliasAc.hpp
-WithCDefinitionBuiltinAliasAc.h
 WithCDefinitionBuiltinAliasAc.hpp
 WithoutCDefinitionAliasAc.hpp

--- a/compiler/tools/fpp-depend/test/filenames_generated_output.ref.txt
+++ b/compiler/tools/fpp-depend/test/filenames_generated_output.ref.txt
@@ -32,8 +32,6 @@ TTopologyAppAi.xml
 TTopologyDictionary.json
 T_PTlmPacketsAc.cpp
 T_PTlmPacketsAc.hpp
-WithCDefinitionAliasAc.h
 WithCDefinitionAliasAc.hpp
-WithCDefinitionBuiltinAliasAc.h
 WithCDefinitionBuiltinAliasAc.hpp
 WithoutCDefinitionAliasAc.hpp

--- a/compiler/tools/fpp-depend/test/filenames_include_auto_generated_output.ref.txt
+++ b/compiler/tools/fpp-depend/test/filenames_include_auto_generated_output.ref.txt
@@ -32,8 +32,6 @@ TTopologyAppAi.xml
 TTopologyDictionary.json
 T_PTlmPacketsAc.cpp
 T_PTlmPacketsAc.hpp
-WithCDefinitionAliasAc.h
 WithCDefinitionAliasAc.hpp
-WithCDefinitionBuiltinAliasAc.h
 WithCDefinitionBuiltinAliasAc.hpp
 WithoutCDefinitionAliasAc.hpp

--- a/compiler/tools/fpp-depend/test/filenames_include_generated_output.ref.txt
+++ b/compiler/tools/fpp-depend/test/filenames_include_generated_output.ref.txt
@@ -32,8 +32,6 @@ TTopologyAppAi.xml
 TTopologyDictionary.json
 T_PTlmPacketsAc.cpp
 T_PTlmPacketsAc.hpp
-WithCDefinitionAliasAc.h
 WithCDefinitionAliasAc.hpp
-WithCDefinitionBuiltinAliasAc.h
 WithCDefinitionBuiltinAliasAc.hpp
 WithoutCDefinitionAliasAc.hpp

--- a/compiler/tools/fpp-filenames/test/include.ref.txt
+++ b/compiler/tools/fpp-filenames/test/include.ref.txt
@@ -32,8 +32,6 @@ TTopologyAppAi.xml
 TTopologyDictionary.json
 T_PTlmPacketsAc.cpp
 T_PTlmPacketsAc.hpp
-WithCDefinitionAliasAc.h
 WithCDefinitionAliasAc.hpp
-WithCDefinitionBuiltinAliasAc.h
 WithCDefinitionBuiltinAliasAc.hpp
 WithoutCDefinitionAliasAc.hpp

--- a/compiler/tools/fpp-filenames/test/ok.ref.txt
+++ b/compiler/tools/fpp-filenames/test/ok.ref.txt
@@ -32,8 +32,6 @@ TTopologyAppAi.xml
 TTopologyDictionary.json
 T_PTlmPacketsAc.cpp
 T_PTlmPacketsAc.hpp
-WithCDefinitionAliasAc.h
 WithCDefinitionAliasAc.hpp
-WithCDefinitionBuiltinAliasAc.h
 WithCDefinitionBuiltinAliasAc.hpp
 WithoutCDefinitionAliasAc.hpp


### PR DESCRIPTION
To determine whether `.h` files are generated, `fpp-filenames` and `fpp-depend` are computing type information that assumes a complete model. However, these tools have to run on incomplete models. In particular, the generate step now fails in the F Prime build.

To fix this issue, I reverted the computation of type info in `ComputeGeneratedFiles.scala`, and I took out the code that determines whether an `.h` file is generated. We now just report the `.hpp` files that are generated, not the `.h` files, if any. This should be good enough for communicating info to the build.