### PR TITLE
Fixed assert in from_prmSetOut_static

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentTesterBaseWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentTesterBaseWriter.scala
@@ -1381,8 +1381,7 @@ case class ComponentTesterBaseWriter(
       lines(s"$testerBaseDecl\n"),
       guardedList (hasParameters) (lines("Fw::SerializeStatus _status;")),
       lines(
-        s"""|$value.resetSer();
-            |
+        s"""|
             |const U32 idBase = _testerBase->getIdBase();
             |FW_ASSERT(
             |  $id >= idBase,

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsTesterBase.ref.cpp
@@ -3094,7 +3094,6 @@ void ActiveParamsTesterBase ::
 {
   ActiveParamsTesterBase* _testerBase = static_cast<ActiveParamsTesterBase*>(callComp);
   Fw::SerializeStatus _status;
-  val.resetSer();
 
   const U32 idBase = _testerBase->getIdBase();
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.cpp
@@ -5126,7 +5126,6 @@ void ActiveSerialTesterBase ::
 {
   ActiveSerialTesterBase* _testerBase = static_cast<ActiveSerialTesterBase*>(callComp);
   Fw::SerializeStatus _status;
-  val.resetSer();
 
   const U32 idBase = _testerBase->getIdBase();
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.cpp
@@ -4856,7 +4856,6 @@ namespace M {
   {
     ActiveTestTesterBase* _testerBase = static_cast<ActiveTestTesterBase*>(callComp);
     Fw::SerializeStatus _status;
-    val.resetSer();
 
     const U32 idBase = _testerBase->getIdBase();
     FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsTesterBase.ref.cpp
@@ -2617,7 +2617,6 @@ void PassiveParamsTesterBase ::
 {
   PassiveParamsTesterBase* _testerBase = static_cast<PassiveParamsTesterBase*>(callComp);
   Fw::SerializeStatus _status;
-  val.resetSer();
 
   const U32 idBase = _testerBase->getIdBase();
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.cpp
@@ -4242,7 +4242,6 @@ void PassiveSerialTesterBase ::
 {
   PassiveSerialTesterBase* _testerBase = static_cast<PassiveSerialTesterBase*>(callComp);
   Fw::SerializeStatus _status;
-  val.resetSer();
 
   const U32 idBase = _testerBase->getIdBase();
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.cpp
@@ -4234,7 +4234,6 @@ void PassiveTestTesterBase ::
 {
   PassiveTestTesterBase* _testerBase = static_cast<PassiveTestTesterBase*>(callComp);
   Fw::SerializeStatus _status;
-  val.resetSer();
 
   const U32 idBase = _testerBase->getIdBase();
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsTesterBase.ref.cpp
@@ -3068,7 +3068,6 @@ void QueuedParamsTesterBase ::
 {
   QueuedParamsTesterBase* _testerBase = static_cast<QueuedParamsTesterBase*>(callComp);
   Fw::SerializeStatus _status;
-  val.resetSer();
 
   const U32 idBase = _testerBase->getIdBase();
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.cpp
@@ -5100,7 +5100,6 @@ void QueuedSerialTesterBase ::
 {
   QueuedSerialTesterBase* _testerBase = static_cast<QueuedSerialTesterBase*>(callComp);
   Fw::SerializeStatus _status;
-  val.resetSer();
 
   const U32 idBase = _testerBase->getIdBase();
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.cpp
@@ -4828,7 +4828,6 @@ void QueuedTestTesterBase ::
 {
   QueuedTestTesterBase* _testerBase = static_cast<QueuedTestTesterBase*>(callComp);
   Fw::SerializeStatus _status;
-  val.resetSer();
 
   const U32 idBase = _testerBase->getIdBase();
   FW_ASSERT(


### PR DESCRIPTION
There is a serial buffer being reset in the ${component}TesterBase, specifically in the `from_prmSetOut_static()` function. After the serial buffer is reset, it is deserialized. The buffer being reset causes the deserialize function to return `FW_DESERIALIZE_BUFFER_EMPTY` which trips an assert.

The solution is to remove the serial buffer reset.