### PR TITLE
Fix bug in code gen for C++ constant defs

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/AutocodeCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/AutocodeCppWriter.scala
@@ -7,6 +7,13 @@ import fpp.compiler.util._
 /** Writes out C++ for F Prime autocode */
 object AutocodeCppWriter extends CppWriter {
 
+  override def tuList(s: State, tul: List[Ast.TransUnit]): Result.Result[Unit] =
+    for {
+      _ <- ConstantCppWriter.write(s, tul)
+      _ <- super.tuList(s, tul)
+    }
+    yield ()
+
   override def defAliasTypeAnnotatedNode(
     s: State,
     aNode: Ast.Annotated[AstNode[Ast.DefAliasType]]

--- a/compiler/lib/src/main/scala/codegen/CppWriter/CppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/CppWriter.scala
@@ -13,11 +13,8 @@ trait CppWriter extends AstStateVisitor with LineUtils {
     visitList(s, tu.members, matchTuMember)
 
   def tuList(s: State, tul: List[Ast.TransUnit]): Result.Result[Unit] =
-    for {
-      _ <- ConstantCppWriter.write(s, tul)
-      _ <- visitList(s, tul, transUnit)
-    }
-    yield ()
+    for (_ <- visitList(s, tul, transUnit)) yield ()
+
 }
 
 object CppWriter extends LineUtils{


### PR DESCRIPTION
Unit test and implementation generators were generating constant defs. Only the autocode generator should do that.