### PR TITLE
Fix omission in spec for type aliases

### DIFF
--- a/docs/fpp-spec.html
+++ b/docs/fpp-spec.html
@@ -1854,6 +1854,9 @@ identifier values.</p>
 <p>An <a href="#Definitions_Abstract-Type-Definitions">abstract type definition</a></p>
 </li>
 <li>
+<p>An <a href="#Definitions_Alias-Type-Definitions">alias type definition</a></p>
+</li>
+<li>
 <p>An <a href="#Definitions_Array-Definitions">array definition</a></p>
 </li>
 <li>
@@ -2722,6 +2725,9 @@ A module member is one of the following:</p>
 <p>A <a href="#Definitions_Port-Definitions">port definition</a></p>
 </li>
 <li>
+<p>A <a href="#Definitions_State-Machine-Definitions">state machine definition</a></p>
+</li>
+<li>
 <p>A <a href="#Definitions_Struct-Definitions">struct definition</a></p>
 </li>
 <li>
@@ -2734,6 +2740,9 @@ A module member is one of the following:</p>
 <p>An <a href="#Definitions_Abstract-Type-Definitions">abstract type definition</a></p>
 </li>
 <li>
+<p>An <a href="#Definitions_Alias-Type-Definitions">alias type definition</a></p>
+</li>
+<li>
 <p>An <a href="#Definitions_Array-Definitions">array definition</a></p>
 </li>
 <li>
@@ -2741,9 +2750,6 @@ A module member is one of the following:</p>
 </li>
 <li>
 <p>An <a href="#Specifiers_Include-Specifiers">include specifier</a></p>
-</li>
-<li>
-<p>A <a href="#Definitions_State-Machine-Definitions">state machine definition</a></p>
 </li>
 </ul>
 </div>
@@ -11153,7 +11159,7 @@ equivalent.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2025-02-20 10:06:58 -0800
+Last updated 2025-04-03 17:17:43 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-users-guide.html
+++ b/docs/fpp-users-guide.html
@@ -15041,7 +15041,7 @@ serialized according to its
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2025-03-05 15:45:55 -0800
+Last updated 2025-04-03 17:17:44 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/spec/Definitions/Component-Definitions.adoc
+++ b/docs/spec/Definitions/Component-Definitions.adoc
@@ -57,6 +57,8 @@ identifier values.
 
 * An <<Definitions_Abstract-Type-Definitions,abstract type definition>>
 
+* An <<Definitions_Alias-Type-Definitions,alias type definition>>
+
 * An <<Definitions_Array-Definitions,array definition>>
 
 * An <<Definitions_Enum-Definitions,enum definition>>
@@ -68,6 +70,7 @@ values.
 * An <<Specifiers_Include-Specifiers,include specifier>>
 
 * An <<Specifiers_Internal-Port-Specifiers,internal port specifier>>
+
 
 The command, event, parameter, telemetry, record, and container
 specifiers are collectively referred to as *dictionary specifiers*.

--- a/docs/spec/Definitions/Component-Definitions.adoc
+++ b/docs/spec/Definitions/Component-Definitions.adoc
@@ -71,7 +71,6 @@ values.
 
 * An <<Specifiers_Internal-Port-Specifiers,internal port specifier>>
 
-
 The command, event, parameter, telemetry, record, and container
 specifiers are collectively referred to as *dictionary specifiers*.
 The record and container specifiers are collectively referred to

--- a/docs/spec/Definitions/Module-Definitions.adoc
+++ b/docs/spec/Definitions/Module-Definitions.adoc
@@ -26,6 +26,8 @@ A module member is one of the following:
 
 * A <<Definitions_Port-Definitions,port definition>>
 
+* A <<Definitions_State-Machine-Definitions,state machine definition>>
+
 * A <<Definitions_Struct-Definitions,struct definition>>
 
 * A <<Definitions_Topology-Definitions,topology definition>>
@@ -34,13 +36,13 @@ A module member is one of the following:
 
 * An <<Definitions_Abstract-Type-Definitions,abstract type definition>>
 
+* An <<Definitions_Alias-Type-Definitions,alias type definition>>
+
 * An <<Definitions_Array-Definitions,array definition>>
 
 * An <<Definitions_Enum-Definitions,enum definition>>
 
 * An <<Specifiers_Include-Specifiers,include specifier>>
-
-* A <<Definitions_State-Machine-Definitions,state machine definition>>
 
 ==== Semantics
 


### PR DESCRIPTION
We forgot to specify that alias type definitions are module members and component members.