### PR TITLE
Changing port formatting to use proper formatter PRI_FwIndexType

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriter.scala
@@ -1073,7 +1073,7 @@ object ComponentCppWriter extends CppWriterUtils {
             s"""|#if FW_OBJECT_NAMES == 1
                 |Fw::ObjectName portName;
                 |portName.format(
-                |  "%s_${printName(port)}[%" PRI_PlatformIntType "]",
+                |  "%s_${printName(port)}[%" PRI_FwIndexType "]",
                 |  this->m_objName.toChar(),
                 |  port
                 |);

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductPortsOnlyComponentAc.ref.cpp
@@ -88,7 +88,7 @@ void ActiveAsyncProductPortsOnlyComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_productRecvIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -107,7 +107,7 @@ void ActiveAsyncProductPortsOnlyComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -126,7 +126,7 @@ void ActiveAsyncProductPortsOnlyComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductsComponentAc.ref.cpp
@@ -321,7 +321,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -345,7 +345,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_productRecvIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -369,7 +369,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -393,7 +393,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -417,7 +417,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -441,7 +441,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -465,7 +465,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -489,7 +489,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -513,7 +513,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -537,7 +537,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -561,7 +561,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -585,7 +585,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -609,7 +609,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -633,7 +633,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -657,7 +657,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -681,7 +681,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -705,7 +705,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -729,7 +729,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -753,7 +753,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -777,7 +777,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -801,7 +801,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -820,7 +820,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -839,7 +839,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -858,7 +858,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -877,7 +877,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -896,7 +896,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -915,7 +915,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -934,7 +934,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -954,7 +954,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -974,7 +974,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -993,7 +993,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1012,7 +1012,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1031,7 +1031,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1050,7 +1050,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1069,7 +1069,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1088,7 +1088,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1107,7 +1107,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1126,7 +1126,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1145,7 +1145,7 @@ void ActiveAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveCommandsComponentAc.ref.cpp
@@ -103,7 +103,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -127,7 +127,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -151,7 +151,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -175,7 +175,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -199,7 +199,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -223,7 +223,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -247,7 +247,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -271,7 +271,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -295,7 +295,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -319,7 +319,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -343,7 +343,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -367,7 +367,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -391,7 +391,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -415,7 +415,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -439,7 +439,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -463,7 +463,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -487,7 +487,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -511,7 +511,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -535,7 +535,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -559,7 +559,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -578,7 +578,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -597,7 +597,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -616,7 +616,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -635,7 +635,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -654,7 +654,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -674,7 +674,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -694,7 +694,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -713,7 +713,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -732,7 +732,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -751,7 +751,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -770,7 +770,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -789,7 +789,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -808,7 +808,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -827,7 +827,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -846,7 +846,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -865,7 +865,7 @@ void ActiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.cpp
@@ -98,7 +98,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -122,7 +122,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -146,7 +146,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -170,7 +170,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -194,7 +194,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -218,7 +218,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -242,7 +242,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -266,7 +266,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -290,7 +290,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -314,7 +314,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -338,7 +338,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -362,7 +362,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -386,7 +386,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -410,7 +410,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -434,7 +434,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -458,7 +458,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -482,7 +482,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -506,7 +506,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -530,7 +530,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -554,7 +554,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -573,7 +573,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -592,7 +592,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -611,7 +611,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -630,7 +630,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -649,7 +649,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -669,7 +669,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -689,7 +689,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -708,7 +708,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -727,7 +727,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -746,7 +746,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -765,7 +765,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -784,7 +784,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -803,7 +803,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -822,7 +822,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -841,7 +841,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -860,7 +860,7 @@ void ActiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveGetProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveGetProductsComponentAc.ref.cpp
@@ -319,7 +319,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -343,7 +343,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -367,7 +367,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -391,7 +391,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -415,7 +415,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -439,7 +439,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -463,7 +463,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -487,7 +487,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -511,7 +511,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -535,7 +535,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -559,7 +559,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -583,7 +583,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -607,7 +607,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -631,7 +631,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -655,7 +655,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -679,7 +679,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -703,7 +703,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -727,7 +727,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -751,7 +751,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -775,7 +775,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -794,7 +794,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -813,7 +813,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -832,7 +832,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -851,7 +851,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -870,7 +870,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -889,7 +889,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_productGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -908,7 +908,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -928,7 +928,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -948,7 +948,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -967,7 +967,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -986,7 +986,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1005,7 +1005,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1024,7 +1024,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1043,7 +1043,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1062,7 +1062,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1081,7 +1081,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1100,7 +1100,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1119,7 +1119,7 @@ void ActiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveGuardedProductsComponentAc.ref.cpp
@@ -319,7 +319,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -343,7 +343,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_productRecvIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -367,7 +367,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -391,7 +391,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -415,7 +415,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -439,7 +439,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -463,7 +463,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -487,7 +487,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -511,7 +511,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -535,7 +535,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -559,7 +559,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -583,7 +583,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -607,7 +607,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -631,7 +631,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -655,7 +655,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -679,7 +679,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -703,7 +703,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -727,7 +727,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -751,7 +751,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -775,7 +775,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -799,7 +799,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -818,7 +818,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -837,7 +837,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -856,7 +856,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -875,7 +875,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -894,7 +894,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -913,7 +913,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -932,7 +932,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -952,7 +952,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -972,7 +972,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -991,7 +991,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1010,7 +1010,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1029,7 +1029,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1048,7 +1048,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1067,7 +1067,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1086,7 +1086,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1105,7 +1105,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1124,7 +1124,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1143,7 +1143,7 @@ void ActiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveNoArgsPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveNoArgsPortsOnlyComponentAc.ref.cpp
@@ -82,7 +82,7 @@ void ActiveNoArgsPortsOnlyComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -106,7 +106,7 @@ void ActiveNoArgsPortsOnlyComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -130,7 +130,7 @@ void ActiveNoArgsPortsOnlyComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -154,7 +154,7 @@ void ActiveNoArgsPortsOnlyComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -173,7 +173,7 @@ void ActiveNoArgsPortsOnlyComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -192,7 +192,7 @@ void ActiveNoArgsPortsOnlyComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveOverflowComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveOverflowComponentAc.ref.cpp
@@ -102,7 +102,7 @@ void ActiveOverflowComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -126,7 +126,7 @@ void ActiveOverflowComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productRecvInHook_InputPort[%" PRI_PlatformIntType "]",
+      "%s_productRecvInHook_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -150,7 +150,7 @@ void ActiveOverflowComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_assertAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_assertAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -174,7 +174,7 @@ void ActiveOverflowComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_blockAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_blockAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -198,7 +198,7 @@ void ActiveOverflowComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_dropAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_dropAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -222,7 +222,7 @@ void ActiveOverflowComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_hookAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_hookAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -246,7 +246,7 @@ void ActiveOverflowComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_serialAsyncHook_InputPort[%" PRI_PlatformIntType "]",
+      "%s_serialAsyncHook_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -265,7 +265,7 @@ void ActiveOverflowComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -284,7 +284,7 @@ void ActiveOverflowComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -303,7 +303,7 @@ void ActiveOverflowComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -322,7 +322,7 @@ void ActiveOverflowComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -341,7 +341,7 @@ void ActiveOverflowComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -361,7 +361,7 @@ void ActiveOverflowComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -381,7 +381,7 @@ void ActiveOverflowComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -400,7 +400,7 @@ void ActiveOverflowComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.cpp
@@ -98,7 +98,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -122,7 +122,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -146,7 +146,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -170,7 +170,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -194,7 +194,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -218,7 +218,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -242,7 +242,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -266,7 +266,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -290,7 +290,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -314,7 +314,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -338,7 +338,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -362,7 +362,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -386,7 +386,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -410,7 +410,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -434,7 +434,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -458,7 +458,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -482,7 +482,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -506,7 +506,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -530,7 +530,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -554,7 +554,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -573,7 +573,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -592,7 +592,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -611,7 +611,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -630,7 +630,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -649,7 +649,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -669,7 +669,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -689,7 +689,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -708,7 +708,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -727,7 +727,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -746,7 +746,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -765,7 +765,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -784,7 +784,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -803,7 +803,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -822,7 +822,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -841,7 +841,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -860,7 +860,7 @@ void ActiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
@@ -137,7 +137,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -161,7 +161,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -185,7 +185,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -209,7 +209,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -233,7 +233,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -257,7 +257,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -281,7 +281,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -305,7 +305,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -329,7 +329,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -353,7 +353,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -377,7 +377,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -401,7 +401,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -425,7 +425,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -449,7 +449,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -473,7 +473,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -497,7 +497,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -521,7 +521,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -545,7 +545,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -569,7 +569,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -593,7 +593,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -617,7 +617,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_serialAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_serialAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -641,7 +641,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_serialAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
+      "%s_serialAsyncAssert_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -665,7 +665,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_serialAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_serialAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -689,7 +689,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_serialAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_serialAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -713,7 +713,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_serialGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_serialGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -737,7 +737,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_serialSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_serialSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -756,7 +756,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -775,7 +775,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -794,7 +794,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -813,7 +813,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -832,7 +832,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -852,7 +852,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -872,7 +872,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -891,7 +891,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -910,7 +910,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -929,7 +929,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -948,7 +948,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -967,7 +967,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -986,7 +986,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1005,7 +1005,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1024,7 +1024,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1043,7 +1043,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1062,7 +1062,7 @@ void ActiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_serialOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_serialOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSyncProductsComponentAc.ref.cpp
@@ -319,7 +319,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -343,7 +343,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_productRecvIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -367,7 +367,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -391,7 +391,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -415,7 +415,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -439,7 +439,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -463,7 +463,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -487,7 +487,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -511,7 +511,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -535,7 +535,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -559,7 +559,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -583,7 +583,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -607,7 +607,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -631,7 +631,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -655,7 +655,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -679,7 +679,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -703,7 +703,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -727,7 +727,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -751,7 +751,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -775,7 +775,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -799,7 +799,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -818,7 +818,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -837,7 +837,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -856,7 +856,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -875,7 +875,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -894,7 +894,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -913,7 +913,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -932,7 +932,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -952,7 +952,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -972,7 +972,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -991,7 +991,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1010,7 +1010,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1029,7 +1029,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1048,7 +1048,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1067,7 +1067,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1086,7 +1086,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1105,7 +1105,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1124,7 +1124,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1143,7 +1143,7 @@ void ActiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.cpp
@@ -98,7 +98,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -122,7 +122,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -146,7 +146,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -170,7 +170,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -194,7 +194,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -218,7 +218,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -242,7 +242,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -266,7 +266,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -290,7 +290,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -314,7 +314,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -338,7 +338,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -362,7 +362,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -386,7 +386,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -410,7 +410,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -434,7 +434,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -458,7 +458,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -482,7 +482,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -506,7 +506,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -530,7 +530,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -554,7 +554,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -573,7 +573,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -592,7 +592,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -611,7 +611,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -630,7 +630,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -649,7 +649,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -669,7 +669,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -689,7 +689,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -708,7 +708,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -727,7 +727,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -746,7 +746,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -765,7 +765,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -784,7 +784,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -803,7 +803,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -822,7 +822,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -841,7 +841,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -860,7 +860,7 @@ void ActiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
@@ -357,7 +357,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
+        "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -381,7 +381,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
+        "%s_productRecvIn_InputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -405,7 +405,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_aliasTypedAsync_InputPort[%" PRI_PlatformIntType "]",
+        "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -429,7 +429,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+        "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -453,7 +453,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
+        "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -477,7 +477,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
+        "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -501,7 +501,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+        "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -525,7 +525,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
+        "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -549,7 +549,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_noArgsStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+        "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -573,7 +573,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
+        "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -597,7 +597,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_typedAliasGuarded_InputPort[%" PRI_PlatformIntType "]",
+        "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -621,7 +621,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_typedAliasReturnSync_InputPort[%" PRI_PlatformIntType "]",
+        "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -645,7 +645,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_typedAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+        "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -669,7 +669,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
+        "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -693,7 +693,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
+        "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -717,7 +717,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
+        "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -741,7 +741,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
+        "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -765,7 +765,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
+        "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -789,7 +789,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+        "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -813,7 +813,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
+        "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -837,7 +837,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
+        "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -856,7 +856,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
+        "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -875,7 +875,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
+        "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -894,7 +894,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
+        "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -913,7 +913,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
+        "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -932,7 +932,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
+        "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -951,7 +951,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
+        "%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -970,7 +970,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
+        "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -990,7 +990,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
+        "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -1010,7 +1010,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
+        "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -1029,7 +1029,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
+        "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -1048,7 +1048,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
+        "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -1067,7 +1067,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+        "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -1086,7 +1086,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_noArgsStringReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+        "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -1105,7 +1105,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_typedAliasOut_OutputPort[%" PRI_PlatformIntType "]",
+        "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -1124,7 +1124,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_typedAliasReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+        "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -1143,7 +1143,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_typedAliasReturnStringOut_OutputPort[%" PRI_PlatformIntType "]",
+        "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -1162,7 +1162,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
+        "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -1181,7 +1181,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+        "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveCommandsComponentAc.ref.cpp
@@ -37,7 +37,7 @@ void PassiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -61,7 +61,7 @@ void PassiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -85,7 +85,7 @@ void PassiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -109,7 +109,7 @@ void PassiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -133,7 +133,7 @@ void PassiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -157,7 +157,7 @@ void PassiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -181,7 +181,7 @@ void PassiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -205,7 +205,7 @@ void PassiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -229,7 +229,7 @@ void PassiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -253,7 +253,7 @@ void PassiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -277,7 +277,7 @@ void PassiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -301,7 +301,7 @@ void PassiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -325,7 +325,7 @@ void PassiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -349,7 +349,7 @@ void PassiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -368,7 +368,7 @@ void PassiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -387,7 +387,7 @@ void PassiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -406,7 +406,7 @@ void PassiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -425,7 +425,7 @@ void PassiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -444,7 +444,7 @@ void PassiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -464,7 +464,7 @@ void PassiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -484,7 +484,7 @@ void PassiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -503,7 +503,7 @@ void PassiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -522,7 +522,7 @@ void PassiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -541,7 +541,7 @@ void PassiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -560,7 +560,7 @@ void PassiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -579,7 +579,7 @@ void PassiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -598,7 +598,7 @@ void PassiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -617,7 +617,7 @@ void PassiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -636,7 +636,7 @@ void PassiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -655,7 +655,7 @@ void PassiveCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveEventsComponentAc.ref.cpp
@@ -37,7 +37,7 @@ void PassiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -61,7 +61,7 @@ void PassiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -85,7 +85,7 @@ void PassiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -109,7 +109,7 @@ void PassiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -133,7 +133,7 @@ void PassiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -157,7 +157,7 @@ void PassiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -181,7 +181,7 @@ void PassiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -205,7 +205,7 @@ void PassiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -229,7 +229,7 @@ void PassiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -253,7 +253,7 @@ void PassiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -277,7 +277,7 @@ void PassiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -301,7 +301,7 @@ void PassiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -325,7 +325,7 @@ void PassiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -349,7 +349,7 @@ void PassiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -368,7 +368,7 @@ void PassiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -387,7 +387,7 @@ void PassiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -406,7 +406,7 @@ void PassiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -425,7 +425,7 @@ void PassiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -444,7 +444,7 @@ void PassiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -464,7 +464,7 @@ void PassiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -484,7 +484,7 @@ void PassiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -503,7 +503,7 @@ void PassiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -522,7 +522,7 @@ void PassiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -541,7 +541,7 @@ void PassiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -560,7 +560,7 @@ void PassiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -579,7 +579,7 @@ void PassiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -598,7 +598,7 @@ void PassiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -617,7 +617,7 @@ void PassiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -636,7 +636,7 @@ void PassiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -655,7 +655,7 @@ void PassiveEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveGetProductPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveGetProductPortsOnlyComponentAc.ref.cpp
@@ -32,7 +32,7 @@ void PassiveGetProductPortsOnlyComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_productGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -51,7 +51,7 @@ void PassiveGetProductPortsOnlyComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveGetProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveGetProductsComponentAc.ref.cpp
@@ -258,7 +258,7 @@ void PassiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -282,7 +282,7 @@ void PassiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -306,7 +306,7 @@ void PassiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -330,7 +330,7 @@ void PassiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -354,7 +354,7 @@ void PassiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -378,7 +378,7 @@ void PassiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -402,7 +402,7 @@ void PassiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -426,7 +426,7 @@ void PassiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -450,7 +450,7 @@ void PassiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -474,7 +474,7 @@ void PassiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -498,7 +498,7 @@ void PassiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -522,7 +522,7 @@ void PassiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -546,7 +546,7 @@ void PassiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -570,7 +570,7 @@ void PassiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -589,7 +589,7 @@ void PassiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -608,7 +608,7 @@ void PassiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -627,7 +627,7 @@ void PassiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -646,7 +646,7 @@ void PassiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -665,7 +665,7 @@ void PassiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -684,7 +684,7 @@ void PassiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_productGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -703,7 +703,7 @@ void PassiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -723,7 +723,7 @@ void PassiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -743,7 +743,7 @@ void PassiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -762,7 +762,7 @@ void PassiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -781,7 +781,7 @@ void PassiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -800,7 +800,7 @@ void PassiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -819,7 +819,7 @@ void PassiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -838,7 +838,7 @@ void PassiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -857,7 +857,7 @@ void PassiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -876,7 +876,7 @@ void PassiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -895,7 +895,7 @@ void PassiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -914,7 +914,7 @@ void PassiveGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveGuardedProductsComponentAc.ref.cpp
@@ -258,7 +258,7 @@ void PassiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -282,7 +282,7 @@ void PassiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_productRecvIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -306,7 +306,7 @@ void PassiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -330,7 +330,7 @@ void PassiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -354,7 +354,7 @@ void PassiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -378,7 +378,7 @@ void PassiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -402,7 +402,7 @@ void PassiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -426,7 +426,7 @@ void PassiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -450,7 +450,7 @@ void PassiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -474,7 +474,7 @@ void PassiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -498,7 +498,7 @@ void PassiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -522,7 +522,7 @@ void PassiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -546,7 +546,7 @@ void PassiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -570,7 +570,7 @@ void PassiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -594,7 +594,7 @@ void PassiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -613,7 +613,7 @@ void PassiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -632,7 +632,7 @@ void PassiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -651,7 +651,7 @@ void PassiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -670,7 +670,7 @@ void PassiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -689,7 +689,7 @@ void PassiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -708,7 +708,7 @@ void PassiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -727,7 +727,7 @@ void PassiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -747,7 +747,7 @@ void PassiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -767,7 +767,7 @@ void PassiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -786,7 +786,7 @@ void PassiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -805,7 +805,7 @@ void PassiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -824,7 +824,7 @@ void PassiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -843,7 +843,7 @@ void PassiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -862,7 +862,7 @@ void PassiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -881,7 +881,7 @@ void PassiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -900,7 +900,7 @@ void PassiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -919,7 +919,7 @@ void PassiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -938,7 +938,7 @@ void PassiveGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveParamsComponentAc.ref.cpp
@@ -37,7 +37,7 @@ void PassiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -61,7 +61,7 @@ void PassiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -85,7 +85,7 @@ void PassiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -109,7 +109,7 @@ void PassiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -133,7 +133,7 @@ void PassiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -157,7 +157,7 @@ void PassiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -181,7 +181,7 @@ void PassiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -205,7 +205,7 @@ void PassiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -229,7 +229,7 @@ void PassiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -253,7 +253,7 @@ void PassiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -277,7 +277,7 @@ void PassiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -301,7 +301,7 @@ void PassiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -325,7 +325,7 @@ void PassiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -349,7 +349,7 @@ void PassiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -368,7 +368,7 @@ void PassiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -387,7 +387,7 @@ void PassiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -406,7 +406,7 @@ void PassiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -425,7 +425,7 @@ void PassiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -444,7 +444,7 @@ void PassiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -464,7 +464,7 @@ void PassiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -484,7 +484,7 @@ void PassiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -503,7 +503,7 @@ void PassiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -522,7 +522,7 @@ void PassiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -541,7 +541,7 @@ void PassiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -560,7 +560,7 @@ void PassiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -579,7 +579,7 @@ void PassiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -598,7 +598,7 @@ void PassiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -617,7 +617,7 @@ void PassiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -636,7 +636,7 @@ void PassiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -655,7 +655,7 @@ void PassiveParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
@@ -37,7 +37,7 @@ void PassiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -61,7 +61,7 @@ void PassiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -85,7 +85,7 @@ void PassiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -109,7 +109,7 @@ void PassiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -133,7 +133,7 @@ void PassiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -157,7 +157,7 @@ void PassiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -181,7 +181,7 @@ void PassiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -205,7 +205,7 @@ void PassiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -229,7 +229,7 @@ void PassiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -253,7 +253,7 @@ void PassiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -277,7 +277,7 @@ void PassiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -301,7 +301,7 @@ void PassiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -325,7 +325,7 @@ void PassiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -349,7 +349,7 @@ void PassiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -373,7 +373,7 @@ void PassiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_serialGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_serialGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -397,7 +397,7 @@ void PassiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_serialSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_serialSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -416,7 +416,7 @@ void PassiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -435,7 +435,7 @@ void PassiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -454,7 +454,7 @@ void PassiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -473,7 +473,7 @@ void PassiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -492,7 +492,7 @@ void PassiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -512,7 +512,7 @@ void PassiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -532,7 +532,7 @@ void PassiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -551,7 +551,7 @@ void PassiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -570,7 +570,7 @@ void PassiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -589,7 +589,7 @@ void PassiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -608,7 +608,7 @@ void PassiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -627,7 +627,7 @@ void PassiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -646,7 +646,7 @@ void PassiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -665,7 +665,7 @@ void PassiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -684,7 +684,7 @@ void PassiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -703,7 +703,7 @@ void PassiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -722,7 +722,7 @@ void PassiveSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_serialOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_serialOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductPortsOnlyComponentAc.ref.cpp
@@ -37,7 +37,7 @@ void PassiveSyncProductPortsOnlyComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_productRecvIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -56,7 +56,7 @@ void PassiveSyncProductPortsOnlyComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -75,7 +75,7 @@ void PassiveSyncProductPortsOnlyComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductsComponentAc.ref.cpp
@@ -258,7 +258,7 @@ void PassiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -282,7 +282,7 @@ void PassiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_productRecvIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -306,7 +306,7 @@ void PassiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -330,7 +330,7 @@ void PassiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -354,7 +354,7 @@ void PassiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -378,7 +378,7 @@ void PassiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -402,7 +402,7 @@ void PassiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -426,7 +426,7 @@ void PassiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -450,7 +450,7 @@ void PassiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -474,7 +474,7 @@ void PassiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -498,7 +498,7 @@ void PassiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -522,7 +522,7 @@ void PassiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -546,7 +546,7 @@ void PassiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -570,7 +570,7 @@ void PassiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -594,7 +594,7 @@ void PassiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -613,7 +613,7 @@ void PassiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -632,7 +632,7 @@ void PassiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -651,7 +651,7 @@ void PassiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -670,7 +670,7 @@ void PassiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -689,7 +689,7 @@ void PassiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -708,7 +708,7 @@ void PassiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -727,7 +727,7 @@ void PassiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -747,7 +747,7 @@ void PassiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -767,7 +767,7 @@ void PassiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -786,7 +786,7 @@ void PassiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -805,7 +805,7 @@ void PassiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -824,7 +824,7 @@ void PassiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -843,7 +843,7 @@ void PassiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -862,7 +862,7 @@ void PassiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -881,7 +881,7 @@ void PassiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -900,7 +900,7 @@ void PassiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -919,7 +919,7 @@ void PassiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -938,7 +938,7 @@ void PassiveSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTelemetryComponentAc.ref.cpp
@@ -37,7 +37,7 @@ void PassiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -61,7 +61,7 @@ void PassiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -85,7 +85,7 @@ void PassiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -109,7 +109,7 @@ void PassiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -133,7 +133,7 @@ void PassiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -157,7 +157,7 @@ void PassiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -181,7 +181,7 @@ void PassiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -205,7 +205,7 @@ void PassiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -229,7 +229,7 @@ void PassiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -253,7 +253,7 @@ void PassiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -277,7 +277,7 @@ void PassiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -301,7 +301,7 @@ void PassiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -325,7 +325,7 @@ void PassiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -349,7 +349,7 @@ void PassiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -368,7 +368,7 @@ void PassiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -387,7 +387,7 @@ void PassiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -406,7 +406,7 @@ void PassiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -425,7 +425,7 @@ void PassiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -444,7 +444,7 @@ void PassiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -464,7 +464,7 @@ void PassiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -484,7 +484,7 @@ void PassiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -503,7 +503,7 @@ void PassiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -522,7 +522,7 @@ void PassiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -541,7 +541,7 @@ void PassiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -560,7 +560,7 @@ void PassiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -579,7 +579,7 @@ void PassiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -598,7 +598,7 @@ void PassiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -617,7 +617,7 @@ void PassiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -636,7 +636,7 @@ void PassiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -655,7 +655,7 @@ void PassiveTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
@@ -258,7 +258,7 @@ void PassiveTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -282,7 +282,7 @@ void PassiveTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_productRecvIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -306,7 +306,7 @@ void PassiveTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -330,7 +330,7 @@ void PassiveTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -354,7 +354,7 @@ void PassiveTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -378,7 +378,7 @@ void PassiveTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -402,7 +402,7 @@ void PassiveTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -426,7 +426,7 @@ void PassiveTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -450,7 +450,7 @@ void PassiveTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -474,7 +474,7 @@ void PassiveTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -498,7 +498,7 @@ void PassiveTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -522,7 +522,7 @@ void PassiveTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -546,7 +546,7 @@ void PassiveTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -570,7 +570,7 @@ void PassiveTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -594,7 +594,7 @@ void PassiveTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -613,7 +613,7 @@ void PassiveTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -632,7 +632,7 @@ void PassiveTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -651,7 +651,7 @@ void PassiveTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -670,7 +670,7 @@ void PassiveTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -689,7 +689,7 @@ void PassiveTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -708,7 +708,7 @@ void PassiveTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -727,7 +727,7 @@ void PassiveTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -747,7 +747,7 @@ void PassiveTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -767,7 +767,7 @@ void PassiveTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -786,7 +786,7 @@ void PassiveTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -805,7 +805,7 @@ void PassiveTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -824,7 +824,7 @@ void PassiveTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -843,7 +843,7 @@ void PassiveTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -862,7 +862,7 @@ void PassiveTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -881,7 +881,7 @@ void PassiveTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -900,7 +900,7 @@ void PassiveTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -919,7 +919,7 @@ void PassiveTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -938,7 +938,7 @@ void PassiveTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductPortsOnlyComponentAc.ref.cpp
@@ -88,7 +88,7 @@ void QueuedAsyncProductPortsOnlyComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_productRecvIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -107,7 +107,7 @@ void QueuedAsyncProductPortsOnlyComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -126,7 +126,7 @@ void QueuedAsyncProductPortsOnlyComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductsComponentAc.ref.cpp
@@ -321,7 +321,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -345,7 +345,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_productRecvIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -369,7 +369,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -393,7 +393,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -417,7 +417,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -441,7 +441,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -465,7 +465,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -489,7 +489,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -513,7 +513,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -537,7 +537,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -561,7 +561,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -585,7 +585,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -609,7 +609,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -633,7 +633,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -657,7 +657,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -681,7 +681,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -705,7 +705,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -729,7 +729,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -753,7 +753,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -777,7 +777,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -801,7 +801,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -820,7 +820,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -839,7 +839,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -858,7 +858,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -877,7 +877,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -896,7 +896,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -915,7 +915,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -934,7 +934,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -954,7 +954,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -974,7 +974,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -993,7 +993,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1012,7 +1012,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1031,7 +1031,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1050,7 +1050,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1069,7 +1069,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1088,7 +1088,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1107,7 +1107,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1126,7 +1126,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1145,7 +1145,7 @@ void QueuedAsyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedCommandsComponentAc.ref.cpp
@@ -103,7 +103,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -127,7 +127,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -151,7 +151,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -175,7 +175,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -199,7 +199,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -223,7 +223,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -247,7 +247,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -271,7 +271,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -295,7 +295,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -319,7 +319,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -343,7 +343,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -367,7 +367,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -391,7 +391,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -415,7 +415,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -439,7 +439,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -463,7 +463,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -487,7 +487,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -511,7 +511,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -535,7 +535,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -559,7 +559,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -578,7 +578,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -597,7 +597,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -616,7 +616,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -635,7 +635,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -654,7 +654,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -674,7 +674,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -694,7 +694,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -713,7 +713,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -732,7 +732,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -751,7 +751,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -770,7 +770,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -789,7 +789,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -808,7 +808,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -827,7 +827,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -846,7 +846,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -865,7 +865,7 @@ void QueuedCommandsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.cpp
@@ -98,7 +98,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -122,7 +122,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -146,7 +146,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -170,7 +170,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -194,7 +194,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -218,7 +218,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -242,7 +242,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -266,7 +266,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -290,7 +290,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -314,7 +314,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -338,7 +338,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -362,7 +362,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -386,7 +386,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -410,7 +410,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -434,7 +434,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -458,7 +458,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -482,7 +482,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -506,7 +506,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -530,7 +530,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -554,7 +554,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -573,7 +573,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -592,7 +592,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -611,7 +611,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -630,7 +630,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -649,7 +649,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -669,7 +669,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -689,7 +689,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -708,7 +708,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -727,7 +727,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -746,7 +746,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -765,7 +765,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -784,7 +784,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -803,7 +803,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -822,7 +822,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -841,7 +841,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -860,7 +860,7 @@ void QueuedEventsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedGetProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedGetProductsComponentAc.ref.cpp
@@ -319,7 +319,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -343,7 +343,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -367,7 +367,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -391,7 +391,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -415,7 +415,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -439,7 +439,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -463,7 +463,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -487,7 +487,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -511,7 +511,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -535,7 +535,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -559,7 +559,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -583,7 +583,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -607,7 +607,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -631,7 +631,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -655,7 +655,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -679,7 +679,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -703,7 +703,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -727,7 +727,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -751,7 +751,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -775,7 +775,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -794,7 +794,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -813,7 +813,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -832,7 +832,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -851,7 +851,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -870,7 +870,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -889,7 +889,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_productGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -908,7 +908,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -928,7 +928,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -948,7 +948,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -967,7 +967,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -986,7 +986,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1005,7 +1005,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1024,7 +1024,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1043,7 +1043,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1062,7 +1062,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1081,7 +1081,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1100,7 +1100,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1119,7 +1119,7 @@ void QueuedGetProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedGuardedProductsComponentAc.ref.cpp
@@ -319,7 +319,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -343,7 +343,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_productRecvIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -367,7 +367,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -391,7 +391,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -415,7 +415,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -439,7 +439,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -463,7 +463,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -487,7 +487,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -511,7 +511,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -535,7 +535,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -559,7 +559,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -583,7 +583,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -607,7 +607,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -631,7 +631,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -655,7 +655,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -679,7 +679,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -703,7 +703,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -727,7 +727,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -751,7 +751,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -775,7 +775,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -799,7 +799,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -818,7 +818,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -837,7 +837,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -856,7 +856,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -875,7 +875,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -894,7 +894,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -913,7 +913,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -932,7 +932,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -952,7 +952,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -972,7 +972,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -991,7 +991,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1010,7 +1010,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1029,7 +1029,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1048,7 +1048,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1067,7 +1067,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1086,7 +1086,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1105,7 +1105,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1124,7 +1124,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1143,7 +1143,7 @@ void QueuedGuardedProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedNoArgsPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedNoArgsPortsOnlyComponentAc.ref.cpp
@@ -82,7 +82,7 @@ void QueuedNoArgsPortsOnlyComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -106,7 +106,7 @@ void QueuedNoArgsPortsOnlyComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -130,7 +130,7 @@ void QueuedNoArgsPortsOnlyComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -154,7 +154,7 @@ void QueuedNoArgsPortsOnlyComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -173,7 +173,7 @@ void QueuedNoArgsPortsOnlyComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -192,7 +192,7 @@ void QueuedNoArgsPortsOnlyComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedOverflowComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedOverflowComponentAc.ref.cpp
@@ -102,7 +102,7 @@ void QueuedOverflowComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -126,7 +126,7 @@ void QueuedOverflowComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productRecvInHook_InputPort[%" PRI_PlatformIntType "]",
+      "%s_productRecvInHook_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -150,7 +150,7 @@ void QueuedOverflowComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_assertAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_assertAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -174,7 +174,7 @@ void QueuedOverflowComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_blockAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_blockAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -198,7 +198,7 @@ void QueuedOverflowComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_dropAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_dropAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -222,7 +222,7 @@ void QueuedOverflowComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_hookAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_hookAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -246,7 +246,7 @@ void QueuedOverflowComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_serialAsyncHook_InputPort[%" PRI_PlatformIntType "]",
+      "%s_serialAsyncHook_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -265,7 +265,7 @@ void QueuedOverflowComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -284,7 +284,7 @@ void QueuedOverflowComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -303,7 +303,7 @@ void QueuedOverflowComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -322,7 +322,7 @@ void QueuedOverflowComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -341,7 +341,7 @@ void QueuedOverflowComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -361,7 +361,7 @@ void QueuedOverflowComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -381,7 +381,7 @@ void QueuedOverflowComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -400,7 +400,7 @@ void QueuedOverflowComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.cpp
@@ -98,7 +98,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -122,7 +122,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -146,7 +146,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -170,7 +170,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -194,7 +194,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -218,7 +218,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -242,7 +242,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -266,7 +266,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -290,7 +290,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -314,7 +314,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -338,7 +338,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -362,7 +362,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -386,7 +386,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -410,7 +410,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -434,7 +434,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -458,7 +458,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -482,7 +482,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -506,7 +506,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -530,7 +530,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -554,7 +554,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -573,7 +573,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -592,7 +592,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -611,7 +611,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -630,7 +630,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -649,7 +649,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -669,7 +669,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -689,7 +689,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -708,7 +708,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -727,7 +727,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -746,7 +746,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -765,7 +765,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -784,7 +784,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -803,7 +803,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -822,7 +822,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -841,7 +841,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -860,7 +860,7 @@ void QueuedParamsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
@@ -137,7 +137,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -161,7 +161,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -185,7 +185,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -209,7 +209,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -233,7 +233,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -257,7 +257,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -281,7 +281,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -305,7 +305,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -329,7 +329,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -353,7 +353,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -377,7 +377,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -401,7 +401,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -425,7 +425,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -449,7 +449,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -473,7 +473,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -497,7 +497,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -521,7 +521,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -545,7 +545,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -569,7 +569,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -593,7 +593,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -617,7 +617,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_serialAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_serialAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -641,7 +641,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_serialAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
+      "%s_serialAsyncAssert_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -665,7 +665,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_serialAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_serialAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -689,7 +689,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_serialAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_serialAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -713,7 +713,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_serialGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_serialGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -737,7 +737,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_serialSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_serialSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -756,7 +756,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -775,7 +775,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -794,7 +794,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -813,7 +813,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -832,7 +832,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -852,7 +852,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -872,7 +872,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -891,7 +891,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -910,7 +910,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -929,7 +929,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -948,7 +948,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -967,7 +967,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -986,7 +986,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1005,7 +1005,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1024,7 +1024,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1043,7 +1043,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1062,7 +1062,7 @@ void QueuedSerialComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_serialOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_serialOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSyncProductsComponentAc.ref.cpp
@@ -319,7 +319,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -343,7 +343,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_productRecvIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -367,7 +367,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -391,7 +391,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -415,7 +415,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -439,7 +439,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -463,7 +463,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -487,7 +487,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -511,7 +511,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -535,7 +535,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -559,7 +559,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -583,7 +583,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -607,7 +607,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -631,7 +631,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -655,7 +655,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -679,7 +679,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -703,7 +703,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -727,7 +727,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -751,7 +751,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -775,7 +775,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -799,7 +799,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -818,7 +818,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -837,7 +837,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -856,7 +856,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -875,7 +875,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -894,7 +894,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -913,7 +913,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -932,7 +932,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -952,7 +952,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -972,7 +972,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -991,7 +991,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1010,7 +1010,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1029,7 +1029,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1048,7 +1048,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1067,7 +1067,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1086,7 +1086,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1105,7 +1105,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1124,7 +1124,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1143,7 +1143,7 @@ void QueuedSyncProductsComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.cpp
@@ -98,7 +98,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -122,7 +122,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -146,7 +146,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -170,7 +170,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -194,7 +194,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -218,7 +218,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -242,7 +242,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -266,7 +266,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -290,7 +290,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -314,7 +314,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -338,7 +338,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -362,7 +362,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -386,7 +386,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -410,7 +410,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -434,7 +434,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -458,7 +458,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -482,7 +482,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -506,7 +506,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -530,7 +530,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -554,7 +554,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -573,7 +573,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -592,7 +592,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -611,7 +611,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -630,7 +630,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -649,7 +649,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -669,7 +669,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -689,7 +689,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -708,7 +708,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -727,7 +727,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -746,7 +746,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -765,7 +765,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -784,7 +784,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -803,7 +803,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -822,7 +822,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -841,7 +841,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -860,7 +860,7 @@ void QueuedTelemetryComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
@@ -355,7 +355,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -379,7 +379,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
+      "%s_productRecvIn_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -403,7 +403,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_aliasTypedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_aliasTypedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -427,7 +427,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -451,7 +451,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -475,7 +475,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -499,7 +499,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -523,7 +523,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -547,7 +547,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -571,7 +571,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -595,7 +595,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -619,7 +619,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -643,7 +643,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasStringReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasStringReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -667,7 +667,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -691,7 +691,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncAssert_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -715,7 +715,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncBlockPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -739,7 +739,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAsyncDropPriority_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -763,7 +763,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -787,7 +787,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnGuarded_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -811,7 +811,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -835,7 +835,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
+      "%s_typedSync_InputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -854,7 +854,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdRegOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -873,7 +873,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_cmdResponseOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -892,7 +892,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_eventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -911,7 +911,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -930,7 +930,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_prmSetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -949,7 +949,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_productRequestOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -968,7 +968,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_productSendOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -988,7 +988,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_textEventOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1008,7 +1008,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_timeGetOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1027,7 +1027,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_tlmOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1046,7 +1046,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1065,7 +1065,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1084,7 +1084,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_noArgsStringReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_noArgsStringReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1103,7 +1103,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1122,7 +1122,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1141,7 +1141,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedAliasReturnStringOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1160,7 +1160,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -1179,7 +1179,7 @@ void QueuedTestComponentBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
+      "%s_typedReturnOut_OutputPort[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/SmChoiceQueuedComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SmChoiceQueuedComponentAc.ref.cpp
@@ -468,7 +468,7 @@ namespace FppTest {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_schedIn_InputPort[%" PRI_PlatformIntType "]",
+        "%s_schedIn_InputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );

--- a/compiler/tools/fpp-to-cpp/test/component/base/SmInitialQueuedComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SmInitialQueuedComponentAc.ref.cpp
@@ -279,7 +279,7 @@ namespace FppTest {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_schedIn_InputPort[%" PRI_PlatformIntType "]",
+        "%s_schedIn_InputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );

--- a/compiler/tools/fpp-to-cpp/test/component/base/SmStateQueuedComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SmStateQueuedComponentAc.ref.cpp
@@ -995,7 +995,7 @@ namespace FppTest {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_schedIn_InputPort[%" PRI_PlatformIntType "]",
+        "%s_schedIn_InputPort[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveAsyncProductsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveAsyncProductsTesterBase.ref.cpp
@@ -35,7 +35,7 @@ void ActiveAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_productRequestOut[%" PRI_PlatformIntType "]",
+      "%s_from_productRequestOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -59,7 +59,7 @@ void ActiveAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_productSendOut[%" PRI_PlatformIntType "]",
+      "%s_from_productSendOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -83,7 +83,7 @@ void ActiveAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_timeGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -107,7 +107,7 @@ void ActiveAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -131,7 +131,7 @@ void ActiveAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -155,7 +155,7 @@ void ActiveAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsStringReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsStringReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -179,7 +179,7 @@ void ActiveAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -203,7 +203,7 @@ void ActiveAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -227,7 +227,7 @@ void ActiveAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnStringOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnStringOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -251,7 +251,7 @@ void ActiveAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -275,7 +275,7 @@ void ActiveAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -294,7 +294,7 @@ void ActiveAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_productRecvIn[%" PRI_PlatformIntType "]",
+      "%s_to_productRecvIn[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -313,7 +313,7 @@ void ActiveAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_aliasTypedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_aliasTypedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -332,7 +332,7 @@ void ActiveAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -351,7 +351,7 @@ void ActiveAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -370,7 +370,7 @@ void ActiveAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -389,7 +389,7 @@ void ActiveAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -408,7 +408,7 @@ void ActiveAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -427,7 +427,7 @@ void ActiveAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -446,7 +446,7 @@ void ActiveAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -465,7 +465,7 @@ void ActiveAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -484,7 +484,7 @@ void ActiveAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -503,7 +503,7 @@ void ActiveAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -522,7 +522,7 @@ void ActiveAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -541,7 +541,7 @@ void ActiveAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncAssert[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -560,7 +560,7 @@ void ActiveAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncBlockPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -579,7 +579,7 @@ void ActiveAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncDropPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -598,7 +598,7 @@ void ActiveAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -617,7 +617,7 @@ void ActiveAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -636,7 +636,7 @@ void ActiveAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -655,7 +655,7 @@ void ActiveAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsTesterBase.ref.cpp
@@ -35,7 +35,7 @@ void ActiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
+      "%s_from_cmdRegOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -59,7 +59,7 @@ void ActiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
+      "%s_from_cmdResponseOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -83,7 +83,7 @@ void ActiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_timeGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -107,7 +107,7 @@ void ActiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -131,7 +131,7 @@ void ActiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -155,7 +155,7 @@ void ActiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsStringReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsStringReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -179,7 +179,7 @@ void ActiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -203,7 +203,7 @@ void ActiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -227,7 +227,7 @@ void ActiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnStringOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnStringOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -251,7 +251,7 @@ void ActiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -275,7 +275,7 @@ void ActiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -294,7 +294,7 @@ void ActiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_cmdIn[%" PRI_PlatformIntType "]",
+      "%s_to_cmdIn[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -313,7 +313,7 @@ void ActiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_aliasTypedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_aliasTypedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -332,7 +332,7 @@ void ActiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -351,7 +351,7 @@ void ActiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -370,7 +370,7 @@ void ActiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -389,7 +389,7 @@ void ActiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -408,7 +408,7 @@ void ActiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -427,7 +427,7 @@ void ActiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -446,7 +446,7 @@ void ActiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -465,7 +465,7 @@ void ActiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -484,7 +484,7 @@ void ActiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -503,7 +503,7 @@ void ActiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -522,7 +522,7 @@ void ActiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -541,7 +541,7 @@ void ActiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncAssert[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -560,7 +560,7 @@ void ActiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncBlockPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -579,7 +579,7 @@ void ActiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncDropPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -598,7 +598,7 @@ void ActiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -617,7 +617,7 @@ void ActiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -636,7 +636,7 @@ void ActiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -655,7 +655,7 @@ void ActiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsTesterBase.ref.cpp
@@ -35,7 +35,7 @@ void ActiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_eventOut[%" PRI_PlatformIntType "]",
+      "%s_from_eventOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -60,7 +60,7 @@ void ActiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_textEventOut[%" PRI_PlatformIntType "]",
+      "%s_from_textEventOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -85,7 +85,7 @@ void ActiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_timeGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -109,7 +109,7 @@ void ActiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -133,7 +133,7 @@ void ActiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -157,7 +157,7 @@ void ActiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsStringReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsStringReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -181,7 +181,7 @@ void ActiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -205,7 +205,7 @@ void ActiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -229,7 +229,7 @@ void ActiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnStringOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnStringOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -253,7 +253,7 @@ void ActiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -277,7 +277,7 @@ void ActiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -296,7 +296,7 @@ void ActiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_aliasTypedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_aliasTypedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -315,7 +315,7 @@ void ActiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -334,7 +334,7 @@ void ActiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -353,7 +353,7 @@ void ActiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -372,7 +372,7 @@ void ActiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -391,7 +391,7 @@ void ActiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -410,7 +410,7 @@ void ActiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -429,7 +429,7 @@ void ActiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -448,7 +448,7 @@ void ActiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -467,7 +467,7 @@ void ActiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -486,7 +486,7 @@ void ActiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -505,7 +505,7 @@ void ActiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -524,7 +524,7 @@ void ActiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncAssert[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -543,7 +543,7 @@ void ActiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncBlockPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -562,7 +562,7 @@ void ActiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncDropPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -581,7 +581,7 @@ void ActiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -600,7 +600,7 @@ void ActiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -619,7 +619,7 @@ void ActiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -638,7 +638,7 @@ void ActiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveGetProductsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveGetProductsTesterBase.ref.cpp
@@ -35,7 +35,7 @@ void ActiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_productGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_productGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -59,7 +59,7 @@ void ActiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_productSendOut[%" PRI_PlatformIntType "]",
+      "%s_from_productSendOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -83,7 +83,7 @@ void ActiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_timeGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -107,7 +107,7 @@ void ActiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -131,7 +131,7 @@ void ActiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -155,7 +155,7 @@ void ActiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsStringReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsStringReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -179,7 +179,7 @@ void ActiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -203,7 +203,7 @@ void ActiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -227,7 +227,7 @@ void ActiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnStringOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnStringOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -251,7 +251,7 @@ void ActiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -275,7 +275,7 @@ void ActiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -294,7 +294,7 @@ void ActiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_aliasTypedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_aliasTypedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -313,7 +313,7 @@ void ActiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -332,7 +332,7 @@ void ActiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -351,7 +351,7 @@ void ActiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -370,7 +370,7 @@ void ActiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -389,7 +389,7 @@ void ActiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -408,7 +408,7 @@ void ActiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -427,7 +427,7 @@ void ActiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -446,7 +446,7 @@ void ActiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -465,7 +465,7 @@ void ActiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -484,7 +484,7 @@ void ActiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -503,7 +503,7 @@ void ActiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -522,7 +522,7 @@ void ActiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncAssert[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -541,7 +541,7 @@ void ActiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncBlockPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -560,7 +560,7 @@ void ActiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncDropPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -579,7 +579,7 @@ void ActiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -598,7 +598,7 @@ void ActiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -617,7 +617,7 @@ void ActiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -636,7 +636,7 @@ void ActiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveGuardedProductsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveGuardedProductsTesterBase.ref.cpp
@@ -35,7 +35,7 @@ void ActiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_productRequestOut[%" PRI_PlatformIntType "]",
+      "%s_from_productRequestOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -59,7 +59,7 @@ void ActiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_productSendOut[%" PRI_PlatformIntType "]",
+      "%s_from_productSendOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -83,7 +83,7 @@ void ActiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_timeGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -107,7 +107,7 @@ void ActiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -131,7 +131,7 @@ void ActiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -155,7 +155,7 @@ void ActiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsStringReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsStringReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -179,7 +179,7 @@ void ActiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -203,7 +203,7 @@ void ActiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -227,7 +227,7 @@ void ActiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnStringOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnStringOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -251,7 +251,7 @@ void ActiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -275,7 +275,7 @@ void ActiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -294,7 +294,7 @@ void ActiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_productRecvIn[%" PRI_PlatformIntType "]",
+      "%s_to_productRecvIn[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -313,7 +313,7 @@ void ActiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_aliasTypedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_aliasTypedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -332,7 +332,7 @@ void ActiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -351,7 +351,7 @@ void ActiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -370,7 +370,7 @@ void ActiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -389,7 +389,7 @@ void ActiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -408,7 +408,7 @@ void ActiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -427,7 +427,7 @@ void ActiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -446,7 +446,7 @@ void ActiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -465,7 +465,7 @@ void ActiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -484,7 +484,7 @@ void ActiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -503,7 +503,7 @@ void ActiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -522,7 +522,7 @@ void ActiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -541,7 +541,7 @@ void ActiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncAssert[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -560,7 +560,7 @@ void ActiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncBlockPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -579,7 +579,7 @@ void ActiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncDropPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -598,7 +598,7 @@ void ActiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -617,7 +617,7 @@ void ActiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -636,7 +636,7 @@ void ActiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -655,7 +655,7 @@ void ActiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveNoArgsPortsOnlyTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveNoArgsPortsOnlyTesterBase.ref.cpp
@@ -35,7 +35,7 @@ void ActiveNoArgsPortsOnlyTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -59,7 +59,7 @@ void ActiveNoArgsPortsOnlyTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -78,7 +78,7 @@ void ActiveNoArgsPortsOnlyTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -97,7 +97,7 @@ void ActiveNoArgsPortsOnlyTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -116,7 +116,7 @@ void ActiveNoArgsPortsOnlyTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -135,7 +135,7 @@ void ActiveNoArgsPortsOnlyTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsTesterBase.ref.cpp
@@ -35,7 +35,7 @@ void ActiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
+      "%s_from_cmdRegOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -59,7 +59,7 @@ void ActiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
+      "%s_from_cmdResponseOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -83,7 +83,7 @@ void ActiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_prmGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_prmGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -107,7 +107,7 @@ void ActiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_prmSetOut[%" PRI_PlatformIntType "]",
+      "%s_from_prmSetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -131,7 +131,7 @@ void ActiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_timeGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -155,7 +155,7 @@ void ActiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -179,7 +179,7 @@ void ActiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -203,7 +203,7 @@ void ActiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsStringReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsStringReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -227,7 +227,7 @@ void ActiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -251,7 +251,7 @@ void ActiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -275,7 +275,7 @@ void ActiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnStringOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnStringOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -299,7 +299,7 @@ void ActiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -323,7 +323,7 @@ void ActiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -342,7 +342,7 @@ void ActiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_cmdIn[%" PRI_PlatformIntType "]",
+      "%s_to_cmdIn[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -361,7 +361,7 @@ void ActiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_aliasTypedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_aliasTypedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -380,7 +380,7 @@ void ActiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -399,7 +399,7 @@ void ActiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -418,7 +418,7 @@ void ActiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -437,7 +437,7 @@ void ActiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -456,7 +456,7 @@ void ActiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -475,7 +475,7 @@ void ActiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -494,7 +494,7 @@ void ActiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -513,7 +513,7 @@ void ActiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -532,7 +532,7 @@ void ActiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -551,7 +551,7 @@ void ActiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -570,7 +570,7 @@ void ActiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -589,7 +589,7 @@ void ActiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncAssert[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -608,7 +608,7 @@ void ActiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncBlockPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -627,7 +627,7 @@ void ActiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncDropPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -646,7 +646,7 @@ void ActiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -665,7 +665,7 @@ void ActiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -684,7 +684,7 @@ void ActiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -703,7 +703,7 @@ void ActiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.cpp
@@ -35,7 +35,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
+      "%s_from_cmdRegOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -59,7 +59,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
+      "%s_from_cmdResponseOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -83,7 +83,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_eventOut[%" PRI_PlatformIntType "]",
+      "%s_from_eventOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -107,7 +107,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_prmGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_prmGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -131,7 +131,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_prmSetOut[%" PRI_PlatformIntType "]",
+      "%s_from_prmSetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -156,7 +156,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_textEventOut[%" PRI_PlatformIntType "]",
+      "%s_from_textEventOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -181,7 +181,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_timeGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -205,7 +205,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_tlmOut[%" PRI_PlatformIntType "]",
+      "%s_from_tlmOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -229,7 +229,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -253,7 +253,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -277,7 +277,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsStringReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsStringReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -301,7 +301,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -325,7 +325,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -349,7 +349,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnStringOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnStringOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -373,7 +373,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -397,7 +397,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -421,7 +421,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_serialOut[%" PRI_PlatformIntType "]",
+      "%s_from_serialOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -440,7 +440,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_cmdIn[%" PRI_PlatformIntType "]",
+      "%s_to_cmdIn[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -459,7 +459,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_aliasTypedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_aliasTypedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -478,7 +478,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -497,7 +497,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -516,7 +516,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -535,7 +535,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -554,7 +554,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -573,7 +573,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -592,7 +592,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -611,7 +611,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -630,7 +630,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -649,7 +649,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -668,7 +668,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -687,7 +687,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncAssert[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -706,7 +706,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncBlockPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -725,7 +725,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncDropPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -744,7 +744,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -763,7 +763,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -782,7 +782,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -801,7 +801,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -820,7 +820,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_serialAsync[%" PRI_PlatformIntType "]",
+      "%s_to_serialAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -839,7 +839,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_serialAsyncAssert[%" PRI_PlatformIntType "]",
+      "%s_to_serialAsyncAssert[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -858,7 +858,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_serialAsyncBlockPriority[%" PRI_PlatformIntType "]",
+      "%s_to_serialAsyncBlockPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -877,7 +877,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_serialAsyncDropPriority[%" PRI_PlatformIntType "]",
+      "%s_to_serialAsyncDropPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -896,7 +896,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_serialGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_serialGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -915,7 +915,7 @@ void ActiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_serialSync[%" PRI_PlatformIntType "]",
+      "%s_to_serialSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSyncProductsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSyncProductsTesterBase.ref.cpp
@@ -35,7 +35,7 @@ void ActiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_productRequestOut[%" PRI_PlatformIntType "]",
+      "%s_from_productRequestOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -59,7 +59,7 @@ void ActiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_productSendOut[%" PRI_PlatformIntType "]",
+      "%s_from_productSendOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -83,7 +83,7 @@ void ActiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_timeGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -107,7 +107,7 @@ void ActiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -131,7 +131,7 @@ void ActiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -155,7 +155,7 @@ void ActiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsStringReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsStringReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -179,7 +179,7 @@ void ActiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -203,7 +203,7 @@ void ActiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -227,7 +227,7 @@ void ActiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnStringOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnStringOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -251,7 +251,7 @@ void ActiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -275,7 +275,7 @@ void ActiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -294,7 +294,7 @@ void ActiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_productRecvIn[%" PRI_PlatformIntType "]",
+      "%s_to_productRecvIn[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -313,7 +313,7 @@ void ActiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_aliasTypedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_aliasTypedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -332,7 +332,7 @@ void ActiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -351,7 +351,7 @@ void ActiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -370,7 +370,7 @@ void ActiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -389,7 +389,7 @@ void ActiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -408,7 +408,7 @@ void ActiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -427,7 +427,7 @@ void ActiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -446,7 +446,7 @@ void ActiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -465,7 +465,7 @@ void ActiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -484,7 +484,7 @@ void ActiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -503,7 +503,7 @@ void ActiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -522,7 +522,7 @@ void ActiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -541,7 +541,7 @@ void ActiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncAssert[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -560,7 +560,7 @@ void ActiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncBlockPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -579,7 +579,7 @@ void ActiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncDropPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -598,7 +598,7 @@ void ActiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -617,7 +617,7 @@ void ActiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -636,7 +636,7 @@ void ActiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -655,7 +655,7 @@ void ActiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryTesterBase.ref.cpp
@@ -35,7 +35,7 @@ void ActiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_timeGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -59,7 +59,7 @@ void ActiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_tlmOut[%" PRI_PlatformIntType "]",
+      "%s_from_tlmOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -83,7 +83,7 @@ void ActiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -107,7 +107,7 @@ void ActiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -131,7 +131,7 @@ void ActiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsStringReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsStringReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -155,7 +155,7 @@ void ActiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -179,7 +179,7 @@ void ActiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -203,7 +203,7 @@ void ActiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnStringOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnStringOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -227,7 +227,7 @@ void ActiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -251,7 +251,7 @@ void ActiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -270,7 +270,7 @@ void ActiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_aliasTypedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_aliasTypedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -289,7 +289,7 @@ void ActiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -308,7 +308,7 @@ void ActiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -327,7 +327,7 @@ void ActiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -346,7 +346,7 @@ void ActiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -365,7 +365,7 @@ void ActiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -384,7 +384,7 @@ void ActiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -403,7 +403,7 @@ void ActiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -422,7 +422,7 @@ void ActiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -441,7 +441,7 @@ void ActiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -460,7 +460,7 @@ void ActiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -479,7 +479,7 @@ void ActiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -498,7 +498,7 @@ void ActiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncAssert[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -517,7 +517,7 @@ void ActiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncBlockPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -536,7 +536,7 @@ void ActiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncDropPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -555,7 +555,7 @@ void ActiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -574,7 +574,7 @@ void ActiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -593,7 +593,7 @@ void ActiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -612,7 +612,7 @@ void ActiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.cpp
@@ -37,7 +37,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
+        "%s_from_cmdRegOut[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -61,7 +61,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
+        "%s_from_cmdResponseOut[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -85,7 +85,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_from_eventOut[%" PRI_PlatformIntType "]",
+        "%s_from_eventOut[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -109,7 +109,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_from_prmGetOut[%" PRI_PlatformIntType "]",
+        "%s_from_prmGetOut[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -133,7 +133,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_from_prmSetOut[%" PRI_PlatformIntType "]",
+        "%s_from_prmSetOut[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -157,7 +157,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_from_productRequestOut[%" PRI_PlatformIntType "]",
+        "%s_from_productRequestOut[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -181,7 +181,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_from_productSendOut[%" PRI_PlatformIntType "]",
+        "%s_from_productSendOut[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -206,7 +206,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_from_textEventOut[%" PRI_PlatformIntType "]",
+        "%s_from_textEventOut[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -231,7 +231,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
+        "%s_from_timeGetOut[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -255,7 +255,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_from_tlmOut[%" PRI_PlatformIntType "]",
+        "%s_from_tlmOut[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -279,7 +279,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
+        "%s_from_noArgsOut[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -303,7 +303,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
+        "%s_from_noArgsReturnOut[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -327,7 +327,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_from_noArgsStringReturnOut[%" PRI_PlatformIntType "]",
+        "%s_from_noArgsStringReturnOut[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -351,7 +351,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_from_typedAliasOut[%" PRI_PlatformIntType "]",
+        "%s_from_typedAliasOut[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -375,7 +375,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_from_typedAliasReturnOut[%" PRI_PlatformIntType "]",
+        "%s_from_typedAliasReturnOut[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -399,7 +399,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_from_typedAliasReturnStringOut[%" PRI_PlatformIntType "]",
+        "%s_from_typedAliasReturnStringOut[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -423,7 +423,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_from_typedOut[%" PRI_PlatformIntType "]",
+        "%s_from_typedOut[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -447,7 +447,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
+        "%s_from_typedReturnOut[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -466,7 +466,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_to_cmdIn[%" PRI_PlatformIntType "]",
+        "%s_to_cmdIn[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -485,7 +485,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_to_productRecvIn[%" PRI_PlatformIntType "]",
+        "%s_to_productRecvIn[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -504,7 +504,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_to_aliasTypedAsync[%" PRI_PlatformIntType "]",
+        "%s_to_aliasTypedAsync[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -523,7 +523,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_to_noArgsAliasStringReturnSync[%" PRI_PlatformIntType "]",
+        "%s_to_noArgsAliasStringReturnSync[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -542,7 +542,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
+        "%s_to_noArgsAsync[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -561,7 +561,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
+        "%s_to_noArgsGuarded[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -580,7 +580,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
+        "%s_to_noArgsReturnGuarded[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -599,7 +599,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
+        "%s_to_noArgsReturnSync[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -618,7 +618,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_to_noArgsStringReturnSync[%" PRI_PlatformIntType "]",
+        "%s_to_noArgsStringReturnSync[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -637,7 +637,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
+        "%s_to_noArgsSync[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -656,7 +656,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_to_typedAliasGuarded[%" PRI_PlatformIntType "]",
+        "%s_to_typedAliasGuarded[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -675,7 +675,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_to_typedAliasReturnSync[%" PRI_PlatformIntType "]",
+        "%s_to_typedAliasReturnSync[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -694,7 +694,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_to_typedAliasStringReturnSync[%" PRI_PlatformIntType "]",
+        "%s_to_typedAliasStringReturnSync[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -713,7 +713,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_to_typedAsync[%" PRI_PlatformIntType "]",
+        "%s_to_typedAsync[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -732,7 +732,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
+        "%s_to_typedAsyncAssert[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -751,7 +751,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
+        "%s_to_typedAsyncBlockPriority[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -770,7 +770,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
+        "%s_to_typedAsyncDropPriority[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -789,7 +789,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
+        "%s_to_typedGuarded[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -808,7 +808,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
+        "%s_to_typedReturnGuarded[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -827,7 +827,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
+        "%s_to_typedReturnSync[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );
@@ -846,7 +846,7 @@ namespace M {
 #if FW_OBJECT_NAMES == 1
       Fw::ObjectName portName;
       portName.format(
-        "%s_to_typedSync[%" PRI_PlatformIntType "]",
+        "%s_to_typedSync[%" PRI_FwIndexType "]",
         this->m_objName.toChar(),
         port
       );

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsTesterBase.ref.cpp
@@ -35,7 +35,7 @@ void PassiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
+      "%s_from_cmdRegOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -59,7 +59,7 @@ void PassiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
+      "%s_from_cmdResponseOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -83,7 +83,7 @@ void PassiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_timeGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -107,7 +107,7 @@ void PassiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -131,7 +131,7 @@ void PassiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -155,7 +155,7 @@ void PassiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsStringReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsStringReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -179,7 +179,7 @@ void PassiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -203,7 +203,7 @@ void PassiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -227,7 +227,7 @@ void PassiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnStringOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnStringOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -251,7 +251,7 @@ void PassiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -275,7 +275,7 @@ void PassiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -294,7 +294,7 @@ void PassiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_cmdIn[%" PRI_PlatformIntType "]",
+      "%s_to_cmdIn[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -313,7 +313,7 @@ void PassiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -332,7 +332,7 @@ void PassiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -351,7 +351,7 @@ void PassiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -370,7 +370,7 @@ void PassiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -389,7 +389,7 @@ void PassiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -408,7 +408,7 @@ void PassiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -427,7 +427,7 @@ void PassiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -446,7 +446,7 @@ void PassiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -465,7 +465,7 @@ void PassiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -484,7 +484,7 @@ void PassiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -503,7 +503,7 @@ void PassiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -522,7 +522,7 @@ void PassiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -541,7 +541,7 @@ void PassiveCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsTesterBase.ref.cpp
@@ -35,7 +35,7 @@ void PassiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_eventOut[%" PRI_PlatformIntType "]",
+      "%s_from_eventOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -60,7 +60,7 @@ void PassiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_textEventOut[%" PRI_PlatformIntType "]",
+      "%s_from_textEventOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -85,7 +85,7 @@ void PassiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_timeGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -109,7 +109,7 @@ void PassiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -133,7 +133,7 @@ void PassiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -157,7 +157,7 @@ void PassiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsStringReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsStringReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -181,7 +181,7 @@ void PassiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -205,7 +205,7 @@ void PassiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -229,7 +229,7 @@ void PassiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnStringOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnStringOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -253,7 +253,7 @@ void PassiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -277,7 +277,7 @@ void PassiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -296,7 +296,7 @@ void PassiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -315,7 +315,7 @@ void PassiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -334,7 +334,7 @@ void PassiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -353,7 +353,7 @@ void PassiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -372,7 +372,7 @@ void PassiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -391,7 +391,7 @@ void PassiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -410,7 +410,7 @@ void PassiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -429,7 +429,7 @@ void PassiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -448,7 +448,7 @@ void PassiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -467,7 +467,7 @@ void PassiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -486,7 +486,7 @@ void PassiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -505,7 +505,7 @@ void PassiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -524,7 +524,7 @@ void PassiveEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveGetProductsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveGetProductsTesterBase.ref.cpp
@@ -35,7 +35,7 @@ void PassiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_productGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_productGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -59,7 +59,7 @@ void PassiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_productSendOut[%" PRI_PlatformIntType "]",
+      "%s_from_productSendOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -83,7 +83,7 @@ void PassiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_timeGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -107,7 +107,7 @@ void PassiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -131,7 +131,7 @@ void PassiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -155,7 +155,7 @@ void PassiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsStringReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsStringReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -179,7 +179,7 @@ void PassiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -203,7 +203,7 @@ void PassiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -227,7 +227,7 @@ void PassiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnStringOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnStringOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -251,7 +251,7 @@ void PassiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -275,7 +275,7 @@ void PassiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -294,7 +294,7 @@ void PassiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -313,7 +313,7 @@ void PassiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -332,7 +332,7 @@ void PassiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -351,7 +351,7 @@ void PassiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -370,7 +370,7 @@ void PassiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -389,7 +389,7 @@ void PassiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -408,7 +408,7 @@ void PassiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -427,7 +427,7 @@ void PassiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -446,7 +446,7 @@ void PassiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -465,7 +465,7 @@ void PassiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -484,7 +484,7 @@ void PassiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -503,7 +503,7 @@ void PassiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -522,7 +522,7 @@ void PassiveGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveGuardedProductsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveGuardedProductsTesterBase.ref.cpp
@@ -35,7 +35,7 @@ void PassiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_productRequestOut[%" PRI_PlatformIntType "]",
+      "%s_from_productRequestOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -59,7 +59,7 @@ void PassiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_productSendOut[%" PRI_PlatformIntType "]",
+      "%s_from_productSendOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -83,7 +83,7 @@ void PassiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_timeGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -107,7 +107,7 @@ void PassiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -131,7 +131,7 @@ void PassiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -155,7 +155,7 @@ void PassiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsStringReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsStringReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -179,7 +179,7 @@ void PassiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -203,7 +203,7 @@ void PassiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -227,7 +227,7 @@ void PassiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnStringOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnStringOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -251,7 +251,7 @@ void PassiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -275,7 +275,7 @@ void PassiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -294,7 +294,7 @@ void PassiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_productRecvIn[%" PRI_PlatformIntType "]",
+      "%s_to_productRecvIn[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -313,7 +313,7 @@ void PassiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -332,7 +332,7 @@ void PassiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -351,7 +351,7 @@ void PassiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -370,7 +370,7 @@ void PassiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -389,7 +389,7 @@ void PassiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -408,7 +408,7 @@ void PassiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -427,7 +427,7 @@ void PassiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -446,7 +446,7 @@ void PassiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -465,7 +465,7 @@ void PassiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -484,7 +484,7 @@ void PassiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -503,7 +503,7 @@ void PassiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -522,7 +522,7 @@ void PassiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -541,7 +541,7 @@ void PassiveGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsTesterBase.ref.cpp
@@ -35,7 +35,7 @@ void PassiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
+      "%s_from_cmdRegOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -59,7 +59,7 @@ void PassiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
+      "%s_from_cmdResponseOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -83,7 +83,7 @@ void PassiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_prmGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_prmGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -107,7 +107,7 @@ void PassiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_prmSetOut[%" PRI_PlatformIntType "]",
+      "%s_from_prmSetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -131,7 +131,7 @@ void PassiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_timeGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -155,7 +155,7 @@ void PassiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -179,7 +179,7 @@ void PassiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -203,7 +203,7 @@ void PassiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsStringReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsStringReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -227,7 +227,7 @@ void PassiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -251,7 +251,7 @@ void PassiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -275,7 +275,7 @@ void PassiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnStringOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnStringOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -299,7 +299,7 @@ void PassiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -323,7 +323,7 @@ void PassiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -342,7 +342,7 @@ void PassiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_cmdIn[%" PRI_PlatformIntType "]",
+      "%s_to_cmdIn[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -361,7 +361,7 @@ void PassiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -380,7 +380,7 @@ void PassiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -399,7 +399,7 @@ void PassiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -418,7 +418,7 @@ void PassiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -437,7 +437,7 @@ void PassiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -456,7 +456,7 @@ void PassiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -475,7 +475,7 @@ void PassiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -494,7 +494,7 @@ void PassiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -513,7 +513,7 @@ void PassiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -532,7 +532,7 @@ void PassiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -551,7 +551,7 @@ void PassiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -570,7 +570,7 @@ void PassiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -589,7 +589,7 @@ void PassiveParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.cpp
@@ -35,7 +35,7 @@ void PassiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
+      "%s_from_cmdRegOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -59,7 +59,7 @@ void PassiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
+      "%s_from_cmdResponseOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -83,7 +83,7 @@ void PassiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_eventOut[%" PRI_PlatformIntType "]",
+      "%s_from_eventOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -107,7 +107,7 @@ void PassiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_prmGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_prmGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -131,7 +131,7 @@ void PassiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_prmSetOut[%" PRI_PlatformIntType "]",
+      "%s_from_prmSetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -156,7 +156,7 @@ void PassiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_textEventOut[%" PRI_PlatformIntType "]",
+      "%s_from_textEventOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -181,7 +181,7 @@ void PassiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_timeGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -205,7 +205,7 @@ void PassiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_tlmOut[%" PRI_PlatformIntType "]",
+      "%s_from_tlmOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -229,7 +229,7 @@ void PassiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -253,7 +253,7 @@ void PassiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -277,7 +277,7 @@ void PassiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsStringReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsStringReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -301,7 +301,7 @@ void PassiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -325,7 +325,7 @@ void PassiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -349,7 +349,7 @@ void PassiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnStringOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnStringOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -373,7 +373,7 @@ void PassiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -397,7 +397,7 @@ void PassiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -421,7 +421,7 @@ void PassiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_serialOut[%" PRI_PlatformIntType "]",
+      "%s_from_serialOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -440,7 +440,7 @@ void PassiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_cmdIn[%" PRI_PlatformIntType "]",
+      "%s_to_cmdIn[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -459,7 +459,7 @@ void PassiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -478,7 +478,7 @@ void PassiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -497,7 +497,7 @@ void PassiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -516,7 +516,7 @@ void PassiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -535,7 +535,7 @@ void PassiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -554,7 +554,7 @@ void PassiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -573,7 +573,7 @@ void PassiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -592,7 +592,7 @@ void PassiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -611,7 +611,7 @@ void PassiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -630,7 +630,7 @@ void PassiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -649,7 +649,7 @@ void PassiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -668,7 +668,7 @@ void PassiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -687,7 +687,7 @@ void PassiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -706,7 +706,7 @@ void PassiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_serialGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_serialGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -725,7 +725,7 @@ void PassiveSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_serialSync[%" PRI_PlatformIntType "]",
+      "%s_to_serialSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSyncProductsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSyncProductsTesterBase.ref.cpp
@@ -35,7 +35,7 @@ void PassiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_productRequestOut[%" PRI_PlatformIntType "]",
+      "%s_from_productRequestOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -59,7 +59,7 @@ void PassiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_productSendOut[%" PRI_PlatformIntType "]",
+      "%s_from_productSendOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -83,7 +83,7 @@ void PassiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_timeGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -107,7 +107,7 @@ void PassiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -131,7 +131,7 @@ void PassiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -155,7 +155,7 @@ void PassiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsStringReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsStringReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -179,7 +179,7 @@ void PassiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -203,7 +203,7 @@ void PassiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -227,7 +227,7 @@ void PassiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnStringOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnStringOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -251,7 +251,7 @@ void PassiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -275,7 +275,7 @@ void PassiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -294,7 +294,7 @@ void PassiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_productRecvIn[%" PRI_PlatformIntType "]",
+      "%s_to_productRecvIn[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -313,7 +313,7 @@ void PassiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -332,7 +332,7 @@ void PassiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -351,7 +351,7 @@ void PassiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -370,7 +370,7 @@ void PassiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -389,7 +389,7 @@ void PassiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -408,7 +408,7 @@ void PassiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -427,7 +427,7 @@ void PassiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -446,7 +446,7 @@ void PassiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -465,7 +465,7 @@ void PassiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -484,7 +484,7 @@ void PassiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -503,7 +503,7 @@ void PassiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -522,7 +522,7 @@ void PassiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -541,7 +541,7 @@ void PassiveSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryTesterBase.ref.cpp
@@ -35,7 +35,7 @@ void PassiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_timeGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -59,7 +59,7 @@ void PassiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_tlmOut[%" PRI_PlatformIntType "]",
+      "%s_from_tlmOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -83,7 +83,7 @@ void PassiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -107,7 +107,7 @@ void PassiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -131,7 +131,7 @@ void PassiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsStringReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsStringReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -155,7 +155,7 @@ void PassiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -179,7 +179,7 @@ void PassiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -203,7 +203,7 @@ void PassiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnStringOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnStringOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -227,7 +227,7 @@ void PassiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -251,7 +251,7 @@ void PassiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -270,7 +270,7 @@ void PassiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -289,7 +289,7 @@ void PassiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -308,7 +308,7 @@ void PassiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -327,7 +327,7 @@ void PassiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -346,7 +346,7 @@ void PassiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -365,7 +365,7 @@ void PassiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -384,7 +384,7 @@ void PassiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -403,7 +403,7 @@ void PassiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -422,7 +422,7 @@ void PassiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -441,7 +441,7 @@ void PassiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -460,7 +460,7 @@ void PassiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -479,7 +479,7 @@ void PassiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -498,7 +498,7 @@ void PassiveTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.cpp
@@ -35,7 +35,7 @@ void PassiveTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
+      "%s_from_cmdRegOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -59,7 +59,7 @@ void PassiveTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
+      "%s_from_cmdResponseOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -83,7 +83,7 @@ void PassiveTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_eventOut[%" PRI_PlatformIntType "]",
+      "%s_from_eventOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -107,7 +107,7 @@ void PassiveTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_prmGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_prmGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -131,7 +131,7 @@ void PassiveTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_prmSetOut[%" PRI_PlatformIntType "]",
+      "%s_from_prmSetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -155,7 +155,7 @@ void PassiveTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_productRequestOut[%" PRI_PlatformIntType "]",
+      "%s_from_productRequestOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -179,7 +179,7 @@ void PassiveTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_productSendOut[%" PRI_PlatformIntType "]",
+      "%s_from_productSendOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -204,7 +204,7 @@ void PassiveTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_textEventOut[%" PRI_PlatformIntType "]",
+      "%s_from_textEventOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -229,7 +229,7 @@ void PassiveTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_timeGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -253,7 +253,7 @@ void PassiveTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_tlmOut[%" PRI_PlatformIntType "]",
+      "%s_from_tlmOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -277,7 +277,7 @@ void PassiveTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -301,7 +301,7 @@ void PassiveTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -325,7 +325,7 @@ void PassiveTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsStringReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsStringReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -349,7 +349,7 @@ void PassiveTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -373,7 +373,7 @@ void PassiveTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -397,7 +397,7 @@ void PassiveTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnStringOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnStringOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -421,7 +421,7 @@ void PassiveTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -445,7 +445,7 @@ void PassiveTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -464,7 +464,7 @@ void PassiveTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_cmdIn[%" PRI_PlatformIntType "]",
+      "%s_to_cmdIn[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -483,7 +483,7 @@ void PassiveTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_productRecvIn[%" PRI_PlatformIntType "]",
+      "%s_to_productRecvIn[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -502,7 +502,7 @@ void PassiveTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -521,7 +521,7 @@ void PassiveTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -540,7 +540,7 @@ void PassiveTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -559,7 +559,7 @@ void PassiveTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -578,7 +578,7 @@ void PassiveTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -597,7 +597,7 @@ void PassiveTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -616,7 +616,7 @@ void PassiveTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -635,7 +635,7 @@ void PassiveTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -654,7 +654,7 @@ void PassiveTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -673,7 +673,7 @@ void PassiveTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -692,7 +692,7 @@ void PassiveTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -711,7 +711,7 @@ void PassiveTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -730,7 +730,7 @@ void PassiveTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedAsyncProductsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedAsyncProductsTesterBase.ref.cpp
@@ -35,7 +35,7 @@ void QueuedAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_productRequestOut[%" PRI_PlatformIntType "]",
+      "%s_from_productRequestOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -59,7 +59,7 @@ void QueuedAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_productSendOut[%" PRI_PlatformIntType "]",
+      "%s_from_productSendOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -83,7 +83,7 @@ void QueuedAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_timeGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -107,7 +107,7 @@ void QueuedAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -131,7 +131,7 @@ void QueuedAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -155,7 +155,7 @@ void QueuedAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsStringReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsStringReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -179,7 +179,7 @@ void QueuedAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -203,7 +203,7 @@ void QueuedAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -227,7 +227,7 @@ void QueuedAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnStringOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnStringOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -251,7 +251,7 @@ void QueuedAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -275,7 +275,7 @@ void QueuedAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -294,7 +294,7 @@ void QueuedAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_productRecvIn[%" PRI_PlatformIntType "]",
+      "%s_to_productRecvIn[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -313,7 +313,7 @@ void QueuedAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_aliasTypedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_aliasTypedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -332,7 +332,7 @@ void QueuedAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -351,7 +351,7 @@ void QueuedAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -370,7 +370,7 @@ void QueuedAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -389,7 +389,7 @@ void QueuedAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -408,7 +408,7 @@ void QueuedAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -427,7 +427,7 @@ void QueuedAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -446,7 +446,7 @@ void QueuedAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -465,7 +465,7 @@ void QueuedAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -484,7 +484,7 @@ void QueuedAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -503,7 +503,7 @@ void QueuedAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -522,7 +522,7 @@ void QueuedAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -541,7 +541,7 @@ void QueuedAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncAssert[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -560,7 +560,7 @@ void QueuedAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncBlockPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -579,7 +579,7 @@ void QueuedAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncDropPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -598,7 +598,7 @@ void QueuedAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -617,7 +617,7 @@ void QueuedAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -636,7 +636,7 @@ void QueuedAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -655,7 +655,7 @@ void QueuedAsyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsTesterBase.ref.cpp
@@ -35,7 +35,7 @@ void QueuedCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
+      "%s_from_cmdRegOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -59,7 +59,7 @@ void QueuedCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
+      "%s_from_cmdResponseOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -83,7 +83,7 @@ void QueuedCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_timeGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -107,7 +107,7 @@ void QueuedCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -131,7 +131,7 @@ void QueuedCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -155,7 +155,7 @@ void QueuedCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsStringReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsStringReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -179,7 +179,7 @@ void QueuedCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -203,7 +203,7 @@ void QueuedCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -227,7 +227,7 @@ void QueuedCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnStringOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnStringOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -251,7 +251,7 @@ void QueuedCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -275,7 +275,7 @@ void QueuedCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -294,7 +294,7 @@ void QueuedCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_cmdIn[%" PRI_PlatformIntType "]",
+      "%s_to_cmdIn[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -313,7 +313,7 @@ void QueuedCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_aliasTypedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_aliasTypedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -332,7 +332,7 @@ void QueuedCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -351,7 +351,7 @@ void QueuedCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -370,7 +370,7 @@ void QueuedCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -389,7 +389,7 @@ void QueuedCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -408,7 +408,7 @@ void QueuedCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -427,7 +427,7 @@ void QueuedCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -446,7 +446,7 @@ void QueuedCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -465,7 +465,7 @@ void QueuedCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -484,7 +484,7 @@ void QueuedCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -503,7 +503,7 @@ void QueuedCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -522,7 +522,7 @@ void QueuedCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -541,7 +541,7 @@ void QueuedCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncAssert[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -560,7 +560,7 @@ void QueuedCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncBlockPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -579,7 +579,7 @@ void QueuedCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncDropPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -598,7 +598,7 @@ void QueuedCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -617,7 +617,7 @@ void QueuedCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -636,7 +636,7 @@ void QueuedCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -655,7 +655,7 @@ void QueuedCommandsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsTesterBase.ref.cpp
@@ -35,7 +35,7 @@ void QueuedEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_eventOut[%" PRI_PlatformIntType "]",
+      "%s_from_eventOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -60,7 +60,7 @@ void QueuedEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_textEventOut[%" PRI_PlatformIntType "]",
+      "%s_from_textEventOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -85,7 +85,7 @@ void QueuedEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_timeGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -109,7 +109,7 @@ void QueuedEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -133,7 +133,7 @@ void QueuedEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -157,7 +157,7 @@ void QueuedEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsStringReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsStringReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -181,7 +181,7 @@ void QueuedEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -205,7 +205,7 @@ void QueuedEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -229,7 +229,7 @@ void QueuedEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnStringOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnStringOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -253,7 +253,7 @@ void QueuedEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -277,7 +277,7 @@ void QueuedEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -296,7 +296,7 @@ void QueuedEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_aliasTypedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_aliasTypedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -315,7 +315,7 @@ void QueuedEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -334,7 +334,7 @@ void QueuedEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -353,7 +353,7 @@ void QueuedEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -372,7 +372,7 @@ void QueuedEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -391,7 +391,7 @@ void QueuedEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -410,7 +410,7 @@ void QueuedEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -429,7 +429,7 @@ void QueuedEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -448,7 +448,7 @@ void QueuedEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -467,7 +467,7 @@ void QueuedEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -486,7 +486,7 @@ void QueuedEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -505,7 +505,7 @@ void QueuedEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -524,7 +524,7 @@ void QueuedEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncAssert[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -543,7 +543,7 @@ void QueuedEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncBlockPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -562,7 +562,7 @@ void QueuedEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncDropPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -581,7 +581,7 @@ void QueuedEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -600,7 +600,7 @@ void QueuedEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -619,7 +619,7 @@ void QueuedEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -638,7 +638,7 @@ void QueuedEventsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedGetProductsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedGetProductsTesterBase.ref.cpp
@@ -35,7 +35,7 @@ void QueuedGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_productGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_productGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -59,7 +59,7 @@ void QueuedGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_productSendOut[%" PRI_PlatformIntType "]",
+      "%s_from_productSendOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -83,7 +83,7 @@ void QueuedGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_timeGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -107,7 +107,7 @@ void QueuedGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -131,7 +131,7 @@ void QueuedGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -155,7 +155,7 @@ void QueuedGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsStringReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsStringReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -179,7 +179,7 @@ void QueuedGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -203,7 +203,7 @@ void QueuedGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -227,7 +227,7 @@ void QueuedGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnStringOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnStringOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -251,7 +251,7 @@ void QueuedGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -275,7 +275,7 @@ void QueuedGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -294,7 +294,7 @@ void QueuedGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_aliasTypedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_aliasTypedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -313,7 +313,7 @@ void QueuedGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -332,7 +332,7 @@ void QueuedGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -351,7 +351,7 @@ void QueuedGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -370,7 +370,7 @@ void QueuedGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -389,7 +389,7 @@ void QueuedGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -408,7 +408,7 @@ void QueuedGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -427,7 +427,7 @@ void QueuedGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -446,7 +446,7 @@ void QueuedGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -465,7 +465,7 @@ void QueuedGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -484,7 +484,7 @@ void QueuedGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -503,7 +503,7 @@ void QueuedGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -522,7 +522,7 @@ void QueuedGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncAssert[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -541,7 +541,7 @@ void QueuedGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncBlockPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -560,7 +560,7 @@ void QueuedGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncDropPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -579,7 +579,7 @@ void QueuedGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -598,7 +598,7 @@ void QueuedGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -617,7 +617,7 @@ void QueuedGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -636,7 +636,7 @@ void QueuedGetProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedGuardedProductsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedGuardedProductsTesterBase.ref.cpp
@@ -35,7 +35,7 @@ void QueuedGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_productRequestOut[%" PRI_PlatformIntType "]",
+      "%s_from_productRequestOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -59,7 +59,7 @@ void QueuedGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_productSendOut[%" PRI_PlatformIntType "]",
+      "%s_from_productSendOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -83,7 +83,7 @@ void QueuedGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_timeGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -107,7 +107,7 @@ void QueuedGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -131,7 +131,7 @@ void QueuedGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -155,7 +155,7 @@ void QueuedGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsStringReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsStringReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -179,7 +179,7 @@ void QueuedGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -203,7 +203,7 @@ void QueuedGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -227,7 +227,7 @@ void QueuedGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnStringOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnStringOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -251,7 +251,7 @@ void QueuedGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -275,7 +275,7 @@ void QueuedGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -294,7 +294,7 @@ void QueuedGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_productRecvIn[%" PRI_PlatformIntType "]",
+      "%s_to_productRecvIn[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -313,7 +313,7 @@ void QueuedGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_aliasTypedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_aliasTypedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -332,7 +332,7 @@ void QueuedGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -351,7 +351,7 @@ void QueuedGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -370,7 +370,7 @@ void QueuedGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -389,7 +389,7 @@ void QueuedGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -408,7 +408,7 @@ void QueuedGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -427,7 +427,7 @@ void QueuedGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -446,7 +446,7 @@ void QueuedGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -465,7 +465,7 @@ void QueuedGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -484,7 +484,7 @@ void QueuedGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -503,7 +503,7 @@ void QueuedGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -522,7 +522,7 @@ void QueuedGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -541,7 +541,7 @@ void QueuedGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncAssert[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -560,7 +560,7 @@ void QueuedGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncBlockPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -579,7 +579,7 @@ void QueuedGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncDropPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -598,7 +598,7 @@ void QueuedGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -617,7 +617,7 @@ void QueuedGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -636,7 +636,7 @@ void QueuedGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -655,7 +655,7 @@ void QueuedGuardedProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedNoArgsPortsOnlyTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedNoArgsPortsOnlyTesterBase.ref.cpp
@@ -35,7 +35,7 @@ void QueuedNoArgsPortsOnlyTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -59,7 +59,7 @@ void QueuedNoArgsPortsOnlyTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -78,7 +78,7 @@ void QueuedNoArgsPortsOnlyTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -97,7 +97,7 @@ void QueuedNoArgsPortsOnlyTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -116,7 +116,7 @@ void QueuedNoArgsPortsOnlyTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -135,7 +135,7 @@ void QueuedNoArgsPortsOnlyTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsTesterBase.ref.cpp
@@ -35,7 +35,7 @@ void QueuedParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
+      "%s_from_cmdRegOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -59,7 +59,7 @@ void QueuedParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
+      "%s_from_cmdResponseOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -83,7 +83,7 @@ void QueuedParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_prmGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_prmGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -107,7 +107,7 @@ void QueuedParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_prmSetOut[%" PRI_PlatformIntType "]",
+      "%s_from_prmSetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -131,7 +131,7 @@ void QueuedParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_timeGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -155,7 +155,7 @@ void QueuedParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -179,7 +179,7 @@ void QueuedParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -203,7 +203,7 @@ void QueuedParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsStringReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsStringReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -227,7 +227,7 @@ void QueuedParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -251,7 +251,7 @@ void QueuedParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -275,7 +275,7 @@ void QueuedParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnStringOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnStringOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -299,7 +299,7 @@ void QueuedParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -323,7 +323,7 @@ void QueuedParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -342,7 +342,7 @@ void QueuedParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_cmdIn[%" PRI_PlatformIntType "]",
+      "%s_to_cmdIn[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -361,7 +361,7 @@ void QueuedParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_aliasTypedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_aliasTypedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -380,7 +380,7 @@ void QueuedParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -399,7 +399,7 @@ void QueuedParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -418,7 +418,7 @@ void QueuedParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -437,7 +437,7 @@ void QueuedParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -456,7 +456,7 @@ void QueuedParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -475,7 +475,7 @@ void QueuedParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -494,7 +494,7 @@ void QueuedParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -513,7 +513,7 @@ void QueuedParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -532,7 +532,7 @@ void QueuedParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -551,7 +551,7 @@ void QueuedParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -570,7 +570,7 @@ void QueuedParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -589,7 +589,7 @@ void QueuedParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncAssert[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -608,7 +608,7 @@ void QueuedParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncBlockPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -627,7 +627,7 @@ void QueuedParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncDropPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -646,7 +646,7 @@ void QueuedParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -665,7 +665,7 @@ void QueuedParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -684,7 +684,7 @@ void QueuedParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -703,7 +703,7 @@ void QueuedParamsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.cpp
@@ -35,7 +35,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
+      "%s_from_cmdRegOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -59,7 +59,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
+      "%s_from_cmdResponseOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -83,7 +83,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_eventOut[%" PRI_PlatformIntType "]",
+      "%s_from_eventOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -107,7 +107,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_prmGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_prmGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -131,7 +131,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_prmSetOut[%" PRI_PlatformIntType "]",
+      "%s_from_prmSetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -156,7 +156,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_textEventOut[%" PRI_PlatformIntType "]",
+      "%s_from_textEventOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -181,7 +181,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_timeGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -205,7 +205,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_tlmOut[%" PRI_PlatformIntType "]",
+      "%s_from_tlmOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -229,7 +229,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -253,7 +253,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -277,7 +277,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsStringReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsStringReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -301,7 +301,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -325,7 +325,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -349,7 +349,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnStringOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnStringOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -373,7 +373,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -397,7 +397,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -421,7 +421,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_serialOut[%" PRI_PlatformIntType "]",
+      "%s_from_serialOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -440,7 +440,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_cmdIn[%" PRI_PlatformIntType "]",
+      "%s_to_cmdIn[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -459,7 +459,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_aliasTypedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_aliasTypedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -478,7 +478,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -497,7 +497,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -516,7 +516,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -535,7 +535,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -554,7 +554,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -573,7 +573,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -592,7 +592,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -611,7 +611,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -630,7 +630,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -649,7 +649,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -668,7 +668,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -687,7 +687,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncAssert[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -706,7 +706,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncBlockPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -725,7 +725,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncDropPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -744,7 +744,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -763,7 +763,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -782,7 +782,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -801,7 +801,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -820,7 +820,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_serialAsync[%" PRI_PlatformIntType "]",
+      "%s_to_serialAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -839,7 +839,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_serialAsyncAssert[%" PRI_PlatformIntType "]",
+      "%s_to_serialAsyncAssert[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -858,7 +858,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_serialAsyncBlockPriority[%" PRI_PlatformIntType "]",
+      "%s_to_serialAsyncBlockPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -877,7 +877,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_serialAsyncDropPriority[%" PRI_PlatformIntType "]",
+      "%s_to_serialAsyncDropPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -896,7 +896,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_serialGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_serialGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -915,7 +915,7 @@ void QueuedSerialTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_serialSync[%" PRI_PlatformIntType "]",
+      "%s_to_serialSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSyncProductsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSyncProductsTesterBase.ref.cpp
@@ -35,7 +35,7 @@ void QueuedSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_productRequestOut[%" PRI_PlatformIntType "]",
+      "%s_from_productRequestOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -59,7 +59,7 @@ void QueuedSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_productSendOut[%" PRI_PlatformIntType "]",
+      "%s_from_productSendOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -83,7 +83,7 @@ void QueuedSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_timeGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -107,7 +107,7 @@ void QueuedSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -131,7 +131,7 @@ void QueuedSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -155,7 +155,7 @@ void QueuedSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsStringReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsStringReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -179,7 +179,7 @@ void QueuedSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -203,7 +203,7 @@ void QueuedSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -227,7 +227,7 @@ void QueuedSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnStringOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnStringOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -251,7 +251,7 @@ void QueuedSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -275,7 +275,7 @@ void QueuedSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -294,7 +294,7 @@ void QueuedSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_productRecvIn[%" PRI_PlatformIntType "]",
+      "%s_to_productRecvIn[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -313,7 +313,7 @@ void QueuedSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_aliasTypedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_aliasTypedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -332,7 +332,7 @@ void QueuedSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -351,7 +351,7 @@ void QueuedSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -370,7 +370,7 @@ void QueuedSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -389,7 +389,7 @@ void QueuedSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -408,7 +408,7 @@ void QueuedSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -427,7 +427,7 @@ void QueuedSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -446,7 +446,7 @@ void QueuedSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -465,7 +465,7 @@ void QueuedSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -484,7 +484,7 @@ void QueuedSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -503,7 +503,7 @@ void QueuedSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -522,7 +522,7 @@ void QueuedSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -541,7 +541,7 @@ void QueuedSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncAssert[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -560,7 +560,7 @@ void QueuedSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncBlockPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -579,7 +579,7 @@ void QueuedSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncDropPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -598,7 +598,7 @@ void QueuedSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -617,7 +617,7 @@ void QueuedSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -636,7 +636,7 @@ void QueuedSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -655,7 +655,7 @@ void QueuedSyncProductsTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryTesterBase.ref.cpp
@@ -35,7 +35,7 @@ void QueuedTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_timeGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -59,7 +59,7 @@ void QueuedTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_tlmOut[%" PRI_PlatformIntType "]",
+      "%s_from_tlmOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -83,7 +83,7 @@ void QueuedTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -107,7 +107,7 @@ void QueuedTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -131,7 +131,7 @@ void QueuedTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsStringReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsStringReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -155,7 +155,7 @@ void QueuedTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -179,7 +179,7 @@ void QueuedTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -203,7 +203,7 @@ void QueuedTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnStringOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnStringOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -227,7 +227,7 @@ void QueuedTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -251,7 +251,7 @@ void QueuedTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -270,7 +270,7 @@ void QueuedTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_aliasTypedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_aliasTypedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -289,7 +289,7 @@ void QueuedTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -308,7 +308,7 @@ void QueuedTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -327,7 +327,7 @@ void QueuedTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -346,7 +346,7 @@ void QueuedTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -365,7 +365,7 @@ void QueuedTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -384,7 +384,7 @@ void QueuedTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -403,7 +403,7 @@ void QueuedTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -422,7 +422,7 @@ void QueuedTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -441,7 +441,7 @@ void QueuedTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -460,7 +460,7 @@ void QueuedTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -479,7 +479,7 @@ void QueuedTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -498,7 +498,7 @@ void QueuedTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncAssert[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -517,7 +517,7 @@ void QueuedTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncBlockPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -536,7 +536,7 @@ void QueuedTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncDropPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -555,7 +555,7 @@ void QueuedTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -574,7 +574,7 @@ void QueuedTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -593,7 +593,7 @@ void QueuedTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -612,7 +612,7 @@ void QueuedTelemetryTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.cpp
@@ -35,7 +35,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
+      "%s_from_cmdRegOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -59,7 +59,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
+      "%s_from_cmdResponseOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -83,7 +83,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_eventOut[%" PRI_PlatformIntType "]",
+      "%s_from_eventOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -107,7 +107,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_prmGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_prmGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -131,7 +131,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_prmSetOut[%" PRI_PlatformIntType "]",
+      "%s_from_prmSetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -155,7 +155,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_productRequestOut[%" PRI_PlatformIntType "]",
+      "%s_from_productRequestOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -179,7 +179,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_productSendOut[%" PRI_PlatformIntType "]",
+      "%s_from_productSendOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -204,7 +204,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_textEventOut[%" PRI_PlatformIntType "]",
+      "%s_from_textEventOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -229,7 +229,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
+      "%s_from_timeGetOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -253,7 +253,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_tlmOut[%" PRI_PlatformIntType "]",
+      "%s_from_tlmOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -277,7 +277,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -301,7 +301,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -325,7 +325,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_noArgsStringReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_noArgsStringReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -349,7 +349,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -373,7 +373,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -397,7 +397,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedAliasReturnStringOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedAliasReturnStringOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -421,7 +421,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -445,7 +445,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
+      "%s_from_typedReturnOut[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -464,7 +464,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_cmdIn[%" PRI_PlatformIntType "]",
+      "%s_to_cmdIn[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -483,7 +483,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_productRecvIn[%" PRI_PlatformIntType "]",
+      "%s_to_productRecvIn[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -502,7 +502,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_aliasTypedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_aliasTypedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -521,7 +521,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -540,7 +540,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -559,7 +559,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -578,7 +578,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -597,7 +597,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -616,7 +616,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -635,7 +635,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
+      "%s_to_noArgsSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -654,7 +654,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -673,7 +673,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -692,7 +692,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAliasStringReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAliasStringReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -711,7 +711,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsync[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -730,7 +730,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncAssert[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -749,7 +749,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncBlockPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -768,7 +768,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
+      "%s_to_typedAsyncDropPriority[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -787,7 +787,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -806,7 +806,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnGuarded[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -825,7 +825,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedReturnSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );
@@ -844,7 +844,7 @@ void QueuedTestTesterBase ::
 #if FW_OBJECT_NAMES == 1
     Fw::ObjectName portName;
     portName.format(
-      "%s_to_typedSync[%" PRI_PlatformIntType "]",
+      "%s_to_typedSync[%" PRI_FwIndexType "]",
       this->m_objName.toChar(),
       port
     );


### PR DESCRIPTION
Port name formatting code was using `PRI_PlatformIntType` instead of the new port index type formatter `PRI_FwIndexType`.  This change fixes that slight issue.

 