### PR TITLE
Fast lexer

### DIFF
--- a/compiler/lib/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/compiler/lib/src/main/resources/META-INF/native-image/reflect-config.json
@@ -3762,14 +3762,6 @@
   "fields":[{"name":"0bitmap$1"}]
 },
 {
-  "name":"fpp.compiler.syntax.Lexer$",
-  "fields":[{"name":"0bitmap$2"}]
-},
-{
-  "name":"fpp.compiler.syntax.Lexer$$anon$1",
-  "fields":[{"name":"0bitmap$1"}]
-},
-{
   "name":"fpp.compiler.syntax.Parser$",
   "fields":[{"name":"0bitmap$1"}]
 },

--- a/compiler/lib/src/main/scala/analysis/Analysis.scala
+++ b/compiler/lib/src/main/scala/analysis/Analysis.scala
@@ -261,7 +261,7 @@ case class Analysis(
     val Value.Integer(v) = Analysis.convertValueToType(
       valueMap(id),
       Type.Integer
-    )
+    ): @unchecked
     v
   }
 

--- a/compiler/lib/src/main/scala/analysis/CheckSemantics/EvalConstantExprs.scala
+++ b/compiler/lib/src/main/scala/analysis/CheckSemantics/EvalConstantExprs.scala
@@ -115,10 +115,13 @@ object EvalConstantExprs extends UseAnalyzer {
   }
 
   override def exprLiteralIntNode(a: Analysis, node: AstNode[Ast.Expr], e: Ast.ExprLiteralInt) = {
-    val bigInt = if (e.value.startsWith("0x") || e.value.startsWith("0X"))
-      BigInt(e.value.substring(2, e.value.length), 16) else BigInt(e.value)
-    val v = Value.Integer(bigInt)
-    Right(a.assignValue(node -> v))
+    val bigInt = if e.value.length > 2 then e.value.substring(0, 2) match {
+      case "0x" | "0X" => BigInt(e.value.substring(2, e.value.length), 16)
+      case "0b" | "0B" => BigInt(e.value.substring(2, e.value.length), 2)
+      case _ => BigInt(e.value)
+    } else BigInt(e.value)
+
+    Right(a.assignValue(node -> Value.Integer(bigInt)))
   }
   
   override def exprLiteralStringNode(a: Analysis, node: AstNode[Ast.Expr], e: Ast.ExprLiteralString) = {

--- a/compiler/lib/src/main/scala/analysis/Semantics/ConstructDictionary/DictionaryEntries.scala
+++ b/compiler/lib/src/main/scala/analysis/Semantics/ConstructDictionary/DictionaryEntries.scala
@@ -45,7 +45,7 @@ final case class DictionaryEntries(a: Analysis, t: Topology) {
       val m = getSpecMap(ci.component)
       m.foldLeft(entryMap) (addEntry(constructEntry, ci))
     }
-    t.instanceMap.keys.foldLeft (Map[BigInt, Entry]()) (addEntriesForInstance),
+    t.instanceMap.keys.foldLeft (Map[BigInt, Entry]()) (addEntriesForInstance)
   }
 
   private def addEntry[Specifier, Entry](

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriter.scala
@@ -546,7 +546,7 @@ case class ComponentCppWriter (
                 case (StateMachine.Kind.Internal, true) => "*this"
                 case (StateMachine.Kind.Internal, false) => ""
               }
-              s"m_stateMachine_$name($args)",
+              s"m_stateMachine_$name($args)"
             }),
           intersperseBlankLines(
             List(

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentTesterBaseWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentTesterBaseWriter.scala
@@ -1297,7 +1297,7 @@ case class ComponentTesterBaseWriter(
             {
               val constantName = paramCommandConstantName(prm.getName, Command.Param.Save)
               val varName = testerPortVariableName(cmdRecvPort.get)
-            lines(
+              lines(
               s"""|Fw::CmdArgBuffer args;
                   |const U32 idBase = this->getIdBase();
                   |FwOpcodeType _prmOpcode = $className::$constantName + idBase;

--- a/compiler/lib/src/main/scala/codegen/CppWriter/TlmPacketSetCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/TlmPacketSetCppWriter.scala
@@ -225,8 +225,8 @@ case class TlmPacketSetCppWriter(
     lines(
       s"""|
           |// The size of the array of omitted channels
-          |constexpr FwIndexType omittedArraySize = $size;""",
-    ),
+          |constexpr FwIndexType omittedArraySize = $size;"""
+    )
   }
 
   private def writeOmittedChannels: List[Line] = {

--- a/compiler/lib/src/main/scala/syntax/CharArrayReader.scala
+++ b/compiler/lib/src/main/scala/syntax/CharArrayReader.scala
@@ -1,0 +1,133 @@
+package fpp.compiler.syntax
+
+import scala.compiletime.uninitialized
+import fpp.compiler.util.Chars._
+
+abstract class CharArrayReader { self =>
+
+  val buf: Array[Char]
+  private def startFrom: Int = 0
+
+  /** Switch whether unicode should be decoded */
+  protected def decodeUni: Boolean = false
+
+  /** An error routine to call on bad unicode escapes \\uxxxx. */
+  protected def error(msg: String): Unit
+
+  /** the last read character */
+  var ch: Char = uninitialized
+
+  /** The offset one past the last read character */
+  var charOffset: Int = startFrom
+
+  /** The offset before the last read character */
+  var lastCharOffset: Int = startFrom
+
+  /** The start offset of the current line */
+  var lineStartOffset: Int = startFrom
+
+  /** Keep track of the current line number to generate `Position` */
+  var lineNo = 0
+
+  private var lastUnicodeOffset = -1
+
+  /** Is last character a unicode escape \\uxxxx? */
+  def isUnicodeEscape: Boolean = charOffset == lastUnicodeOffset
+
+  /** Advance one character; reducing CR;LF pairs to just LF */
+  final def nextChar(): Unit = {
+    val idx = charOffset
+    lastCharOffset = idx
+    charOffset = idx + 1
+    if (idx >= buf.length)
+      ch = SU
+    else {
+      val c = buf(idx)
+      ch = c
+      if (c == '\\') potentialUnicode()
+      else if (c < ' ') { skipCR(); potentialLineEnd() }
+    }
+  }
+
+  def getc(): Char = { nextChar() ; ch }
+
+  /** Advance one character, leaving CR;LF pairs intact.
+   *  This is for use in multi-line strings, so there are no
+   *  "potential line ends" here.
+   */
+  final def nextRawChar(): Unit = {
+    val idx = charOffset
+    lastCharOffset = idx
+    charOffset = idx + 1
+    if (idx >= buf.length)
+      ch = SU
+    else {
+      val c = buf(idx)
+      ch = c
+      if (c == '\\') potentialUnicode()
+    }
+  }
+
+  /** Interpret \\uxxxx escapes */
+  private def potentialUnicode(): Unit = {
+    def evenSlashPrefix: Boolean = {
+      var p = charOffset - 2
+      while (p >= 0 && buf(p) == '\\') p -= 1
+      (charOffset - p) % 2 == 0
+    }
+    def udigit: Int =
+      if (charOffset >= buf.length) {
+        // Since the positioning code is very insistent about throwing exceptions,
+        // we have to decrement the position so our error message can be seen, since
+        // we are one past EOF.  This happens with e.g. val x = \ u 1 <EOF>
+        error("incomplete unicode escape")
+        SU
+      }
+      else {
+        val d = digit2int(buf(charOffset), 16)
+        if (d >= 0) charOffset += 1
+        else error("error in unicode escape")
+        d
+      }
+    if (charOffset < buf.length && buf(charOffset) == 'u' && decodeUni && evenSlashPrefix) {
+      while ({
+        charOffset += 1
+        charOffset < buf.length && buf(charOffset) == 'u'
+      })
+      ()
+      val code = udigit << 12 | udigit << 8 | udigit << 4 | udigit
+      lastUnicodeOffset = charOffset
+      ch = code.toChar
+    }
+  }
+
+  /** replace CR;LF by LF */
+  private def skipCR(): Unit =
+    if (ch == CR)
+      if (charOffset < buf.length && buf(charOffset) == LF) {
+        charOffset += 1
+        ch = LF
+      }
+
+  /** Handle line ends */
+  private def potentialLineEnd(): Unit =
+    if (ch == LF || ch == FF) {
+      lineStartOffset = charOffset
+      lineNo += 1
+    }
+
+  def isAtEnd: Boolean = charOffset >= buf.length
+
+  /** A new reader that takes off at the current character position */
+  def lookaheadReader(): CharArrayLookaheadReader = new CharArrayLookaheadReader
+
+  def lookaheadChar(): Char = lookaheadReader().getc()
+
+  class CharArrayLookaheadReader extends CharArrayReader {
+    val buf: Array[Char] = self.buf
+    charOffset = self.charOffset
+    ch = self.ch
+    override def decodeUni: Boolean = self.decodeUni
+    def error(msg: String): Unit = self.error(msg)
+  }
+}

--- a/compiler/lib/src/main/scala/syntax/Context.scala
+++ b/compiler/lib/src/main/scala/syntax/Context.scala
@@ -1,0 +1,25 @@
+package fpp.compiler.syntax
+
+import fpp.compiler.util.Error
+import fpp.compiler.util.Result
+import fpp.compiler.util.SemanticError.MultiError
+
+class Context {
+  private var errors: List[Error] = List()
+
+  /** Report an error has  */
+  def report(err: Error) = {
+    errors = errors :+ err
+  }
+
+  def hasErrors: Boolean = errors.nonEmpty
+
+  def print(): Unit = {
+    errors.foreach(_.print)
+  }
+
+  def result(): Result.Result[Int] = {
+    if hasErrors then Left(MultiError(errors))
+    else Right(0)
+  }
+}

--- a/compiler/lib/src/main/scala/syntax/Lexer.scala
+++ b/compiler/lib/src/main/scala/syntax/Lexer.scala
@@ -1,116 +1,565 @@
 package fpp.compiler.syntax
 
-import fpp.compiler.util._
-import scala.util.parsing.combinator.RegexParsers
-import scala.util.parsing.input.Positional
-import scala.util.parsing.input.Position
+import fpp.compiler.util.{File, Location, Result, CharBuffer}
+import fpp.compiler.util.Chars.*
 
-object Lexer extends RegexParsers {
+import scala.collection.mutable
+import scala.annotation.switch
+import scala.annotation.tailrec
+import scala.collection.immutable.HashMap
+import fpp.compiler.syntax.TokenId
+import fpp.compiler.syntax.TokenId.*
+import fpp.compiler.util.SemanticError.InvalidToken
 
-  def eol: Parser[Token] = {
-    newlines ^^ { _ => Token.EOL() }
+import scala.util.parsing.input.{Position, Reader}
+
+object Lexer {
+
+  private val keywords: Map[String, TokenId] = Map(
+    ("F32", F32),
+    ("F64", F64),
+    ("I16", I16),
+    ("I32", I32),
+    ("I64", I64),
+    ("I8", I8),
+    ("U16", U16),
+    ("U32", U32),
+    ("U64", U64),
+    ("U8", U8),
+    ("action", ACTION),
+    ("active", ACTIVE),
+    ("activity", ACTIVITY),
+    ("always", ALWAYS),
+    ("array", ARRAY),
+    ("assert", ASSERT),
+    ("async", ASYNC),
+    ("at", AT),
+    ("base", BASE),
+    ("block", BLOCK),
+    ("bool", BOOL),
+    ("change", CHANGE),
+    ("choice", CHOICE),
+    ("command", COMMAND),
+    ("component", COMPONENT),
+    ("connections", CONNECTIONS),
+    ("constant", CONSTANT),
+    ("container", CONTAINER),
+    ("cpu", CPU),
+    ("default", DEFAULT),
+    ("diagnostic", DIAGNOSTIC),
+    ("do", DO),
+    ("drop", DROP),
+    ("else", ELSE),
+    ("enter", ENTER),
+    ("entry", ENTRY),
+    ("enum", ENUM),
+    ("event", EVENT),
+    ("exit", EXIT),
+    ("false", FALSE),
+    ("fatal", FATAL),
+    ("format", FORMAT),
+    ("get", GET),
+    ("group", GROUP),
+    ("guard", GUARD),
+    ("guarded", GUARDED),
+    ("health", HEALTH),
+    ("high", HIGH),
+    ("hook", HOOK),
+    ("id", ID),
+    ("if", IF),
+    ("import", IMPORT),
+    ("include", INCLUDE),
+    ("initial", INITIAL),
+    ("input", INPUT),
+    ("instance", INSTANCE),
+    ("internal", INTERNAL),
+    ("locate", LOCATE),
+    ("low", LOW),
+    ("machine", MACHINE),
+    ("match", MATCH),
+    ("module", MODULE),
+    ("omit", OMIT),
+    ("on", ON),
+    ("opcode", OPCODE),
+    ("orange", ORANGE),
+    ("output", OUTPUT),
+    ("packet", PACKET),
+    ("packets", PACKETS),
+    ("param", PARAM),
+    ("passive", PASSIVE),
+    ("phase", PHASE),
+    ("port", PORT),
+    ("priority", PRIORITY),
+    ("private", PRIVATE),
+    ("product", PRODUCT),
+    ("queue", QUEUE),
+    ("queued", QUEUED),
+    ("record", RECORD),
+    ("recv", RECV),
+    ("red", RED),
+    ("ref", REF),
+    ("reg", REG),
+    ("request", REQUEST),
+    ("resp", RESP),
+    ("save", SAVE),
+    ("send", SEND),
+    ("serial", SERIAL),
+    ("set", SET),
+    ("severity", SEVERITY),
+    ("signal", SIGNAL),
+    ("size", SIZE),
+    ("stack", STACK),
+    ("state", STATE),
+    ("string", STRING),
+    ("struct", STRUCT),
+    ("sync", SYNC),
+    ("telemetry", TELEMETRY),
+    ("text", TEXT),
+    ("throttle", THROTTLE),
+    ("time", TIME),
+    ("topology", TOPOLOGY),
+    ("true", TRUE),
+    ("type", TYPE),
+    ("unmatched", UNMATCHED),
+    ("update", UPDATE),
+    ("warning", WARNING),
+    ("with", WITH),
+    ("yellow", YELLOW)
+  )
+
+  val reservedWordSet = Set.from(keywords.keys)
+
+  trait TokenData {
+
+    /** the next token */
+    var token: TokenId
+
+    /** the line number of the first character of the current token */
+    var line: Int = 0
+
+    /** the offset of the first character of the current token */
+    var offset: Int = 0
+
+    /** the offset of the character following the token preceding this one */
+    var lastOffset: Int = 0
+
+    /** the offset of the newline immediately preceding the token, or -1 if
+     * token is not preceded by a newline.
+     */
+    var lineOffset: Int = 0
+
+    /** the next identifier is forced to not be a keyword */
+    var reservedWord = false
+
+    /** the string value of a literal */
+    var strVal: String = ""
+
+    /** the base of a number */
+    var base: Int = 0
+
+    def copyFrom(td: TokenData): Unit = {
+      this.token = td.token
+      this.offset = td.offset
+      this.lastOffset = td.lastOffset
+      this.lineOffset = td.lineOffset
+      this.strVal = td.strVal
+      this.base = td.base
+    }
   }
 
-  def identifier: Parser[Token] = positioned {
-    "\\$?[A-Za-z_][A-Za-z_0-9]*".r ^^ { s => Token.IDENTIFIER(s.replaceAll("\\$", "")) }
+  class TokenPosition(
+                       val line: Int,
+                       val column: Int,
+                       lineStr: String
+                     ) extends Position {
+    protected def lineContents: String = lineStr
   }
 
-  def ignore: Parser[Unit] = {
-    // Ignore a comment not followed by a newline
-    def comment: Parser[Unit] = unitParser(newlinesOpt ~ "#[^\r\n]*".r)
-    def spaces: Parser[Unit] = unitParser(" +".r)
-    def escapedNewline: Parser[Unit] = unitParser("\\" ~ newline)
-    unitParser(rep(comment | spaces | escapedNewline))
-  }
+  class Scanner(
+                 file: File,
+                 content: Array[Char],
+                 includingLoc: Option[Location] = None
+               )(using ctx: Context)
+    extends CharArrayReader
+      with TokenData
+      with Iterator[Token] {
 
-  def lexFile(file: File, includingLoc: Option[Location] = None): Result.Result[List[Token]] = {
-    ParserState.file = file
-    ParserState.includingLoc = includingLoc
-    for {
-      reader <- file.openRead(ParserState.includingLoc)
-      result <- checkResult(parse(tokens, reader))
-    } yield result
-  }
+    /** File to scan */
+    val buf: Array[Char] = content
 
-  def lexString(s: String): Result.Result[List[Token]] = {
-    ParserState.file = File.StdIn
-    ParserState.includingLoc = None
-    checkResult(parse(tokens, s))
-  }
+    /** Current token to return */
+    var token: TokenId = EOF
 
-  def literalFloat: Parser[Token] = positioned {
-    (
-      "[0-9]+[Ee][+-]?[0-9]+".r |
-      raw"[0-9]*\.[0-9]+([Ee][+-]?[0-9]+)?".r |
-      raw"[0-9]+\.[0-9]*([Ee][+-]?[0-9]+)?".r
-    ) ^^ { Token.LITERAL_FLOAT(_) }
-  }
+    val lines = new String(content).split("\n")
 
-  def literalInt: Parser[Token] = positioned {
-    ( "0[Xx][0-9a-fA-F]+".r | "[0-9]+".r ) ^^ { Token.LITERAL_INT(_) }
-  }
+    def list(): Result.Result[List[Token]] = {
+      val out = mutable.ArrayBuffer[Token]()
+      var tok = next()
+      while (tok != Token.EOF) {
+        out.append(tok)
+        tok = next()
+      }
 
-  def literalString: Parser[Token] = positioned {
-    literalStringMulti | literalStringSingle
-  }
-
-  def literalStringMulti: Parser[Token] = positioned {
-    "\"\"\"" ~>! stringContent(3) ^^ {
-      case s0 => {
-        val s = "^\\r?\\n".r.replaceAllIn(s0, "")
-        val numInitialSpaces = {
-          def recurse(s: String, n: Int): Int =
-            if (s.length == 0) n
-            else if (s.head == ' ') recurse(s.tail, n + 1)
-            else n
-          recurse(s, 0)
-        }
-        def stripPrefix(s: String): String = {
-          def recurse(pos: Int, s: String): String = {
-            if (s.length == 0 || pos >= numInitialSpaces) s
-            else if (s.head == ' ') recurse(pos + 1, s.tail)
-            else s
-          }
-          recurse(0, s)
-        }
-        val ss  = s.split("\\r?\\n").dropWhile(_.length == 0).toList
-        val ss1 = ss.map(stripPrefix)
-        val s1 = ss1.mkString("\n")
-        Token.LITERAL_STRING(s1)
+      ctx.result() match {
+        case Left(err) => Left(err)
+        case Right(_) => Right(out.toList)
       }
     }
-  }
 
-  def literalStringSingle: Parser[Token] = positioned {
-    "\"" ~>! stringContent(1) ^^ { case s => Token.LITERAL_STRING(s) }
-  }
+    def hasNext: Boolean = !isAtEnd
 
-  def newline: Parser[Unit] =
-    // Convert a comment followed by a newline to a newline
-    unitParser(" *(#[^\r\n]*)?\r?\n *".r)
+    def next(): Token = {
+      if token == EOF then nextChar()
+      fetchToken()
 
-  def parseAllInput[T](p: Parser[T]): parseAllInput[T] = new parseAllInput[T](p)
-  class parseAllInput[T](p: Parser[T]) extends Parser[T] {
-    def dropWhile(in: Input, p: Char => Boolean): Input = {
-      if (in.atEnd) in
-      else if (p(in.first)) dropWhile(in.rest, p)
-      else in
+      val out = token match {
+        case EOF => return Token.EOF
+        case ACTION => Token.ACTION()
+        case ACTIVE => Token.ACTIVE()
+        case ACTIVITY => Token.ACTIVITY()
+        case ALWAYS => Token.ALWAYS()
+        case ARRAY => Token.ARRAY()
+        case ASSERT => Token.ASSERT()
+        case ASYNC => Token.ASYNC()
+        case AT => Token.AT()
+        case BASE => Token.BASE()
+        case BLOCK => Token.BLOCK()
+        case BOOL => Token.BOOL()
+        case CHANGE => Token.CHANGE()
+        case COLON => Token.COLON()
+        case COMMA => Token.COMMA()
+        case COMMAND => Token.COMMAND()
+        case COMPONENT => Token.COMPONENT()
+        case CONNECTIONS => Token.CONNECTIONS()
+        case CONSTANT => Token.CONSTANT()
+        case CONTAINER => Token.CONTAINER()
+        case CPU => Token.CPU()
+        case DEFAULT => Token.DEFAULT()
+        case DIAGNOSTIC => Token.DIAGNOSTIC()
+        case DO => Token.DO()
+        case DOT => Token.DOT()
+        case DROP => Token.DROP()
+        case ELSE => Token.ELSE()
+        case ENTER => Token.ENTER()
+        case ENTRY => Token.ENTRY()
+        case ENUM => Token.ENUM()
+        case EOL => Token.EOL()
+        case EQUALS => Token.EQUALS()
+        case EVENT => Token.EVENT()
+        case EXIT => Token.EXIT()
+        case F32 => Token.F32()
+        case F64 => Token.F64()
+        case FALSE => Token.FALSE()
+        case FATAL => Token.FATAL()
+        case FORMAT => Token.FORMAT()
+        case GET => Token.GET()
+        case GROUP => Token.GROUP()
+        case GUARD => Token.GUARD()
+        case GUARDED => Token.GUARDED()
+        case HEALTH => Token.HEALTH()
+        case HIGH => Token.HIGH()
+        case HOOK => Token.HOOK()
+        case I16 => Token.I16()
+        case I32 => Token.I32()
+        case I64 => Token.I64()
+        case I8 => Token.I8()
+        case ID => Token.ID()
+        case IDENTIFIER => Token.IDENTIFIER(strVal)
+        case IF => Token.IF()
+        case IMPORT => Token.IMPORT()
+        case INCLUDE => Token.INCLUDE()
+        case INITIAL => Token.INITIAL()
+        case INPUT => Token.INPUT()
+        case INSTANCE => Token.INSTANCE()
+        case INTERNAL => Token.INTERNAL()
+        case CHOICE => Token.CHOICE()
+        case LBRACE => Token.LBRACE()
+        case LBRACKET => Token.LBRACKET()
+        case LITERAL_FLOAT => Token.LITERAL_FLOAT(strVal)
+        case LITERAL_INT => Token.LITERAL_INT(strVal)
+        case LITERAL_STRING => Token.LITERAL_STRING(strVal)
+        case LOCATE => Token.LOCATE()
+        case LOW => Token.LOW()
+        case LPAREN => Token.LPAREN()
+        case MACHINE => Token.MACHINE()
+        case MATCH => Token.MATCH()
+        case MINUS => Token.MINUS()
+        case MODULE => Token.MODULE()
+        case OMIT => Token.OMIT()
+        case ON => Token.ON()
+        case OPCODE => Token.OPCODE()
+        case ORANGE => Token.ORANGE()
+        case OUTPUT => Token.OUTPUT()
+        case PACKET => Token.PACKET()
+        case PACKETS => Token.PACKETS()
+        case PARAM => Token.PARAM()
+        case PASSIVE => Token.PASSIVE()
+        case PHASE => Token.PHASE()
+        case PLUS => Token.PLUS()
+        case PORT => Token.PORT()
+        case POST_ANNOTATION => Token.POST_ANNOTATION(strVal)
+        case PRE_ANNOTATION => Token.PRE_ANNOTATION(strVal)
+        case PRIORITY => Token.PRIORITY()
+        case PRIVATE => Token.PRIVATE()
+        case PRODUCT => Token.PRODUCT()
+        case QUEUE => Token.QUEUE()
+        case QUEUED => Token.QUEUED()
+        case RARROW => Token.RARROW()
+        case RBRACE => Token.RBRACE()
+        case RBRACKET => Token.RBRACKET()
+        case RECORD => Token.RECORD()
+        case RECV => Token.RECV()
+        case RED => Token.RED()
+        case REF => Token.REF()
+        case REG => Token.REG()
+        case REQUEST => Token.REQUEST()
+        case RESP => Token.RESP()
+        case RPAREN => Token.RPAREN()
+        case SAVE => Token.SAVE()
+        case SEMI => Token.SEMI()
+        case SEND => Token.SEND()
+        case SERIAL => Token.SERIAL()
+        case SET => Token.SET()
+        case SEVERITY => Token.SEVERITY()
+        case SIGNAL => Token.SIGNAL()
+        case SIZE => Token.SIZE()
+        case SLASH => Token.SLASH()
+        case STACK => Token.STACK()
+        case STAR => Token.STAR()
+        case STATE => Token.STATE()
+        case STRING => Token.STRING()
+        case STRUCT => Token.STRUCT()
+        case SYNC => Token.SYNC()
+        case TELEMETRY => Token.TELEMETRY()
+        case TEXT => Token.TEXT()
+        case THROTTLE => Token.THROTTLE()
+        case TIME => Token.TIME()
+        case TOPOLOGY => Token.TOPOLOGY()
+        case TRUE => Token.TRUE()
+        case TYPE => Token.TYPE()
+        case U16 => Token.U16()
+        case U32 => Token.U32()
+        case U64 => Token.U64()
+        case U8 => Token.U8()
+        case UNMATCHED => Token.UNMATCHED()
+        case UPDATE => Token.UPDATE()
+        case WARNING => Token.WARNING()
+        case WITH => Token.WITH()
+        case YELLOW => Token.YELLOW()
+      }
+
+      out.setPos(pos())
     }
-    def apply(in: Input) = p(in) match {
-      case s @ Success(out, in1) =>
-        if (in1.atEnd) s
-        else {
-          // We hit an illegal character
-          val in2 = dropWhile(in1, _ == ' ')
-          val c = in2.first
+
+    def pos() = {
+      new TokenPosition(
+        line + 1,
+        offset - lineOffset,
+        lines(Math.min(line, lines.length - 1))
+      )
+    }
+
+    /** Generate an error at the current position */
+    def error(msg: String): Unit = {
+      ctx.report(InvalidToken(Location(file, pos(), includingLoc), msg))
+    }
+
+    // Setting token data ----------------------------------------------------
+
+    private def initialCharBufferSize = 1024
+
+    /** A character buffer for literals */
+    private val litBuf = CharBuffer(initialCharBufferSize)
+
+    /** append Unicode character to "litBuf" buffer
+     */
+    private def putChar(c: Char): Unit = litBuf.append(c)
+
+    /** Finish up construction of identifier */
+    private def finishIdent(): Unit = {
+      setStrVal()
+      if reservedWord then token = IDENTIFIER
+      else {
+        token = keywords.get(strVal) match {
+          case Some(key) => key
+          case None => IDENTIFIER
+        }
+      }
+    }
+
+    /** Clear buffer and set string */
+    private def setStrVal(): Unit = {
+      strVal = litBuf.toString
+      litBuf.clear()
+    }
+
+    @tailrec
+    private final def fetchToken(): Unit = {
+      offset = charOffset - 1
+      lineOffset = if (lastOffset < lineStartOffset) lineStartOffset else -1
+      reservedWord = false
+      line = lineNo
+      (ch: @switch) match {
+        case SU => token = EOF
+        // Skip whitespace
+        case ' ' | FF =>
+          nextChar()
+          fetchToken()
+        case '$' =>
+          val lch = lookaheadChar()
+          // Reserved words (identifier that overlaps a keyword)
+          (lch: @switch) match {
+            case 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K' |
+                 'L' | 'M' | 'N' | 'O' | 'P' | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' |
+                 'W' | 'X' | 'Y' | 'Z' | '_' | 'a' | 'b' | 'c' | 'd' | 'e' | 'f' |
+                 'g' | 'h' | 'i' | 'j' | 'k' | 'l' | 'm' | 'n' | 'o' | 'p' | 'q' |
+                 'r' | 's' | 't' | 'u' | 'v' | 'w' | 'x' | 'y' | 'z' =>
+              nextChar()
+              reservedWord = true
+              fetchIdentRest()
+            case _ =>
+              error("invalid usage of '$', expected identifier")
+              nextChar()
+              fetchToken()
+          }
+        // Identifier or keyword
+        case 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K' |
+             'L' | 'M' | 'N' | 'O' | 'P' | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' |
+             'W' | 'X' | 'Y' | 'Z' | '_' | 'a' | 'b' | 'c' | 'd' | 'e' | 'f' |
+             'g' | 'h' | 'i' | 'j' | 'k' | 'l' | 'm' | 'n' | 'o' | 'p' | 'q' |
+             'r' | 's' | 't' | 'u' | 'v' | 'w' | 'x' | 'y' | 'z' =>
+          putChar(ch)
+          nextChar()
+          fetchIdentRest()
+        // Numeric literal
+        case '0' =>
+          def fetchLeadingZero(): Unit = {
+            nextChar()
+            ch match {
+              case 'x' | 'X' =>
+                base = 16
+                putChar('0')
+                putChar('x')
+                nextChar()
+              case 'b' | 'B' =>
+                putChar('0')
+                putChar('b')
+                nextChar()
+              case _ => base = 10; putChar('0')
+            }
+            if (base != 10 && digit2int(ch, base) < 0)
+              error("invalid literal number")
+          }
+
+          fetchLeadingZero()
+          fetchNumber()
+        // More numeric literals
+        case '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' =>
+          base = 10
+          fetchNumber()
+
+        // Escaped newline
+        case '\\' =>
+          nextChar()
+          if (ch == LF) {
+            nextChar()
+            fetchToken()
+          } else error("expected line continuation")
+        // String Literals
+        case '\"' =>
+          nextChar()
+          if (ch == '\"') {
+            nextChar()
+            if (ch == '\"') {
+              nextChar()
+              fetchStringLitMulti()
+            } else {
+              strVal = ""
+              token = LITERAL_STRING
+            }
+          } else fetchStringLitSingle()
+        // Fractional floating
+        case '.' =>
+          nextChar()
+          // Check if this is actually part of a float
+          if ('0' <= ch && ch <= '9') {
+            putChar('.')
+            fetchFraction()
+            setStrVal()
+          } else token = DOT
+        // Newline
+        case LF | '#' =>
+          eatNewlines()
+
+          // Check the next token
+          // Some tokens eat newlines and others don't
+          (ch: @switch) match {
+            case ')' | ']' | '}' =>
+              // Fetch the next token to avoid this newline
+              fetchToken()
+            case _ => token = EOL
+          }
+        case '@' =>
+          nextChar()
+          if (ch == '<') {
+            token = POST_ANNOTATION
+            nextChar()
+          } else token = PRE_ANNOTATION
+          fetchAnnotationRest()
+          eatNewlines()
+        // Token Symbols
+        case '*' =>
+          nextChar(); token = STAR
+          eatNewlines()
+        case '-' =>
+          nextChar()
+          if (ch == '>') {
+            token = RARROW
+            nextChar()
+          } else token = MINUS
+          eatNewlines()
+        case '+' =>
+          nextChar(); token = PLUS
+          eatNewlines()
+        case '/' =>
+          nextChar(); token = SLASH
+          eatNewlines()
+        case '=' =>
+          nextChar(); token = EQUALS
+          eatNewlines()
+        case ';' =>
+          nextChar(); token = SEMI
+          eatNewlines()
+        case ':' =>
+          nextChar(); token = COLON
+          eatNewlines()
+        case ',' =>
+          nextChar(); token = COMMA
+          eatNewlines()
+        case '(' =>
+          nextChar(); token = LPAREN
+          eatNewlines()
+        case '{' =>
+          nextChar(); token = LBRACE
+          eatNewlines()
+        case ')' =>
+          nextChar(); token = RPAREN
+        case '}' =>
+          nextChar(); token = RBRACE
+        case '[' =>
+          nextChar(); token = LBRACKET
+          eatNewlines()
+        case ']' =>
+          nextChar(); token = RBRACKET
+        case _ =>
           val errMsg = {
             // Print out the unicode value, in case the console can't
             // display it as a character
             val prefix =
-              s"illegal character (unicode value ${c.toInt}, hex 0x${c.toInt.toHexString})"
+              s"unicode value ${ch.toInt}, hex 0x${ch.toInt.toHexString}"
             // Generate a special error message for tab characters
             // These are especially tricky and also somewhat common
-            if (c == '\t')
+            if (ch == '\t')
               List(
                 prefix,
                 "note: embedded tab characters are not allowed in FPP source files",
@@ -118,255 +567,177 @@ object Lexer extends RegexParsers {
               ).mkString("\n")
             else prefix
           }
-          Failure(errMsg, in2)
-        }
-      case other => other
-    }
-  }
 
-  def postAnnotation: Parser[Token] = {
-    "@<[^\r\n]*".r <~ newlinesOpt ^^ {
-      case s => {
-        val s1 = s.stripPrefix("@<").trim
-        Token.POST_ANNOTATION(s1)
+          error(errMsg)
+          nextChar()
+          fetchToken()
       }
     }
-  }
 
-  def preAnnotation: Parser[Token] = {
-    "@[^\r\n]*".r <~ newlinesOpt ^^ {
-      case s => {
-        val s1 = s.stripPrefix("@").trim
-        Token.PRE_ANNOTATION(s1)
-      }
-    }
-  }
-
-  def reservedWord: Parser[Token] = positioned {
-    type ST = (String, Unit => Token)
-    def f(st: ST): Parser[Token] = {
-      val (s, t) = st
-      (s ++ raw"\b").r ^^ { _ => t(()) }
-    }
-    (reservedWords map f).foldRight (internalError) ((x, y) => y | x)
-  }
-
-  def stringContent(numEndMarks: Int): Parser[String] =
-    new Parser[String] {
-      /** The state of the string parser */
-      trait State
-      /** Reading state */
-      case class Reading(
-        /** The number of consecutive marks read so far */
-        marks: String
-      ) extends State
-      /** The escaping state immediately after \ */
-      case object Escaping extends State
-      def parse(s: State, in: Input, out: StringBuilder): ParseResult[String] =
-        if (in.atEnd)
-          Failure("unterminated string at end of input", in)
-        else if (numEndMarks == 1 && in.first == '\n')
-          Failure("unterminated string before newline", in.rest)
-        else s match {
-          case Reading(marks) => in.first match {
-            case '"' =>
-              if (marks.length >= numEndMarks)
-                throw new InternalError(
-                  s"marks.length=$marks.length, numEndMarks=$numEndMarks"
-                )
-              else if (marks.length + 1 == numEndMarks)
-                Success(out.result(), in.rest)
-              else parse(Reading(marks + "\""), in.rest, out)
-            case '\\' => parse(Escaping, in.rest, out.append(marks))
-            case c =>
-              parse(Reading(""), in.rest, out.append(marks).append(c))
+    /**
+     * Read through all whitespace, comments, and newlines until another token is reached
+     * This does not update any state of the current token
+     */
+    @tailrec
+    private final def eatNewlines(): Unit = {
+      (ch: @switch) match {
+        // Skip whitespace
+        case LF | ' ' =>
+          nextChar()
+          eatNewlines()
+        // Skip comments
+        case '#' =>
+          nextChar()
+          while (ch != LF) {
+            nextChar()
           }
-          case Escaping => parse(Reading(""), in.rest, out.append(in.first))
-        }
-      def apply(in: Input) = parse(Reading(""), in, new StringBuilder())
-    }
-
-  def symbol: Parser[Token] = positioned {
-    type PSTP = (Parser[Unit], String, Unit => Token, Parser[Unit])
-    def f(pstp: PSTP): Parser[Token] = {
-      val (p1, s, t, p2) = pstp
-      p1 ~> accept(s.toList) <~ p2 ^^ { _ => t(()) }
-    }
-    (symbols map f).foldRight (internalError) ((x, y) => y | x)
-  }
-
-  def token: Parser[Token] = positioned {
-    reservedWord |
-    identifier |
-    literalFloat |
-    literalInt |
-    literalString |
-    postAnnotation |
-    preAnnotation |
-    symbol |
-    eol
-  }
-
-  def tokens: Parser[List[Token]] = {
-    val p = ignore ~> repsep(token, ignore) <~ ignore
-    parseAllInput(p)
-  }
-
-  def unitParser[T](p: Parser[T]): Parser[Unit] = { p ^^ { _ => () } }
-
-  override def skipWhitespace = false
-
-  private def checkResult[T](pr: ParseResult[T]): Result.Result[T] = {
-    pr match {
-      case NoSuccess(msg, next) => {
-        val loc = Location(ParserState.file, next.pos, ParserState.includingLoc)
-        Left(SyntaxError(loc, msg))
+          eatNewlines()
+        case _ =>
       }
-      case Success(result, _) => Right(result)
-      // Suppress false compiler warning
-      case _ => throw new InternalError("This cannot happen")
+    }
+
+    @tailrec
+    private def fetchIdentRest(): Unit = (ch: @switch) match {
+      // Valid identifier characters
+      case 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K' |
+           'L' | 'M' | 'N' | 'O' | 'P' | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' |
+           'W' | 'X' | 'Y' | 'Z' | '_' | 'a' | 'b' | 'c' | 'd' | 'e' | 'f' |
+           'g' | 'h' | 'i' | 'j' | 'k' | 'l' | 'm' | 'n' | 'o' | 'p' | 'q' |
+           'r' | 's' | 't' | 'u' | 'v' | 'w' | 'x' | 'y' | 'z' | '0' | '1' |
+           '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' =>
+        putChar(ch)
+        nextChar()
+        fetchIdentRest()
+      case _ => finishIdent()
+    }
+
+    @tailrec
+    private def fetchAnnotationRest(): Unit = (ch: @switch) match {
+      case LF =>
+        setStrVal()
+        nextChar()
+        strVal = strVal.trim()
+      case _ =>
+        putChar(ch)
+        nextChar()
+        fetchAnnotationRest()
+    }
+
+    @tailrec
+    private def fetchStringLitMulti(): Unit = {
+      (ch: @switch) match {
+        case '\"' =>
+          nextChar()
+          if (ch == '\"') {
+            nextChar()
+            if (ch == '\"') {
+              setStrVal()
+              nextChar()
+              token = LITERAL_STRING
+              return
+            } else {
+              putChar('\"')
+              putChar('\"')
+            }
+          } else putChar('\"')
+
+          fetchStringLitMulti()
+        case _ =>
+          putChar(ch)
+          nextChar()
+          fetchStringLitMulti()
+      }
+    }
+
+    @tailrec
+    private def fetchStringLitSingle(): Unit = {
+      (ch: @switch) match {
+        case '\n' =>
+          nextChar()
+          setStrVal()
+          error("missing string double quote closure")
+        case '\\' =>
+          nextChar()
+          (ch: @switch) match {
+            case '\\' => putChar('\\')
+            case '\"' => putChar('\"')
+            // TODO(tumbar) We could put in more string escape sequences
+            case _ => error("invalid string escape sequence")
+          }
+
+          nextChar()
+          fetchStringLitSingle()
+        case '\"' =>
+          nextChar()
+          setStrVal()
+          token = LITERAL_STRING
+        case _ =>
+          putChar(ch)
+          nextChar()
+          fetchStringLitSingle()
+      }
+    }
+
+    /** Read a number into strVal and set base */
+    private def fetchNumber(): Unit = {
+      while (digit2int(ch, base) >= 0) {
+        putChar(ch)
+        nextChar()
+      }
+
+      token = LITERAL_INT
+      if (base == 10 && ch == '.') {
+        val lch = lookaheadChar()
+        if ('0' <= lch && lch <= '9') {
+          putChar('.')
+          nextChar()
+          fetchFraction()
+        }
+      } else
+        (ch: @switch) match {
+          case 'e' | 'E' =>
+            if (base == 10) fetchFraction()
+          case _ =>
+        }
+
+      setStrVal()
+    }
+
+    /** read fractional part and exponent of floating point number if one is
+     * present.
+     */
+    private def fetchFraction(): Unit = {
+      token = LITERAL_FLOAT
+      while ('0' <= ch && ch <= '9') {
+        putChar(ch)
+        nextChar()
+      }
+
+      if (ch == 'e' || ch == 'E') {
+        val lookahead = lookaheadReader()
+        lookahead.nextChar()
+        if (lookahead.ch == '+' || lookahead.ch == '-')
+          lookahead.nextChar()
+        if ('0' <= lookahead.ch && lookahead.ch <= '9') {
+          putChar(ch)
+          nextChar()
+          if (ch == '+' || ch == '-') {
+            putChar(ch)
+            nextChar()
+          }
+          while ('0' <= ch && ch <= '9') {
+            putChar(ch)
+            nextChar()
+          }
+        }
+      }
+
+      checkNoLetter()
+    }
+
+    private def checkNoLetter(): Unit = {
+      if (isIdentifierPart(ch) && ch >= ' ')
+        error("Invalid literal number")
     }
   }
-
-  val internalError: Parser[Token] = failure("internal error"): Parser[Token]
-
-  val newlines: Parser[Unit] = unitParser(rep1(newline))
-
-  val newlinesOpt: Parser[Unit] = unitParser(rep(newline))
-
-  val nothing: Parser[Unit] = success(())
-
-  val reservedWords: List[(String, Unit => Token)] = List(
-    ("F32", (u: Unit) => Token.F32()),
-    ("F64", (u: Unit) => Token.F64()),
-    ("I16", (u: Unit) => Token.I16()),
-    ("I32", (u: Unit) => Token.I32()),
-    ("I64", (u: Unit) => Token.I64()),
-    ("I8", (u: Unit) => Token.I8()),
-    ("U16", (u: Unit) => Token.U16()),
-    ("U32", (u: Unit) => Token.U32()),
-    ("U64", (u: Unit) => Token.U64()),
-    ("U8", (u: Unit) => Token.U8()),
-    ("action", (u: Unit) => Token.ACTION()),
-    ("active", (u: Unit) => Token.ACTIVE()),
-    ("activity", (u: Unit) => Token.ACTIVITY()),
-    ("always", (u: Unit) => Token.ALWAYS()),
-    ("array", (u: Unit) => Token.ARRAY()),
-    ("assert", (u: Unit) => Token.ASSERT()),
-    ("async", (u: Unit) => Token.ASYNC()),
-    ("at", (u: Unit) => Token.AT()),
-    ("base", (u: Unit) => Token.BASE()),
-    ("block", (u: Unit) => Token.BLOCK()),
-    ("bool", (u: Unit) => Token.BOOL()),
-    ("change", (u: Unit) => Token.CHANGE()),
-    ("choice", (u: Unit) => Token.CHOICE()),
-    ("command", (u: Unit) => Token.COMMAND()),
-    ("component", (u: Unit) => Token.COMPONENT()),
-    ("connections", (u: Unit) => Token.CONNECTIONS()),
-    ("constant", (u: Unit) => Token.CONSTANT()),
-    ("container", (u: Unit) => Token.CONTAINER()),
-    ("cpu", (u: Unit) => Token.CPU()),
-    ("default", (u: Unit) => Token.DEFAULT()),
-    ("diagnostic", (u: Unit) => Token.DIAGNOSTIC()),
-    ("do", (u: Unit) => Token.DO()),
-    ("drop", (u: Unit) => Token.DROP()),
-    ("else", (u: Unit) => Token.ELSE()),
-    ("enter", (u: Unit) => Token.ENTER()),
-    ("entry", (u: Unit) => Token.ENTRY()),
-    ("enum", (u: Unit) => Token.ENUM()),
-    ("event", (u: Unit) => Token.EVENT()),
-    ("exit", (u: Unit) => Token.EXIT()),
-    ("false", (u: Unit) => Token.FALSE()),
-    ("fatal", (u: Unit) => Token.FATAL()),
-    ("format", (u: Unit) => Token.FORMAT()),
-    ("get", (u: Unit) => Token.GET()),
-    ("group", (u: Unit) => Token.GROUP()),
-    ("guard", (u: Unit) => Token.GUARD()),
-    ("guarded", (u: Unit) => Token.GUARDED()),
-    ("health", (u: Unit) => Token.HEALTH()),
-    ("high", (u: Unit) => Token.HIGH()),
-    ("hook", (u: Unit) => Token.HOOK()),
-    ("id", (u: Unit) => Token.ID()),
-    ("if", (u: Unit) => Token.IF()),
-    ("import", (u: Unit) => Token.IMPORT()),
-    ("include", (u: Unit) => Token.INCLUDE()),
-    ("initial", (u: Unit) => Token.INITIAL()),
-    ("input", (u: Unit) => Token.INPUT()),
-    ("instance", (u: Unit) => Token.INSTANCE()),
-    ("internal", (u: Unit) => Token.INTERNAL()),
-    ("locate", (u: Unit) => Token.LOCATE()),
-    ("low", (u: Unit) => Token.LOW()),
-    ("machine", (u: Unit) => Token.MACHINE()),
-    ("match", (u: Unit) => Token.MATCH()),
-    ("module", (u: Unit) => Token.MODULE()),
-    ("omit", (u: Unit) => Token.OMIT()),
-    ("on", (u: Unit) => Token.ON()),
-    ("opcode", (u: Unit) => Token.OPCODE()),
-    ("orange", (u: Unit) => Token.ORANGE()),
-    ("output", (u: Unit) => Token.OUTPUT()),
-    ("packet", (u: Unit) => Token.PACKET()),
-    ("packets", (u: Unit) => Token.PACKETS()),
-    ("param", (u: Unit) => Token.PARAM()),
-    ("passive", (u: Unit) => Token.PASSIVE()),
-    ("phase", (u: Unit) => Token.PHASE()),
-    ("port", (u: Unit) => Token.PORT()),
-    ("priority", (u: Unit) => Token.PRIORITY()),
-    ("private", (u: Unit) => Token.PRIVATE()),
-    ("product", (u: Unit) => Token.PRODUCT()),
-    ("queue", (u: Unit) => Token.QUEUE()),
-    ("queued", (u: Unit) => Token.QUEUED()),
-    ("record", (u: Unit) => Token.RECORD()),
-    ("recv", (u: Unit) => Token.RECV()),
-    ("red", (u: Unit) => Token.RED()),
-    ("ref", (u: Unit) => Token.REF()),
-    ("reg", (u: Unit) => Token.REG()),
-    ("request", (u: Unit) => Token.REQUEST()),
-    ("resp", (u: Unit) => Token.RESP()),
-    ("save", (u: Unit) => Token.SAVE()),
-    ("send", (u: Unit) => Token.SEND()),
-    ("serial", (u: Unit) => Token.SERIAL()),
-    ("set", (u: Unit) => Token.SET()),
-    ("severity", (u: Unit) => Token.SEVERITY()),
-    ("signal", (u: Unit) => Token.SIGNAL()),
-    ("size", (u: Unit) => Token.SIZE()),
-    ("stack", (u: Unit) => Token.STACK()),
-    ("state", (u: Unit) => Token.STATE()),
-    ("string", (u: Unit) => Token.STRING()),
-    ("struct", (u: Unit) => Token.STRUCT()),
-    ("sync", (u: Unit) => Token.SYNC()),
-    ("telemetry", (u: Unit) => Token.TELEMETRY()),
-    ("text", (u: Unit) => Token.TEXT()),
-    ("throttle", (u: Unit) => Token.THROTTLE()),
-    ("time", (u: Unit) => Token.TIME()),
-    ("topology", (u: Unit) => Token.TOPOLOGY()),
-    ("true", (u: Unit) => Token.TRUE()),
-    ("type", (u: Unit) => Token.TYPE()),
-    ("unmatched", (u: Unit) => Token.UNMATCHED()),
-    ("update", (u: Unit) => Token.UPDATE()),
-    ("warning", (u: Unit) => Token.WARNING()),
-    ("with", (u: Unit) => Token.WITH()),
-    ("yellow", (u: Unit) => Token.YELLOW()),
-  )
-
-  val reservedWordSet = reservedWords.map(_._1).toSet
-
-  val symbols: List[(Parser[Unit], String, Unit => Token, Parser[Unit])] = List(
-    (newlinesOpt, ")", (u: Unit) => Token.RPAREN(), nothing),
-    (newlinesOpt, "]", (u: Unit) => Token.RBRACKET(), nothing),
-    (newlinesOpt, "}", (u: Unit) => Token.RBRACE(), nothing),
-    (nothing, "(", (u: Unit) => Token.LPAREN(), newlinesOpt),
-    (nothing, "*", (u: Unit) => Token.STAR(), newlinesOpt),
-    (nothing, "+", (u: Unit) => Token.PLUS(), newlinesOpt),
-    (nothing, ",", (u: Unit) => Token.COMMA(), newlinesOpt),
-    (nothing, "-", (u: Unit) => Token.MINUS(), newlinesOpt),
-    (nothing, "->", (u: Unit) => Token.RARROW(), newlinesOpt),
-    (nothing, ".", (u: Unit) => Token.DOT(), nothing),
-    (nothing, "/", (u: Unit) => Token.SLASH(), newlinesOpt),
-    (nothing, ":", (u: Unit) => Token.COLON(), newlinesOpt),
-    (nothing, ";", (u: Unit) => Token.SEMI(), newlinesOpt),
-    (nothing, "=", (u: Unit) => Token.EQUALS(), newlinesOpt),
-    (nothing, "[", (u: Unit) => Token.LBRACKET(), newlinesOpt),
-    (nothing, "{", (u: Unit) => Token.LBRACE(), newlinesOpt),
-  )
-
 }

--- a/compiler/lib/src/main/scala/syntax/Parser.scala
+++ b/compiler/lib/src/main/scala/syntax/Parser.scala
@@ -10,38 +10,48 @@ object Parser extends Parsers {
 
   class TokenReader(tokens: Seq[Token]) extends Reader[Token] {
     override def first = tokens.head
+
     override def atEnd = tokens.isEmpty
+
     override def pos = tokens.headOption.map(_.pos).getOrElse(NoPosition)
+
     override def rest = new TokenReader(tokens.tail)
   }
 
   def componentKind: Parser[Ast.ComponentKind] = {
-    active ^^ { case _ => Ast.ComponentKind.Active } |
-    passive ^^ { case _ => Ast.ComponentKind.Passive } |
-    queued ^^ { case _ => Ast.ComponentKind.Queued } |
-    failure("component kind expected")
+    active ^^ (_ => Ast.ComponentKind.Active) |
+      passive ^^ (_ => Ast.ComponentKind.Passive) |
+      queued ^^ (_ => Ast.ComponentKind.Queued) |
+      failure("component kind expected")
   }
 
-  def componentMemberNode: Parser[Ast.ComponentMember.Node] = {
-    node(defAliasType) ^^ { case n => Ast.ComponentMember.DefAliasType(n) } |
-    node(defAbsType) ^^ { case n => Ast.ComponentMember.DefAbsType(n) } |
-    node(defArray) ^^ { case n => Ast.ComponentMember.DefArray(n) } |
-    node(defConstant) ^^ { case n => Ast.ComponentMember.DefConstant(n) } |
-    node(defEnum) ^^ { case n => Ast.ComponentMember.DefEnum(n) } |
-    node(defStateMachine) ^^ { case n => Ast.ComponentMember.DefStateMachine(n) } |
-    node(defStruct) ^^ { case n => Ast.ComponentMember.DefStruct(n) } |
-    node(specCommand) ^^ { case n => Ast.ComponentMember.SpecCommand(n) } |
-    node(specContainer) ^^ { case n => Ast.ComponentMember.SpecContainer(n) } |
-    node(specEvent) ^^ { case n => Ast.ComponentMember.SpecEvent(n) } |
-    node(specInclude) ^^ { case n => Ast.ComponentMember.SpecInclude(n) } |
-    node(specInternalPort) ^^ { case n => Ast.ComponentMember.SpecInternalPort(n) } |
-    node(specPortInstance) ^^ { case n => Ast.ComponentMember.SpecPortInstance(n) } |
-    node(specPortMatching) ^^ { case n => Ast.ComponentMember.SpecPortMatching(n) } |
-    node(specParam) ^^ { case n => Ast.ComponentMember.SpecParam(n) } |
-    node(specRecord) ^^ { case n => Ast.ComponentMember.SpecRecord(n) } |
-    node(specStateMachineInstance) ^^ { case n => Ast.ComponentMember.SpecStateMachineInstance(n) } |
-    node(specTlmChannel) ^^ { case n => Ast.ComponentMember.SpecTlmChannel(n) } |
-    failure("component member expected")
+  private def componentMemberNode: Parser[Ast.ComponentMember.Node] = {
+    node(defAliasType) ^^ (n => Ast.ComponentMember.DefAliasType(n)) |
+      node(defAbsType) ^^ (n => Ast.ComponentMember.DefAbsType(n)) |
+      node(defArray) ^^ (n => Ast.ComponentMember.DefArray(n)) |
+      node(defConstant) ^^ (n => Ast.ComponentMember.DefConstant(n)) |
+      node(defEnum) ^^ (n => Ast.ComponentMember.DefEnum(n)) |
+      node(defStateMachine) ^^ (n =>
+        Ast.ComponentMember.DefStateMachine(n)) |
+      node(defStruct) ^^ (n => Ast.ComponentMember.DefStruct(n)) |
+      node(specCommand) ^^ (n => Ast.ComponentMember.SpecCommand(n)) |
+      node(specContainer) ^^ (n =>
+        Ast.ComponentMember.SpecContainer(n)) |
+      node(specEvent) ^^ (n => Ast.ComponentMember.SpecEvent(n)) |
+      node(specInclude) ^^ (n => Ast.ComponentMember.SpecInclude(n)) |
+      node(specInternalPort) ^^ (n =>
+        Ast.ComponentMember.SpecInternalPort(n)) |
+      node(specPortInstance) ^^ (n =>
+        Ast.ComponentMember.SpecPortInstance(n)) |
+      node(specPortMatching) ^^ (n =>
+        Ast.ComponentMember.SpecPortMatching(n)) |
+      node(specParam) ^^ (n => Ast.ComponentMember.SpecParam(n)) |
+      node(specRecord) ^^ (n => Ast.ComponentMember.SpecRecord(n)) |
+      node(specStateMachineInstance) ^^ (n =>
+        Ast.ComponentMember.SpecStateMachineInstance(n)) |
+      node(specTlmChannel) ^^ (n =>
+        Ast.ComponentMember.SpecTlmChannel(n)) |
+      failure("component member expected")
   }
 
   def componentMembers: Parser[List[Ast.ComponentMember]] =
@@ -49,8 +59,9 @@ object Parser extends Parsers {
 
   def connection: Parser[Ast.SpecConnectionGraph.Connection] = {
     def connectionPort = node(portInstanceIdentifier) ~! opt(index)
+
     opt(unmatched) ~ connectionPort ~! (rarrow ~>! connectionPort) ^^ {
-      case unmatched ~ (fromPort ~ fromIndex) ~ (toPort ~ toIndex) => {
+      case unmatched ~ (fromPort ~ fromIndex) ~ (toPort ~ toIndex) =>
         Ast.SpecConnectionGraph.Connection(
           unmatched.isDefined,
           fromPort,
@@ -58,21 +69,20 @@ object Parser extends Parsers {
           toPort,
           toIndex
         )
-      }
     }
   }
 
-  def defAliasType: Parser[Ast.DefAliasType] = {
+  private def defAliasType: Parser[Ast.DefAliasType] = {
     ((typeToken ~> ident) ~ (equals ~> node(typeName))) ^^ {
       case ident ~ typeName => Ast.DefAliasType(ident, typeName)
     }
   }
 
   def defAbsType: Parser[Ast.DefAbsType] = {
-    (typeToken ~> ident) ^^ { case id => Ast.DefAbsType(id) }
+    (typeToken ~> ident) ^^ (id => Ast.DefAbsType(id))
   }
 
-  def defAction: Parser[Ast.DefAction] = {
+  private def defAction: Parser[Ast.DefAction] = {
     (action ~> ident) ~! opt(colon ~>! node(typeName)) ^^ {
       case ident ~ typeName => Ast.DefAction(ident, typeName)
     }
@@ -80,15 +90,18 @@ object Parser extends Parsers {
 
   def defArray: Parser[Ast.DefArray] = {
     (array ~>! ident <~! equals) ~!
-    index ~! node(typeName) ~!
-    opt(default ~>! exprNode) ~!
-    opt(format ~>! node(literalString)) ^^ {
-      case name ~ size ~ eltType ~ default ~ format => Ast.DefArray(name, size, eltType, default, format)
+      index ~! node(typeName) ~!
+      opt(default ~>! exprNode) ~!
+      opt(format ~>! node(literalString)) ^^ {
+      case name ~ size ~ eltType ~ default ~ format =>
+        Ast.DefArray(name, size, eltType, default, format)
     }
   }
 
-  def defChoice: Parser[Ast.DefChoice] = {
-    (choice ~> ident) ~! (lbrace ~> ifToken ~> node(ident)) ~! node(transitionExpr) ~!
+  private def defChoice: Parser[Ast.DefChoice] = {
+    (choice ~> ident) ~! (lbrace ~> ifToken ~> node(ident)) ~! node(
+      transitionExpr
+    ) ~!
       (elseToken ~> node(transitionExpr)) <~! rbrace ^^ {
       case ident ~ guard ~ ifTransition ~ elseTransition =>
         Ast.DefChoice(ident, guard, ifTransition, elseTransition)
@@ -104,19 +117,25 @@ object Parser extends Parsers {
   def defComponentInstance: Parser[Ast.DefComponentInstance] = {
     def initSpecSequence = {
       def id(x: Ast.Annotated[AstNode[Ast.SpecInit]]) = x
-      opt(lbrace ~>! annotatedElementSequence(node(specInit), semi, id) <~! rbrace) ^^ {
+
+      opt(
+        lbrace ~>! annotatedElementSequence(node(specInit), semi, id) <~! rbrace
+      ) ^^ {
         case Some(elements) => elements
         case None => Nil
       }
     }
-    (instance ~>! ident) ~! (colon ~>! node(qualIdent)) ~! (base ~! id ~>! exprNode) ~!
-    opt(typeToken ~>! node(literalString)) ~!
-    opt(at ~>! node(literalString)) ~!
-    opt(queue ~! size ~>! exprNode) ~!
-    opt(stack ~! size ~>! exprNode) ~!
-    opt(priority ~>! exprNode) ~!
-    opt(cpu ~>! exprNode) ~!
-    initSpecSequence ^^ {
+
+    (instance ~>! ident) ~! (colon ~>! node(
+      qualIdent
+    )) ~! (base ~! id ~>! exprNode) ~!
+      opt(typeToken ~>! node(literalString)) ~!
+      opt(at ~>! node(literalString)) ~!
+      opt(queue ~! size ~>! exprNode) ~!
+      opt(stack ~! size ~>! exprNode) ~!
+      opt(priority ~>! exprNode) ~!
+      opt(cpu ~>! exprNode) ~!
+      initSpecSequence ^^ {
       case name ~ typeName ~ baseId ~ implType ~ file ~ queueSize ~ stackSize ~ priority ~ cpu ~ initSpecSequence =>
         Ast.DefComponentInstance(
           name,
@@ -134,29 +153,32 @@ object Parser extends Parsers {
   }
 
   def defConstant: Parser[Ast.DefConstant] = {
-    (constant ~>! ident) ~! (equals ~>! exprNode) ^^ {
-      case id ~ e => Ast.DefConstant(id, e)
+    (constant ~>! ident) ~! (equals ~>! exprNode) ^^ { case id ~ e =>
+      Ast.DefConstant(id, e)
     }
   }
 
   def defEnum: Parser[Ast.DefEnum] = {
     def id(x: Ast.Annotated[AstNode[Ast.DefEnumConstant]]) = x
+
     def constants = annotatedElementSequence(node(defEnumConstant), comma, id)
+
     (enumeration ~>! ident) ~!
-    opt(colon ~>! node(typeName)) ~!
-    (lbrace ~>! constants <~! rbrace) ~!
-    opt(default ~>! exprNode) ^^ {
-      case name ~ typeName ~ constants ~ default => Ast.DefEnum(name, typeName, constants, default)
+      opt(colon ~>! node(typeName)) ~!
+      (lbrace ~>! constants <~! rbrace) ~!
+      opt(default ~>! exprNode) ^^ {
+      case name ~ typeName ~ constants ~ default =>
+        Ast.DefEnum(name, typeName, constants, default)
     }
   }
 
   def defEnumConstant: Parser[Ast.DefEnumConstant] = {
-    ident ~! opt(equals ~>! exprNode) ^^ {
-      case id ~ e => Ast.DefEnumConstant(id, e)
+    ident ~! opt(equals ~>! exprNode) ^^ { case id ~ e =>
+      Ast.DefEnumConstant(id, e)
     }
   }
 
-  def defGuard: Parser[Ast.DefGuard] = {
+  private def defGuard: Parser[Ast.DefGuard] = {
     (guard ~> ident) ~! opt(colon ~>! node(typeName)) ^^ {
       case ident ~ typeName => Ast.DefGuard(ident, typeName)
     }
@@ -170,11 +192,12 @@ object Parser extends Parsers {
 
   def defPort: Parser[Ast.DefPort] = {
     (port ~>! ident) ~! formalParamList ~! opt(rarrow ~>! node(typeName)) ^^ {
-      case ident ~ formalParamList ~ returnType => Ast.DefPort(ident, formalParamList, returnType)
+      case ident ~ formalParamList ~ returnType =>
+        Ast.DefPort(ident, formalParamList, returnType)
     }
   }
 
-  def defSignal: Parser[Ast.DefSignal] = {
+  private def defSignal: Parser[Ast.DefSignal] = {
     (signal ~> ident) ~! opt(colon ~>! node(typeName)) ^^ {
       case ident ~ typeName => Ast.DefSignal(ident, typeName)
     }
@@ -187,28 +210,41 @@ object Parser extends Parsers {
   }
 
   def defStateMachine: Parser[Ast.DefStateMachine] = {
-    state ~> (machine ~> ident) ~! opt(lbrace ~>! stateMachineMembers <~! rbrace) ^^ {
-      case name ~ members => Ast.DefStateMachine(name, members)
+    state ~> (machine ~> ident) ~! opt(
+      lbrace ~>! stateMachineMembers <~! rbrace
+    ) ^^ { case name ~ members =>
+      Ast.DefStateMachine(name, members)
     }
   }
 
   def defStruct: Parser[Ast.DefStruct] = {
     def id(x: Ast.Annotated[AstNode[Ast.StructTypeMember]]) = x
+
     def members = annotatedElementSequence(node(structTypeMember), comma, id)
-    (struct ~>! ident) ~! (lbrace ~>! members <~! rbrace) ~! opt(default ~>! exprNode) ^^ {
-      case name ~ members ~ default => Ast.DefStruct(name, members, default)
+
+    (struct ~>! ident) ~! (lbrace ~>! members <~! rbrace) ~! opt(
+      default ~>! exprNode
+    ) ^^ { case name ~ members ~ default =>
+      Ast.DefStruct(name, members, default)
     }
   }
 
   def specTlmPacketSet: Parser[Ast.SpecTlmPacketSet] = {
     def omitted: Parser[List[AstNode[Ast.TlmChannelIdentifier]]] = {
-      opt(omit ~>! lbrace ~>! elementSequence(node(tlmChannelIdentifier), comma) <~! rbrace) ^^ {
+      opt(
+        omit ~>! lbrace ~>! elementSequence(
+          node(tlmChannelIdentifier),
+          comma
+        ) <~! rbrace
+      ) ^^ {
         case Some(elements) => elements
         case None => Nil
       }
     }
+
     (telemetry ~> packets) ~>! ident ~! (lbrace ~>! tlmPacketSetMembers <~! rbrace) ~! omitted ^^ {
-      case name ~ members ~ omitted => Ast.SpecTlmPacketSet(name, members, omitted)
+      case name ~ members ~ omitted =>
+        Ast.SpecTlmPacketSet(name, members, omitted)
     }
   }
 
@@ -218,9 +254,10 @@ object Parser extends Parsers {
     }
   }
 
-  def doExpr: Parser[List[AstNode[Ast.Ident]]] = {
+  private def doExpr: Parser[List[AstNode[Ast.Ident]]] = {
     def elts = elementSequence(node(ident), comma)
-    doToken ~>! lbrace ~>! elts <~! rbrace ^^ { case elts => elts }
+
+    doToken ~>! lbrace ~>! elts <~! rbrace ^^ (elts => elts)
   }
 
   def exprNode: Parser[AstNode[Ast.Expr]] = {
@@ -229,53 +266,74 @@ object Parser extends Parsers {
         val op ~ e2 = op_e2
         val binop =
           op match {
-            case Token.MINUS() => AstNode.create(Ast.ExprBinop(e1, Ast.Binop.Sub, e2))
-            case Token.PLUS() => AstNode.create(Ast.ExprBinop(e1, Ast.Binop.Add, e2))
-            case Token.SLASH() => AstNode.create(Ast.ExprBinop(e1, Ast.Binop.Div, e2))
-            case Token.STAR() => AstNode.create(Ast.ExprBinop(e1, Ast.Binop.Mul, e2))
+            case Token.MINUS() =>
+              AstNode.create(Ast.ExprBinop(e1, Ast.Binop.Sub, e2))
+            case Token.PLUS() =>
+              AstNode.create(Ast.ExprBinop(e1, Ast.Binop.Add, e2))
+            case Token.SLASH() =>
+              AstNode.create(Ast.ExprBinop(e1, Ast.Binop.Div, e2))
+            case Token.STAR() =>
+              AstNode.create(Ast.ExprBinop(e1, Ast.Binop.Mul, e2))
             case _ => throw new InternalError(s"invalid binary operator ${op}")
-        }
+          }
         val loc = Location(ParserState.file, op.pos, ParserState.includingLoc)
         Locations.put(binop.id, loc)
         binop
       }
+
       es.foldLeft(e)(f)
     }
+
     def dotOperand = node {
       def arrayExpr =
-        lbracket ~>! elementSequence(exprNode, comma) <~! rbracket ^^ {
-          case es => Ast.ExprArray(es)
-        }
-      def falseExpr = falseToken ^^ { case _ => Ast.ExprLiteralBool(Ast.LiteralBool.False) }
-      def floatExpr = literalFloat ^^ { case s => Ast.ExprLiteralFloat(s) }
-      def identExpr = ident ^^ { case id => Ast.ExprIdent(id) }
-      def intExpr = literalInt ^^ { case li => Ast.ExprLiteralInt(li) }
-      def parenExpr = lparen ~> exprNode <~ rparen ^^ { case e => Ast.ExprParen(e) }
-      def stringExpr = literalString ^^ { case s => Ast.ExprLiteralString(s) }
-      def structMember = ident ~! (equals ~>! exprNode) ^^ {
-        case id ~ e => Ast.StructMember(id, e)
+        lbracket ~>! elementSequence(exprNode, comma) <~! rbracket ^^ (es => Ast.ExprArray(es))
+
+      def falseExpr = falseToken ^^ (_ =>
+        Ast.ExprLiteralBool(Ast.LiteralBool.False))
+
+      def floatExpr = literalFloat ^^ (s => Ast.ExprLiteralFloat(s))
+
+      def identExpr = ident ^^ (id => Ast.ExprIdent(id))
+
+      def intExpr = literalInt ^^ (li => Ast.ExprLiteralInt(li))
+
+      def parenExpr = lparen ~> exprNode <~ rparen ^^ (e =>
+        Ast.ExprParen(e))
+
+      def stringExpr = literalString ^^ (s => Ast.ExprLiteralString(s))
+
+      def structMember = ident ~! (equals ~>! exprNode) ^^ { case id ~ e =>
+        Ast.StructMember(id, e)
       }
+
       def structExpr =
-        lbrace ~>! elementSequence(node(structMember), comma) <~! rbrace ^^ {
-          case es => Ast.ExprStruct(es)
-        }
-      def trueExpr = trueToken ^^ { case _ => Ast.ExprLiteralBool(Ast.LiteralBool.True) }
+        lbrace ~>! elementSequence(node(structMember), comma) <~! rbrace ^^ (es => Ast.ExprStruct(es))
+
+      def trueExpr = trueToken ^^ (_ =>
+        Ast.ExprLiteralBool(Ast.LiteralBool.True))
+
       arrayExpr |
-      falseExpr |
-      floatExpr |
-      identExpr |
-      intExpr |
-      parenExpr |
-      stringExpr |
-      structExpr |
-      trueExpr |
-      failure("expression expected")
+        falseExpr |
+        floatExpr |
+        identExpr |
+        intExpr |
+        parenExpr |
+        stringExpr |
+        structExpr |
+        trueExpr |
+        failure("expression expected")
     }
+
     def unaryMinus = node {
-      minus ~>! unaryMinusOperand ^^ { case e => Ast.ExprUnop(Ast.Unop.Minus, e) }
+      minus ~>! unaryMinusOperand ^^ (e =>
+        Ast.ExprUnop(Ast.Unop.Minus, e))
     }
+
     def unaryMinusOperand = {
-      def dotSelectors(e: AstNode[Ast.Expr], ss: List[Token ~ AstNode[String]]) = {
+      def dotSelectors(
+                        e: AstNode[Ast.Expr],
+                        ss: List[Token ~ AstNode[String]]
+                      ) = {
         def f(e: AstNode[Ast.Expr], s: Token ~ AstNode[String]) = {
           val _ ~ id = s
           val dot = AstNode.create(Ast.ExprDot(e, id))
@@ -283,16 +341,24 @@ object Parser extends Parsers {
           Locations.put(dot.id, loc)
           dot
         }
+
         ss.foldLeft(e)(f)
       }
-      dotOperand ~ rep(dot ~! node(ident)) ^^ { case e ~ ss => dotSelectors(e, ss) }
+
+      dotOperand ~ rep(dot ~! node(ident)) ^^ { case e ~ ss =>
+        dotSelectors(e, ss)
+      }
     }
+
     def mulDivOperand = unaryMinus | unaryMinusOperand
-    def addSubOperand = mulDivOperand ~ rep((star | slash) ~! mulDivOperand) ^^ {
-      case e ~ es => leftAssoc(e, es)
-    }
-    addSubOperand ~ rep((plus | minus) ~! addSubOperand) ^^ {
-      case e ~ es => leftAssoc(e, es)
+
+    def addSubOperand =
+      mulDivOperand ~ rep((star | slash) ~! mulDivOperand) ^^ { case e ~ es =>
+        leftAssoc(e, es)
+      }
+
+    addSubOperand ~ rep((plus | minus) ~! addSubOperand) ^^ { case e ~ es =>
+      leftAssoc(e, es)
     }
   }
 
@@ -303,14 +369,17 @@ object Parser extends Parsers {
         case None => Ast.FormalParam.Value
       }
     }
-    kind ~ ident ~! (colon ~>! node(typeName)) ^^ {
-      case kind ~ id ~ tn => Ast.FormalParam(kind, id, tn)
+
+    kind ~ ident ~! (colon ~>! node(typeName)) ^^ { case kind ~ id ~ tn =>
+      Ast.FormalParam(kind, id, tn)
     }
   }
 
   def formalParamList: Parser[Ast.FormalParamList] = {
     def id(x: Ast.Annotated[AstNode[Ast.FormalParam]]) = x
+
     def params = annotatedElementSequence(node(formalParam), comma, id)
+
     opt(lparen ~>! params <~! rparen) ^^ {
       case Some(params) => params
       case None => Nil
@@ -319,78 +388,93 @@ object Parser extends Parsers {
 
   def index: Parser[AstNode[Ast.Expr]] = lbracket ~>! exprNode <~! rbracket
 
-  def lexAndParse[T](
-    tokenStream: => Result.Result[List[Token]],
-    parser: Parser[T]
-  ): Result.Result[T] = {
-    for {
-      tokens <- tokenStream
-      result <- parseTokens(parser)(tokens)
-    } yield result
-  }
-
   def moduleMemberNode: Parser[Ast.ModuleMember.Node] = {
-    node(defAliasType) ^^ { case n => Ast.ModuleMember.DefAliasType(n) } |
-    node(defAbsType) ^^ { case n => Ast.ModuleMember.DefAbsType(n) } |
-    node(defArray) ^^ { case n => Ast.ModuleMember.DefArray(n) } |
-    node(defComponent) ^^ { case n => Ast.ModuleMember.DefComponent(n) } |
-    node(defComponentInstance) ^^ { case n => Ast.ModuleMember.DefComponentInstance(n) } |
-    node(defConstant) ^^ { case n => Ast.ModuleMember.DefConstant(n) } |
-    node(defEnum) ^^ { case n => Ast.ModuleMember.DefEnum(n) } |
-    node(defModule) ^^ { case n => Ast.ModuleMember.DefModule(n) } |
-    node(defPort) ^^ { case n => Ast.ModuleMember.DefPort(n) } |
-    node(defStateMachine) ^^ { case n => Ast.ModuleMember.DefStateMachine(n) } |
-    node(defStruct) ^^ { case n => Ast.ModuleMember.DefStruct(n) } |
-    node(defTopology) ^^ { case n => Ast.ModuleMember.DefTopology(n) } |
-    node(specInclude) ^^ { case n => Ast.ModuleMember.SpecInclude(n) } |
-    node(specLoc) ^^ { case n => Ast.ModuleMember.SpecLoc(n) } |
-    failure("module member expected")
+    node(defAliasType) ^^ (n => Ast.ModuleMember.DefAliasType(n)) |
+      node(defAbsType) ^^ (n => Ast.ModuleMember.DefAbsType(n)) |
+      node(defArray) ^^ (n => Ast.ModuleMember.DefArray(n)) |
+      node(defComponent) ^^ (n => Ast.ModuleMember.DefComponent(n)) |
+      node(defComponentInstance) ^^ (n =>
+        Ast.ModuleMember.DefComponentInstance(n)) |
+      node(defConstant) ^^ (n => Ast.ModuleMember.DefConstant(n)) |
+      node(defEnum) ^^ (n => Ast.ModuleMember.DefEnum(n)) |
+      node(defModule) ^^ (n => Ast.ModuleMember.DefModule(n)) |
+      node(defPort) ^^ (n => Ast.ModuleMember.DefPort(n)) |
+      node(defStateMachine) ^^ (n =>
+        Ast.ModuleMember.DefStateMachine(n)) |
+      node(defStruct) ^^ (n => Ast.ModuleMember.DefStruct(n)) |
+      node(defTopology) ^^ (n => Ast.ModuleMember.DefTopology(n)) |
+      node(specInclude) ^^ (n => Ast.ModuleMember.SpecInclude(n)) |
+      node(specLoc) ^^ (n => Ast.ModuleMember.SpecLoc(n)) |
+      failure("module member expected")
   }
 
-  def moduleMembers: Parser[List[Ast.ModuleMember]] = annotatedElementSequence(moduleMemberNode, semi, Ast.ModuleMember(_))
+  def moduleMembers: Parser[List[Ast.ModuleMember]] =
+    annotatedElementSequence(moduleMemberNode, semi, Ast.ModuleMember(_))
 
   def node[T](p: Parser[T]): Parser[AstNode[T]] = {
     final case class Positioned(t: T) extends Positional
+
     def positionedT: Parser[Positioned] = positioned {
-      p ^^ { case x => Positioned(x) }
+      p ^^ (x => Positioned(x))
     }
+
     positionedT ^^ {
-      case pt @ Positioned(t) => {
+      case pt@Positioned(t) =>
         val n = AstNode.create(t)
         val loc = Location(ParserState.file, pt.pos, ParserState.includingLoc)
         Locations.put(n.id, loc)
         n
-      }
     }
   }
 
-  def parseAllInput[T](p: Parser[T]): Parser[T] = new Parser[T] {
-    def apply(in: Input) = {
-      val r = p(in)
-      r match {
-        case s @ Success(out, in1) =>
-          error match {
-            case Some(e) => e
-            case None => if (in1.atEnd) s else Failure("unexpected token", in1)
-          }
-        case other => other
-      }
+  def parseAllInput[T](p: Parser[T]): Parser[T] = (in: Input) => {
+    val r = p(in)
+    r match {
+      case s@Success(out, in1) =>
+        error match {
+          case Some(e) => e
+          case None => if (in1.atEnd) s else Failure("unexpected token " + in1.first, in1)
+        }
+      case other => other
     }
   }
 
-  def parseFile[T] (p: Parser[T]) (includingLoc: Option[Location]) (f: File): Result.Result[T] =
-    lexAndParse(Lexer.lexFile(f, includingLoc), p)
+  def parseFile[T](
+                    p: Parser[T]
+                  )(includingLoc: Option[Location])(f: File): Result.Result[T] = {
+    ParserState.file = f
+    ParserState.includingLoc = includingLoc
 
-  def parseString[T](p: Parser[T])(s: String): Result.Result[T] = lexAndParse(Lexer.lexString(s), p)
+    for {
+      // Read the file
+      file <- f.openRead(includingLoc)
 
-  def parseTokens[T](p: Parser[T])(tokens: Seq[Token]): Result.Result[T] = {
+      ctx = Context()
+
+      // Parse the file
+      ast <- parseTokens(p)(new Lexer.Scanner(f, file, includingLoc)(using ctx))
+    } yield ast
+  }
+
+  def parseString[T](p: Parser[T])(s: String): Result.Result[T] = {
+    val ctx = Context()
+    for {
+      ast <- parseTokens(p)(new Lexer.Scanner(ParserState.file, s.toCharArray)(using ctx))
+    } yield ast
+  }
+
+  private def parseTokens[T](p: Parser[T])(scanner: Lexer.Scanner): Result.Result[T] = {
     error = None
+    val tokens = scanner.list() match {
+      case Left(err) => return Left(err)
+      case Right(t) => t
+    }
+
     val reader = new TokenReader(tokens)
     parseAllInput(p)(reader) match {
-      case NoSuccess(msg, next) => {
+      case NoSuccess(msg, next) =>
         val loc = Location(ParserState.file, next.pos, ParserState.includingLoc)
-        Left(SyntaxError(loc,msg))
-      }
+        Left(SyntaxError(loc, msg))
       case Success(result, next) => Right(result)
       // Suppress false compiler warning
       case _ => throw new InternalError("This cannot happen")
@@ -399,38 +483,40 @@ object Parser extends Parsers {
 
   def portInstanceIdentifier: Parser[Ast.PortInstanceIdentifier] =
     node(ident) ~! (dot ~>! qualIdentNodeList) ^^ {
-      case id ~ qid => {
+      case id ~ qid =>
         val portName :: tail = qid.reverse
         val componentInstance = id :: tail.reverse
         val node = Ast.QualIdent.Node.fromNodeList(componentInstance)
         Ast.PortInstanceIdentifier(node, portName)
-      }
     }
 
   def qualIdent: Parser[Ast.QualIdent] =
-    qualIdentNodeList ^^ { case qid => Ast.QualIdent.fromNodeList(qid) }
+    qualIdentNodeList ^^ (qid => Ast.QualIdent.fromNodeList(qid))
 
-  def qualIdentNodeList: Parser[Ast.QualIdent.NodeList] = rep1sep(node(ident), dot)
+  private def qualIdentNodeList: Parser[Ast.QualIdent.NodeList] =
+    rep1sep(node(ident), dot)
 
   def queueFull: Parser[Ast.QueueFull] = {
-    assert ^^ { case _ => Ast.QueueFull.Assert } |
-    block ^^ { case _ => Ast.QueueFull.Block } |
-    drop ^^ { case _ => Ast.QueueFull.Drop } |
-    hook ^^ { case _ => Ast.QueueFull.Hook } |
-    failure("queue full expected")
+    assert ^^ (_ => Ast.QueueFull.Assert) |
+      block ^^ (_ => Ast.QueueFull.Block) |
+      drop ^^ (_ => Ast.QueueFull.Drop) |
+      hook ^^ (_ => Ast.QueueFull.Hook) |
+      failure("queue full expected")
   }
 
   def specCommand: Parser[Ast.SpecCommand] = {
     def kind = {
-      async ^^ { case _ => Ast.SpecCommand.Async } |
-      guarded ^^ { case _ => Ast.SpecCommand.Guarded } |
-      sync ^^ { case _ => Ast.SpecCommand.Sync } |
-      failure("command kind expected")
+      async ^^ (_ => Ast.SpecCommand.Async) |
+        guarded ^^ (_ => Ast.SpecCommand.Guarded) |
+        sync ^^ (_ => Ast.SpecCommand.Sync) |
+        failure("command kind expected")
     }
+
     kind ~ (command ~> ident) ~! formalParamList ~!
-    opt(opcode ~>! exprNode) ~! opt(priority ~>! exprNode) ~! opt(node(queueFull)) ^^ {
-      case kind ~ name ~ params ~ opcode ~ priority ~ queueFull =>
-        Ast.SpecCommand(kind, name, params, opcode, priority, queueFull)
+      opt(opcode ~>! exprNode) ~! opt(priority ~>! exprNode) ~! opt(
+      node(queueFull)
+    ) ^^ { case kind ~ name ~ params ~ opcode ~ priority ~ queueFull =>
+      Ast.SpecCommand(kind, name, params, opcode, priority, queueFull)
     }
   }
 
@@ -442,117 +528,126 @@ object Parser extends Parsers {
 
   def specConnectionGraph: Parser[Ast.SpecConnectionGraph] = {
     def directGraph = {
-      (connections ~> ident) ~! (lbrace ~>! elementSequence(connection, comma) <~! rbrace) ^^ {
-        case ident ~ connections => Ast.SpecConnectionGraph.Direct(ident, connections)
+      (connections ~> ident) ~! (lbrace ~>! elementSequence(
+        connection,
+        comma
+      ) <~! rbrace) ^^ { case ident ~ connections =>
+        Ast.SpecConnectionGraph.Direct(ident, connections)
       }
     }
+
     def patternGraph = {
       def patternKind = {
-        command ^^ { case _ => Ast.SpecConnectionGraph.Pattern.Command } |
-        event ^^ { case _ => Ast.SpecConnectionGraph.Pattern.Event } |
-        health ^^ { case _ => Ast.SpecConnectionGraph.Pattern.Health } |
-        param ^^ { case _ => Ast.SpecConnectionGraph.Pattern.Param } |
-        telemetry ^^ { case _ => Ast.SpecConnectionGraph.Pattern.Telemetry } |
-        text ~ event ^^ { case _ => Ast.SpecConnectionGraph.Pattern.TextEvent } |
-        time ^^ { case _ => Ast.SpecConnectionGraph.Pattern.Time }
+        command ^^ (_ => Ast.SpecConnectionGraph.Pattern.Command) |
+          event ^^ (_ => Ast.SpecConnectionGraph.Pattern.Event) |
+          health ^^ (_ => Ast.SpecConnectionGraph.Pattern.Health) |
+          param ^^ (_ => Ast.SpecConnectionGraph.Pattern.Param) |
+          telemetry ^^ (_ => Ast.SpecConnectionGraph.Pattern.Telemetry) |
+          text ~ event ^^ (_ =>
+            Ast.SpecConnectionGraph.Pattern.TextEvent) |
+          time ^^ (_ => Ast.SpecConnectionGraph.Pattern.Time)
       }
+
       def instanceSequence = {
         opt(lbrace ~>! elementSequence(node(qualIdent), comma) <~! rbrace) ^^ {
           case Some(elements) => elements
           case None => Nil
         }
       }
-      patternKind ~ (connections ~! instance ~>! node(qualIdent)) ~! instanceSequence ^^ {
-        case kind ~ source ~ targets => Ast.SpecConnectionGraph.Pattern(
+
+      patternKind ~ (connections ~! instance ~>! node(
+        qualIdent
+      )) ~! instanceSequence ^^ { case kind ~ source ~ targets =>
+        Ast.SpecConnectionGraph.Pattern(
           kind,
           source,
           targets
         )
       }
     }
+
     directGraph | patternGraph | failure("connection graph expected")
   }
 
   def specContainer: Parser[Ast.SpecContainer] = {
     ((product ~ container) ~>! ident) ~!
-    opt(id ~>! exprNode) ~!
-    opt((default ~ priority) ~>! exprNode) ^^ {
-      case name ~ id ~ defaultPriority => Ast.SpecContainer(
-        name,
-        id,
-        defaultPriority
-      )
+      opt(id ~>! exprNode) ~!
+      opt((default ~ priority) ~>! exprNode) ^^ {
+      case name ~ id ~ defaultPriority =>
+        Ast.SpecContainer(
+          name,
+          id,
+          defaultPriority
+        )
     }
   }
 
   def specEvent: Parser[Ast.SpecEvent] = {
     def severityLevel = {
-      activity ~ high ^^ { case _ => Ast.SpecEvent.ActivityHigh } |
-      activity ~ low ^^ { case _ => Ast.SpecEvent.ActivityLow } |
-      command ^^ { case _ => Ast.SpecEvent.Command } |
-      diagnostic ^^ { case _ => Ast.SpecEvent.Diagnostic } |
-      fatal ^^ { case _ => Ast.SpecEvent.Fatal } |
-      warning ~ high ^^ { case _ => Ast.SpecEvent.WarningHigh } |
-      warning ~ low ^^ { case _ => Ast.SpecEvent.WarningLow } |
-      failure("severity level expected")
+      activity ~ high ^^ (_ => Ast.SpecEvent.ActivityHigh) |
+        activity ~ low ^^ (_ => Ast.SpecEvent.ActivityLow) |
+        command ^^ (_ => Ast.SpecEvent.Command) |
+        diagnostic ^^ (_ => Ast.SpecEvent.Diagnostic) |
+        fatal ^^ (_ => Ast.SpecEvent.Fatal) |
+        warning ~ high ^^ (_ => Ast.SpecEvent.WarningHigh) |
+        warning ~ low ^^ (_ => Ast.SpecEvent.WarningLow) |
+        failure("severity level expected")
     }
+
     (event ~> ident) ~! formalParamList ~! (severity ~>! severityLevel) ~!
-    opt(id ~>! exprNode) ~!
-    (format ~>! node(literalString)) ~!
-    opt(throttle ~>! exprNode) ^^ {
+      opt(id ~>! exprNode) ~!
+      (format ~>! node(literalString)) ~!
+      opt(throttle ~>! exprNode) ^^ {
       case name ~ params ~ severity ~ id ~ format ~ throttle =>
         Ast.SpecEvent(name, params, severity, id, format, throttle)
     }
   }
 
   def specInclude: Parser[Ast.SpecInclude] = {
-    include ~>! node(literalString) ^^ { case file => Ast.SpecInclude(file) }
+    include ~>! node(literalString) ^^ (file => Ast.SpecInclude(file))
   }
 
   def specInit: Parser[Ast.SpecInit] = {
-    (phase ~>! exprNode) ~! literalString ^^ {
-      case phase ~ code => Ast.SpecInit(phase, code)
+    (phase ~>! exprNode) ~! literalString ^^ { case phase ~ code =>
+      Ast.SpecInit(phase, code)
     }
   }
 
-  def specInitialTransition: Parser[Ast.SpecInitialTransition] = {
-    initial ~> node(transitionExpr) ^^ {
-      case transition => Ast.SpecInitialTransition(transition)
-    }
+  private def specInitialTransition: Parser[Ast.SpecInitialTransition] = {
+    initial ~> node(transitionExpr) ^^ (transition =>
+      Ast.SpecInitialTransition(transition))
   }
 
-  def specStateEntry: Parser[Ast.SpecStateEntry] = {
-    entry ~> doExpr ^^ {
-      case actions => Ast.SpecStateEntry(actions)
-    }
+  private def specStateEntry: Parser[Ast.SpecStateEntry] = {
+    entry ~> doExpr ^^ (actions =>
+      Ast.SpecStateEntry(actions))
   }
 
-  def specStateExit: Parser[Ast.SpecStateExit] = {
-    exit ~> doExpr ^^ {
-      case actions => Ast.SpecStateExit(actions)
-    }
+  private def specStateExit: Parser[Ast.SpecStateExit] = {
+    exit ~> doExpr ^^ (actions =>
+      Ast.SpecStateExit(actions))
   }
 
   def specInternalPort: Parser[Ast.SpecInternalPort] = {
     (internal ~! port ~>! ident) ~! formalParamList ~!
-    opt(priority ~>! exprNode) ~!
-    opt(queueFull) ^^ {
-      case name ~ params ~ priority ~ queueFull =>
-        Ast.SpecInternalPort(name, params, priority, queueFull)
+      opt(priority ~>! exprNode) ~!
+      opt(queueFull) ^^ { case name ~ params ~ priority ~ queueFull =>
+      Ast.SpecInternalPort(name, params, priority, queueFull)
     }
   }
 
   def specLoc: Parser[Ast.SpecLoc] = {
     def kind = {
-      component ^^ { case _ => Ast.SpecLoc.Component } |
-      constant ^^ { case _ => Ast.SpecLoc.Constant } |
-      instance ^^ { case _ => Ast.SpecLoc.ComponentInstance } |
-      port ^^ { case _ => Ast.SpecLoc.Port } |
-      state ~! machine ^^ { case _ => Ast.SpecLoc.StateMachine } |
-      topology ^^ { case _ => Ast.SpecLoc.Topology } |
-      typeToken ^^ { case _ => Ast.SpecLoc.Type } |
-      failure("location kind expected")
+      component ^^ (_ => Ast.SpecLoc.Component) |
+        constant ^^ (_ => Ast.SpecLoc.Constant) |
+        instance ^^ (_ => Ast.SpecLoc.ComponentInstance) |
+        port ^^ (_ => Ast.SpecLoc.Port) |
+        state ~! machine ^^ (_ => Ast.SpecLoc.StateMachine) |
+        topology ^^ (_ => Ast.SpecLoc.Topology) |
+        typeToken ^^ (_ => Ast.SpecLoc.Type) |
+        failure("location kind expected")
     }
+
     (locate ~>! kind) ~! node(qualIdent) ~! (at ~>! node(literalString)) ^^ {
       case kind ~ symbol ~ file => Ast.SpecLoc(kind, symbol, file)
     }
@@ -560,10 +655,10 @@ object Parser extends Parsers {
 
   def specParam: Parser[Ast.SpecParam] = {
     (param ~>! ident) ~ (colon ~>! node(typeName)) ~!
-    opt(default ~>! exprNode) ~!
-    opt(id ~>! exprNode) ~!
-    opt(set ~! opcode ~>! exprNode) ~!
-    opt(save ~! opcode ~>! exprNode) ^^ {
+      opt(default ~>! exprNode) ~!
+      opt(id ~>! exprNode) ~!
+      opt(set ~! opcode ~>! exprNode) ~!
+      opt(save ~! opcode ~>! exprNode) ^^ {
       case name ~ typeName ~ default ~ id ~ setOpcode ~ saveOpcode =>
         Ast.SpecParam(name, typeName, default, id, setOpcode, saveOpcode)
     }
@@ -571,52 +666,64 @@ object Parser extends Parsers {
 
   def specPortInstance: Parser[Ast.SpecPortInstance] = {
     def generalKind = {
-      async ~ input ^^ { case _ => Ast.SpecPortInstance.AsyncInput } |
-      guarded ~ input ^^ { case _ => Ast.SpecPortInstance.GuardedInput } |
-      output ^^ { case _ => Ast.SpecPortInstance.Output } |
-      sync ~ input ^^ { case _ => Ast.SpecPortInstance.SyncInput }
+      async ~ input ^^ (_ => Ast.SpecPortInstance.AsyncInput) |
+        guarded ~ input ^^ (_ => Ast.SpecPortInstance.GuardedInput) |
+        output ^^ (_ => Ast.SpecPortInstance.Output) |
+        sync ~ input ^^ (_ => Ast.SpecPortInstance.SyncInput)
     }
+
     def instanceType = {
-      node(qualIdent) ^^ { case qi => Some(qi) } |
-      serial ^^ { case _ => None} |
-      failure("port type expected")
+      node(qualIdent) ^^ (qi => Some(qi)) |
+        serial ^^ (_ => None) |
+        failure("port type expected")
     }
+
     def specialInputKind = {
-      async ^^ { case _ => Ast.SpecPortInstance.Async } |
-      guarded ^^ { case _ => Ast.SpecPortInstance.Guarded } |
-      sync ^^ { case _ => Ast.SpecPortInstance.Sync }
+      async ^^ (_ => Ast.SpecPortInstance.Async) |
+        guarded ^^ (_ => Ast.SpecPortInstance.Guarded) |
+        sync ^^ (_ => Ast.SpecPortInstance.Sync)
     }
+
     def specialKind = {
-      command ~ recv ^^ { case _ => Ast.SpecPortInstance.CommandRecv } |
-      command ~ reg ^^ { case _ => Ast.SpecPortInstance.CommandReg } |
-      command ~ resp ^^ { case _ => Ast.SpecPortInstance.CommandResp } |
-      event ^^ { case _ => Ast.SpecPortInstance.Event } |
-      param ~ get ^^ { case _ => Ast.SpecPortInstance.ParamGet } |
-      param ~ set ^^ { case _ => Ast.SpecPortInstance.ParamSet } |
-      product ~ get ^^ { case _ => Ast.SpecPortInstance.ProductGet } |
-      product ~ recv ^^ { case _ => Ast.SpecPortInstance.ProductRecv } |
-      product ~ request ^^ { case _ => Ast.SpecPortInstance.ProductRequest } |
-      product ~ send ^^ { case _ => Ast.SpecPortInstance.ProductSend } |
-      telemetry ^^ { case _ => Ast.SpecPortInstance.Telemetry } |
-      text ~ event ^^ { case _ => Ast.SpecPortInstance.TextEvent } |
-      time ~ get ^^ { case _ => Ast.SpecPortInstance.TimeGet }
+      command ~ recv ^^ (_ => Ast.SpecPortInstance.CommandRecv) |
+        command ~ reg ^^ (_ => Ast.SpecPortInstance.CommandReg) |
+        command ~ resp ^^ (_ => Ast.SpecPortInstance.CommandResp) |
+        event ^^ (_ => Ast.SpecPortInstance.Event) |
+        param ~ get ^^ (_ => Ast.SpecPortInstance.ParamGet) |
+        param ~ set ^^ (_ => Ast.SpecPortInstance.ParamSet) |
+        product ~ get ^^ (_ => Ast.SpecPortInstance.ProductGet) |
+        product ~ recv ^^ (_ => Ast.SpecPortInstance.ProductRecv) |
+        product ~ request ^^ (_ => Ast.SpecPortInstance.ProductRequest) |
+        product ~ send ^^ (_ => Ast.SpecPortInstance.ProductSend) |
+        telemetry ^^ (_ => Ast.SpecPortInstance.Telemetry) |
+        text ~ event ^^ (_ => Ast.SpecPortInstance.TextEvent) |
+        time ~ get ^^ (_ => Ast.SpecPortInstance.TimeGet)
     }
+
     def general = {
       generalKind ~! (port ~>! ident) ~!
-      (colon ~>! opt(index)) ~!
-      instanceType ~!
-      opt(priority ~>! exprNode) ~!
-      opt(node(queueFull)) ^^ {
+        (colon ~>! opt(index)) ~!
+        instanceType ~!
+        opt(priority ~>! exprNode) ~!
+        opt(node(queueFull)) ^^ {
         case kind ~ name ~ size ~ ty ~ priority ~ queueFull =>
-          Ast.SpecPortInstance.General(kind, name, size, ty, priority, queueFull)
+          Ast.SpecPortInstance.General(
+            kind,
+            name,
+            size,
+            ty,
+            priority,
+            queueFull
+          )
       }
     }
+
     def special: Parser[Ast.SpecPortInstance] = {
       opt(specialInputKind) ~
-      specialKind ~
-      (port ~>! ident) ~!
-      opt(priority ~>! exprNode) ~!
-      opt(node(queueFull)) ^^ {
+        specialKind ~
+        (port ~>! ident) ~!
+        opt(priority ~>! exprNode) ~!
+        opt(node(queueFull)) ^^ {
         case inputKind ~ kind ~ name ~ priority ~ queueFull =>
           Ast.SpecPortInstance.Special(
             inputKind,
@@ -627,6 +734,7 @@ object Parser extends Parsers {
           )
       }
     }
+
     general | special
   }
 
@@ -641,11 +749,12 @@ object Parser extends Parsers {
       case Some(_) => true
       case None => false
     }
+
     ((product ~ record) ~>! ident) ~!
-    (colon ~>! node(typeName)) ~!
-    arrayOpt ~!
-    opt(id ~>! exprNode) ^^ {
-      case name ~ recordType ~ arrayOpt ~ id => Ast.SpecRecord(
+      (colon ~>! node(typeName)) ~!
+      arrayOpt ~!
+      opt(id ~>! exprNode) ^^ { case name ~ recordType ~ arrayOpt ~ id =>
+      Ast.SpecRecord(
         name,
         recordType,
         arrayOpt,
@@ -656,115 +765,128 @@ object Parser extends Parsers {
 
   def specStateMachineInstance: Parser[Ast.SpecStateMachineInstance] = {
     (state ~> machine ~> (instance ~>! ident) ~! (colon ~>! node(qualIdent)) ~!
-    opt(priority ~>! exprNode) ~!
-    opt(queueFull)) ^^ {
-      case name ~ statemachine ~ priority ~ queueFull => 
-        Ast.SpecStateMachineInstance(name, statemachine, priority, queueFull)
+      opt(priority ~>! exprNode) ~!
+      opt(queueFull)) ^^ { case name ~ statemachine ~ priority ~ queueFull =>
+      Ast.SpecStateMachineInstance(name, statemachine, priority, queueFull)
     }
   }
 
   def specTlmChannel: Parser[Ast.SpecTlmChannel] = {
     def updateSetting = {
-      always ^^ { case _ => Ast.SpecTlmChannel.Always } |
-      on ~! change ^^ { case _ => Ast.SpecTlmChannel.OnChange } |
-      failure("update kind expected")
+      always ^^ (_ => Ast.SpecTlmChannel.Always) |
+        on ~! change ^^ (_ => Ast.SpecTlmChannel.OnChange) |
+        failure("update kind expected")
     }
+
     def kind = {
-      orange ^^ { case _ => Ast.SpecTlmChannel.Orange } |
-      red ^^ { case _ => Ast.SpecTlmChannel.Red } |
-      yellow ^^ { case _ => Ast.SpecTlmChannel.Yellow }
+      orange ^^ (_ => Ast.SpecTlmChannel.Orange) |
+        red ^^ (_ => Ast.SpecTlmChannel.Red) |
+        yellow ^^ (_ => Ast.SpecTlmChannel.Yellow)
     }
+
     def limit = {
       node(kind) ~! exprNode ^^ { case kind ~ e => (kind, e) }
     }
+
     def limitSequence(p: Parser[Token]) = {
       opt(p ~! lbrace ~>! elementSequence(limit, comma) <~! rbrace) ^^ {
         case Some(seq) => seq
         case None => Nil
       }
     }
+
     (telemetry ~> ident) ~!
-    (colon ~>! node(typeName)) ~!
-    opt(id ~>! exprNode) ~!
-    opt(update ~>! updateSetting) ~!
-    opt(format ~>! node(literalString)) ~!
-    limitSequence(low) ~! limitSequence(high) ^^ {
-      case name ~ typeName ~ id ~ update ~ format ~ low ~ high => Ast.SpecTlmChannel(
-        name,
-        typeName,
-        id,
-        update,
-        format,
-        low,
-        high
-      )
+      (colon ~>! node(typeName)) ~!
+      opt(id ~>! exprNode) ~!
+      opt(update ~>! updateSetting) ~!
+      opt(format ~>! node(literalString)) ~!
+      limitSequence(low) ~! limitSequence(high) ^^ {
+      case name ~ typeName ~ id ~ update ~ format ~ low ~ high =>
+        Ast.SpecTlmChannel(
+          name,
+          typeName,
+          id,
+          update,
+          format,
+          low,
+          high
+        )
     }
   }
 
   def specTlmPacket: Parser[Ast.SpecTlmPacket] = {
     packet ~>! ident ~! opt(id ~>! exprNode) ~! (group ~>! exprNode) ~!
       (lbrace ~>! tlmPacketMembers <~! rbrace) ^^ {
-        case name ~ id ~ group ~ members =>
-          Ast.SpecTlmPacket(name, id, group, members)
-      }
+      case name ~ id ~ group ~ members =>
+        Ast.SpecTlmPacket(name, id, group, members)
+    }
   }
 
   def specTopImport: Parser[Ast.SpecTopImport] =
-    importToken ~>! node(qualIdent) ^^ { case top => Ast.SpecTopImport(top) }
+    importToken ~>! node(qualIdent) ^^ (top => Ast.SpecTopImport(top))
 
-  def specStateTransition: Parser[Ast.SpecStateTransition] = {
+  private def specStateTransition: Parser[Ast.SpecStateTransition] = {
     (on ~> node(ident)) ~! opt(ifToken ~> node(ident)) ~ transitionOrDo ^^ {
       case signal ~ guard ~ transitionOrDo =>
         Ast.SpecStateTransition(signal, guard, transitionOrDo)
     }
   }
 
-  def stateMachineMemberNode: Parser[Ast.StateMachineMember.Node] = {
-    node(specInitialTransition) ^^ { case n => Ast.StateMachineMember.SpecInitialTransition(n) } |
-    node(defState) ^^ { case n => Ast.StateMachineMember.DefState(n) } |
-    node(defSignal) ^^ { case n => Ast.StateMachineMember.DefSignal(n) } |
-    node(defAction) ^^ { case n => Ast.StateMachineMember.DefAction(n) } |
-    node(defGuard) ^^ { case n => Ast.StateMachineMember.DefGuard(n) } |
-    node(defChoice) ^^ { case n => Ast.StateMachineMember.DefChoice(n) } |
-    failure("state machine member expected")
+  private def stateMachineMemberNode: Parser[Ast.StateMachineMember.Node] = {
+    node(specInitialTransition) ^^ (n =>
+      Ast.StateMachineMember.SpecInitialTransition(n)) |
+      node(defState) ^^ (n => Ast.StateMachineMember.DefState(n)) |
+      node(defSignal) ^^ (n => Ast.StateMachineMember.DefSignal(n)) |
+      node(defAction) ^^ (n => Ast.StateMachineMember.DefAction(n)) |
+      node(defGuard) ^^ (n => Ast.StateMachineMember.DefGuard(n)) |
+      node(defChoice) ^^ (n => Ast.StateMachineMember.DefChoice(n)) |
+      failure("state machine member expected")
   }
 
-  def stateMachineMembers: Parser[List[Ast.StateMachineMember]] =
-    annotatedElementSequence(stateMachineMemberNode, semi, Ast.StateMachineMember(_))
+  private def stateMachineMembers: Parser[List[Ast.StateMachineMember]] =
+    annotatedElementSequence(
+      stateMachineMemberNode,
+      semi,
+      Ast.StateMachineMember(_)
+    )
 
-  def stateMemberNode: Parser[Ast.StateMember.Node] = {
-    node(defChoice) ^^ { case n => Ast.StateMember.DefChoice(n) } |
-    node(defState) ^^ { case n => Ast.StateMember.DefState(n) } |
-    node(specInitialTransition) ^^ { case n => Ast.StateMember.SpecInitialTransition(n) } |
-    node(specStateEntry) ^^ { case n => Ast.StateMember.SpecStateEntry(n) } |
-    node(specStateExit) ^^ { case n => Ast.StateMember.SpecStateExit(n) } |
-    node(specStateTransition) ^^ { case n => Ast.StateMember.SpecStateTransition(n) } |
-    failure("state member expected")
+  private def stateMemberNode: Parser[Ast.StateMember.Node] = {
+    node(defChoice) ^^ (n => Ast.StateMember.DefChoice(n)) |
+      node(defState) ^^ (n => Ast.StateMember.DefState(n)) |
+      node(specInitialTransition) ^^ (n =>
+        Ast.StateMember.SpecInitialTransition(n)) |
+      node(specStateEntry) ^^ (n => Ast.StateMember.SpecStateEntry(n)) |
+      node(specStateExit) ^^ (n => Ast.StateMember.SpecStateExit(n)) |
+      node(specStateTransition) ^^ (n =>
+        Ast.StateMember.SpecStateTransition(n)) |
+      failure("state member expected")
   }
 
-  def stateMembers: Parser[List[Ast.StateMember]] =
+  private def stateMembers: Parser[List[Ast.StateMember]] =
     annotatedElementSequence(stateMemberNode, semi, Ast.StateMember(_))
 
   def structTypeMember: Parser[Ast.StructTypeMember] = {
-    ident ~! (colon ~>! opt(index)) ~! node(typeName) ~! opt(format ~>! node(literalString)) ^^ {
-      case name ~ size ~ typeName ~ format => Ast.StructTypeMember(name, size, typeName, format)
+    ident ~! (colon ~>! opt(index)) ~! node(typeName) ~! opt(
+      format ~>! node(literalString)
+    ) ^^ { case name ~ size ~ typeName ~ format =>
+      Ast.StructTypeMember(name, size, typeName, format)
     }
   }
 
   def tlmChannelIdentifier: Parser[Ast.TlmChannelIdentifier] =
     node(ident) ~! (dot ~>! qualIdentNodeList) ^^ {
-      case id ~ qid => {
+      case id ~ qid =>
         val channelName :: tail = qid.reverse
         val componentInstance = id :: tail.reverse
         val node = Ast.QualIdent.Node.fromNodeList(componentInstance)
         Ast.TlmChannelIdentifier(node, channelName)
-      }
     }
 
-  def tlmPacketSetMemberNode: Parser[Ast.TlmPacketSetMember.Node] = {
-    node(specInclude) ^^ { case n => Ast.TlmPacketSetMember.SpecInclude(n) } |
-    node(specTlmPacket) ^^ { case n => Ast.TlmPacketSetMember.SpecTlmPacket(n) } |
-    failure("telemetry packet set member expected")
+  private def tlmPacketSetMemberNode: Parser[Ast.TlmPacketSetMember.Node] = {
+    node(specInclude) ^^ (n => Ast.TlmPacketSetMember.SpecInclude(n)) |
+      node(specTlmPacket) ^^ (n =>
+        Ast.TlmPacketSetMember.SpecTlmPacket(n)) |
+      failure("telemetry packet set member expected")
   }
 
   def tlmPacketSetMembers: Parser[List[Ast.TlmPacketSetMember]] =
@@ -775,69 +897,76 @@ object Parser extends Parsers {
     )
 
   def tlmPacketMember: Parser[Ast.TlmPacketMember] = {
-    node(specInclude) ^^ { case n => Ast.TlmPacketMember.SpecInclude(n) } |
-    node(tlmChannelIdentifier) ^^ { case n => Ast.TlmPacketMember.TlmChannelIdentifier(n) } |
-    failure("telemetry packet member expected")
+    node(specInclude) ^^ (n => Ast.TlmPacketMember.SpecInclude(n)) |
+      node(tlmChannelIdentifier) ^^ (n =>
+        Ast.TlmPacketMember.TlmChannelIdentifier(n)) |
+      failure("telemetry packet member expected")
   }
 
   def tlmPacketMembers: Parser[List[Ast.TlmPacketMember]] =
     elementSequence(tlmPacketMember, comma)
 
-  def topologyMemberNode: Parser[Ast.TopologyMember.Node] = {
-    node(specCompInstance) ^^ { case n => Ast.TopologyMember.SpecCompInstance(n) } |
-    node(specConnectionGraph) ^^ { case n => Ast.TopologyMember.SpecConnectionGraph(n) } |
-    node(specInclude) ^^ { case n => Ast.TopologyMember.SpecInclude(n) } |
-    node(specTlmPacketSet) ^^ { case n => Ast.TopologyMember.SpecTlmPacketSet(n) } |
-    node(specTopImport) ^^ { case n => Ast.TopologyMember.SpecTopImport(n) } |
-    failure("topology member expected")
+  private def topologyMemberNode: Parser[Ast.TopologyMember.Node] = {
+    node(specCompInstance) ^^ (n =>
+      Ast.TopologyMember.SpecCompInstance(n)) |
+      node(specConnectionGraph) ^^ (n =>
+        Ast.TopologyMember.SpecConnectionGraph(n)) |
+      node(specInclude) ^^ (n => Ast.TopologyMember.SpecInclude(n)) |
+      node(specTlmPacketSet) ^^ (n =>
+        Ast.TopologyMember.SpecTlmPacketSet(n)) |
+      node(specTopImport) ^^ (n => Ast.TopologyMember.SpecTopImport(n)) |
+      failure("topology member expected")
   }
 
   def topologyMembers: Parser[List[Ast.TopologyMember]] =
     annotatedElementSequence(topologyMemberNode, semi, Ast.TopologyMember(_))
 
   def transUnit: Parser[Ast.TransUnit] = {
-    tuMembers ^^ { case members => Ast.TransUnit(members) }
+    tuMembers ^^ (members => Ast.TransUnit(members))
   }
 
   def transitionExpr: Parser[Ast.TransitionExpr] =
-    opt(doExpr) ~ (enter ~> node(qualIdent)) ^^ {
-      case actionsOpt ~ target => Ast.TransitionExpr(
+    opt(doExpr) ~ (enter ~> node(qualIdent)) ^^ { case actionsOpt ~ target =>
+      Ast.TransitionExpr(
         actionsOpt.getOrElse(Nil),
         target
       )
     }
 
   def transitionOrDo: Parser[Ast.TransitionOrDo] = {
-    def transitionParser: Parser[Ast.TransitionOrDo.Transition] = node(transitionExpr) ^^ {
-      case e => Ast.TransitionOrDo.Transition(e)
-    }
-    def doParser: Parser[Ast.TransitionOrDo.Do] = doExpr ^^ {
-      case actions => Ast.TransitionOrDo.Do(actions)
-    }
+    def transitionParser: Parser[Ast.TransitionOrDo.Transition] =
+      node(transitionExpr) ^^ (e =>
+        Ast.TransitionOrDo.Transition(e))
+
+    def doParser: Parser[Ast.TransitionOrDo.Do] = doExpr ^^ (actions =>
+      Ast.TransitionOrDo.Do(actions))
+
     transitionParser | doParser
   }
 
-  def tuMembers = moduleMembers
+  private def tuMembers = moduleMembers
 
   def typeName: Parser[Ast.TypeName] = {
     def typeNameFloat =
       accept("F32()", { case Token.F32() => Ast.TypeNameFloat(Ast.F32()) }) |
-      accept("F64()", { case Token.F64() => Ast.TypeNameFloat(Ast.F64()) })
+        accept("F64()", { case Token.F64() => Ast.TypeNameFloat(Ast.F64()) })
+
     def typeNameInt =
       accept("I8()", { case Token.I8() => Ast.TypeNameInt(Ast.I8()) }) |
-      accept("I16()", { case Token.I16() => Ast.TypeNameInt(Ast.I16()) }) |
-      accept("I32()", { case Token.I32() => Ast.TypeNameInt(Ast.I32()) }) |
-      accept("I64()", { case Token.I64() => Ast.TypeNameInt(Ast.I64()) }) |
-      accept("U8()", { case Token.U8() => Ast.TypeNameInt(Ast.U8()) }) |
-      accept("U16()", { case Token.U16() => Ast.TypeNameInt(Ast.U16()) }) |
-      accept("U32()", { case Token.U32() => Ast.TypeNameInt(Ast.U32()) }) |
-      accept("U64()", { case Token.U64() => Ast.TypeNameInt(Ast.U64()) })
+        accept("I16()", { case Token.I16() => Ast.TypeNameInt(Ast.I16()) }) |
+        accept("I32()", { case Token.I32() => Ast.TypeNameInt(Ast.I32()) }) |
+        accept("I64()", { case Token.I64() => Ast.TypeNameInt(Ast.I64()) }) |
+        accept("U8()", { case Token.U8() => Ast.TypeNameInt(Ast.U8()) }) |
+        accept("U16()", { case Token.U16() => Ast.TypeNameInt(Ast.U16()) }) |
+        accept("U32()", { case Token.U32() => Ast.TypeNameInt(Ast.U32()) }) |
+        accept("U64()", { case Token.U64() => Ast.TypeNameInt(Ast.U64()) })
+
     accept("bool", { case Token.BOOL() => Ast.TypeNameBool }) |
-    string ~> opt(size ~>! exprNode) ^^ { case e => Ast.TypeNameString(e) } |
-    typeNameFloat |
-    typeNameInt |
-    node(qualIdent) ^^ { case qid => Ast.TypeNameQualIdent(qid) } |
-    failure("type name expected")
+      string ~> opt(size ~>! exprNode) ^^ (e => Ast.TypeNameString(e)) |
+      typeNameFloat |
+      typeNameInt |
+      node(qualIdent) ^^ (qid => Ast.TypeNameQualIdent(qid)) |
+      failure("type name expected")
   }
 
   def visibility: Parser[Ast.Visibility] = {
@@ -847,165 +976,180 @@ object Parser extends Parsers {
     }
   }
 
-  override def commit[T](p: => Parser[T]) = Parser{ in =>
+  override def commit[T](p: => Parser[T]) = Parser { in =>
     def setError(e: Error) = {
       error match {
-        case None => { error = Some(e) }
+        case None => error = Some(e)
         case Some(_) => ()
       }
       e
     }
+
     val r = p(in)
-    r match{
-      case s @ Success(_, _) => s
-      case e : Error => setError(e)
+    r match {
+      case s@Success(_, _) => s
+      case e: Error => setError(e)
       case Failure(msg, next) => setError(Error(msg, next))
     }
   }
 
   override type Elem = Token
 
-  private def action = accept("action", { case t : Token.ACTION => t })
+  private def action = accept("action", { case t: Token.ACTION => t })
 
-  private def active = accept("active", { case t : Token.ACTIVE => t })
+  private def active = accept("active", { case t: Token.ACTIVE => t })
 
-  private def activity = accept("activity", { case t : Token.ACTIVITY => t })
+  private def activity = accept("activity", { case t: Token.ACTIVITY => t })
 
-  private def always = accept("always", { case t : Token.ALWAYS => t })
+  private def always = accept("always", { case t: Token.ALWAYS => t })
 
   private def annotatedElementSequence[E, S, T](
-    elt: Parser[E],
-    punct: Parser[S],
-    constructor: Ast.Annotated[E] => T
-  ): Parser[List[T]] = {
+                                                 elt: Parser[E],
+                                                 punct: Parser[S],
+                                                 constructor: Ast.Annotated[E] => T
+                                               ): Parser[List[T]] = {
     def terminator = punct | eol
-    def prefix0 = elt ^^ { case elt => (Nil, elt) }
+
+    def prefix0 = elt ^^ (elt => (Nil, elt))
+
     def prefix1 = rep1(preAnnotation) ~! elt ^^ { case al ~ elt => (al, elt) }
+
     def prefix = prefix0 | prefix1
+
     def punctTerminatedElt = (prefix <~ terminator) ~ rep(postAnnotation) ^^ {
       case (al1, elt) ~ al2 => (al1, elt, al2)
     }
+
     def annotationTerminatedElt = prefix ~ rep1(postAnnotation) ^^ {
       case (al1, elt) ~ al2 => (al1, elt, al2)
     }
+
     def terminatedElt = punctTerminatedElt | annotationTerminatedElt
-    def unterminatedElt = rep(preAnnotation) ~ elt ^^ {
-      case al ~ elt => (al, elt, Nil)
+
+    def unterminatedElt = rep(preAnnotation) ~ elt ^^ { case al ~ elt =>
+      (al, elt, Nil)
     }
+
     def elts = rep(terminatedElt) ~ opt(unterminatedElt) ^^ {
       case elts ~ Some(elt) => elts :+ elt
       case elts ~ None => elts
     }
+
     (rep(eol) ~> elts) ^^ { elts => elts.map(constructor) }
   }
 
-  private def array = accept("array", { case t : Token.ARRAY => t })
+  private def array = accept("array", { case t: Token.ARRAY => t })
 
-  private def assert = accept("assert", { case t : Token.ASSERT => t })
+  private def assert = accept("assert", { case t: Token.ASSERT => t })
 
-  private def async = accept("async", { case t : Token.ASYNC => t })
+  private def async = accept("async", { case t: Token.ASYNC => t })
 
-  private def at = accept("at", { case t : Token.AT => t })
+  private def at = accept("at", { case t: Token.AT => t })
 
-  private def base = accept("base", { case t : Token.BASE => t })
+  private def base = accept("base", { case t: Token.BASE => t })
 
-  private def block = accept("block", { case t : Token.BLOCK => t })
+  private def block = accept("block", { case t: Token.BLOCK => t })
 
-  private def change = accept("change", { case t : Token.CHANGE => t })
+  private def change = accept("change", { case t: Token.CHANGE => t })
 
-  private def choice = accept("choice", { case t : Token.CHOICE => t })
+  private def choice = accept("choice", { case t: Token.CHOICE => t })
 
-  private def lbrace = accept("{", { case t : Token.LBRACE => t })
+  private def lbrace = accept("{", { case t: Token.LBRACE => t })
 
-  private def colon = accept(":", { case t : Token.COLON => t })
+  private def colon = accept(":", { case t: Token.COLON => t })
 
-  private def comma = accept(",", { case t : Token.COMMA => t })
+  private def comma = accept(",", { case t: Token.COMMA => t })
 
-  private def command = accept("command", { case t : Token.COMMAND => t })
+  private def command = accept("command", { case t: Token.COMMAND => t })
 
-  private def component = accept("component", { case t : Token.COMPONENT => t })
+  private def component = accept("component", { case t: Token.COMPONENT => t })
 
-  private def connections = accept("connections", { case t : Token.CONNECTIONS => t })
+  private def connections =
+    accept("connections", { case t: Token.CONNECTIONS => t })
 
-  private def constant = accept("constant", { case t : Token.CONSTANT => t })
+  private def constant = accept("constant", { case t: Token.CONSTANT => t })
 
-  private def container = accept("container", { case t : Token.CONTAINER => t })
+  private def container = accept("container", { case t: Token.CONTAINER => t })
 
-  private def cpu = accept("cpu", { case t : Token.CPU => t })
+  private def cpu = accept("cpu", { case t: Token.CPU => t })
 
-  private def default = accept("default", { case t : Token.DEFAULT => t })
+  private def default = accept("default", { case t: Token.DEFAULT => t })
 
-  private def diagnostic = accept("diagnostic", { case t : Token.DIAGNOSTIC => t })
+  private def diagnostic =
+    accept("diagnostic", { case t: Token.DIAGNOSTIC => t })
 
-  private def doToken = accept("do", { case t : Token.DO => t })
+  private def doToken = accept("do", { case t: Token.DO => t })
 
-  private def dot = accept(".", { case t : Token.DOT => t })
+  private def dot = accept(".", { case t: Token.DOT => t })
 
-  private def drop = accept("drop", { case t : Token.DROP => t })
+  private def drop = accept("drop", { case t: Token.DROP => t })
 
-  private def elementSequence[E,S](elt: Parser[E], sep: Parser[S]): Parser[List[E]] =
+  private def elementSequence[E, S](
+                                     elt: Parser[E],
+                                     sep: Parser[S]
+                                   ): Parser[List[E]] =
     repsep(elt, sep | eol) <~ opt(sep | eol)
 
-  private def elseToken = accept("else", { case t : Token.ELSE => t })
+  private def elseToken = accept("else", { case t: Token.ELSE => t })
 
-  private def enter = accept("enter", { case t : Token.ENTER => t })
+  private def enter = accept("enter", { case t: Token.ENTER => t })
 
-  private def entry = accept("entry", { case t : Token.ENTRY => t })
+  private def entry = accept("entry", { case t: Token.ENTRY => t })
 
-  private def enumeration = accept("enum", { case t : Token.ENUM => t })
+  private def enumeration = accept("enum", { case t: Token.ENUM => t })
 
-  private def eol = accept("end of line", { case t : Token.EOL => t })
+  private def eol = accept("end of line", { case t: Token.EOL => t })
 
-  private def equals = accept("=", { case t : Token.EQUALS => t })
+  private def equals = accept("=", { case t: Token.EQUALS => t })
 
-  private def event = accept("event", { case t : Token.EVENT => t })
+  private def event = accept("event", { case t: Token.EVENT => t })
 
-  private def exit = accept("exit", { case t : Token.EXIT => t })
+  private def exit = accept("exit", { case t: Token.EXIT => t })
 
-  private def falseToken = accept("false", { case t : Token.FALSE => t })
+  private def falseToken = accept("false", { case t: Token.FALSE => t })
 
-  private def fatal = accept("fatal", { case t : Token.FATAL => t })
+  private def fatal = accept("fatal", { case t: Token.FATAL => t })
 
-  private def format = accept("format", { case t : Token.FORMAT => t })
+  private def format = accept("format", { case t: Token.FORMAT => t })
 
-  private def fppMatch = accept("match", { case t : Token.MATCH => t })
+  private def fppMatch = accept("match", { case t: Token.MATCH => t })
 
-  private def fppWith = accept("with", { case t : Token.WITH => t })
+  private def fppWith = accept("with", { case t: Token.WITH => t })
 
-  private def get = accept("get", { case t : Token.GET => t })
+  private def get = accept("get", { case t: Token.GET => t })
 
-  private def group = accept("group", { case t : Token.GROUP => t })
+  private def group = accept("group", { case t: Token.GROUP => t })
 
-  private def guard = accept("guard", { case t : Token.GUARD => t })
+  private def guard = accept("guard", { case t: Token.GUARD => t })
 
-  private def guarded = accept("guarded", { case t : Token.GUARDED => t })
+  private def guarded = accept("guarded", { case t: Token.GUARDED => t })
 
-  private def health = accept("health", { case t : Token.HEALTH => t })
+  private def health = accept("health", { case t: Token.HEALTH => t })
 
-  private def high = accept("high", { case t : Token.HIGH => t })
+  private def high = accept("high", { case t: Token.HIGH => t })
 
-  private def hook = accept("hook", { case t : Token.HOOK => t })
+  private def hook = accept("hook", { case t: Token.HOOK => t })
 
-  private def id = accept("id", { case t : Token.ID => t })
+  private def id = accept("id", { case t: Token.ID => t })
 
   private def ident: Parser[Ast.Ident] =
     accept("identifier", { case Token.IDENTIFIER(s) => s })
 
-  private def ifToken = accept("if", { case t : Token.IF => t })
+  private def ifToken = accept("if", { case t: Token.IF => t })
 
-  private def importToken = accept("import", { case t : Token.IMPORT => t })
+  private def importToken = accept("import", { case t: Token.IMPORT => t })
 
-  private def include = accept("include", { case t : Token.INCLUDE => t })
+  private def include = accept("include", { case t: Token.INCLUDE => t })
 
-  private def initial = accept("initial", { case t : Token.INITIAL => t })
+  private def initial = accept("initial", { case t: Token.INITIAL => t })
 
-  private def input = accept("input", { case t : Token.INPUT => t })
+  private def input = accept("input", { case t: Token.INPUT => t })
 
-  private def instance = accept("instance", { case t : Token.INSTANCE => t })
+  private def instance = accept("instance", { case t: Token.INSTANCE => t })
 
-  private def internal = accept("internal", { case t : Token.INTERNAL => t })
+  private def internal = accept("internal", { case t: Token.INTERNAL => t })
 
-  private def lbracket = accept("[", { case t : Token.LBRACKET => t })
+  private def lbracket = accept("[", { case t: Token.LBRACKET => t })
 
   private def literalFloat: Parser[String] =
     accept("floating-point literal", { case Token.LITERAL_FLOAT(s) => s })
@@ -1016,41 +1160,41 @@ object Parser extends Parsers {
   private def literalString: Parser[String] =
     accept("string literal", { case Token.LITERAL_STRING(s) => s })
 
-  private def locate = accept("locate", { case t : Token.LOCATE => t })
+  private def locate = accept("locate", { case t: Token.LOCATE => t })
 
-  private def low = accept("low", { case t : Token.LOW => t })
+  private def low = accept("low", { case t: Token.LOW => t })
 
-  private def lparen = accept("(", { case t : Token.LPAREN => t })
+  private def lparen = accept("(", { case t: Token.LPAREN => t })
 
-  private def machine = accept("machine", { case t : Token.MACHINE => t })
+  private def machine = accept("machine", { case t: Token.MACHINE => t })
 
-  private def minus = accept("-", { case t : Token.MINUS => t })
+  private def minus = accept("-", { case t: Token.MINUS => t })
 
-  private def module = accept("module", { case t : Token.MODULE => t })
+  private def module = accept("module", { case t: Token.MODULE => t })
 
-  private def omit = accept("omit", { case t : Token.OMIT => t })
+  private def omit = accept("omit", { case t: Token.OMIT => t })
 
-  private def on = accept("on", { case t : Token.ON => t })
+  private def on = accept("on", { case t: Token.ON => t })
 
-  private def opcode = accept("opcode", { case t : Token.OPCODE => t })
+  private def opcode = accept("opcode", { case t: Token.OPCODE => t })
 
-  private def orange = accept("orange", { case t : Token.ORANGE => t })
+  private def orange = accept("orange", { case t: Token.ORANGE => t })
 
-  private def output = accept("output", { case t : Token.OUTPUT => t })
+  private def output = accept("output", { case t: Token.OUTPUT => t })
 
-  private def packet = accept("packet", { case t : Token.PACKET => t })
+  private def packet = accept("packet", { case t: Token.PACKET => t })
 
-  private def packets = accept("packets", { case t : Token.PACKETS => t })
+  private def packets = accept("packets", { case t: Token.PACKETS => t })
 
-  private def param = accept("param", { case t : Token.PARAM => t })
+  private def param = accept("param", { case t: Token.PARAM => t })
 
-  private def passive = accept("passive", { case t : Token.PASSIVE => t })
+  private def passive = accept("passive", { case t: Token.PASSIVE => t })
 
-  private def phase = accept("phase", { case t : Token.PHASE => t })
+  private def phase = accept("phase", { case t: Token.PHASE => t })
 
-  private def plus = accept("+", { case t : Token.PLUS => t })
+  private def plus = accept("+", { case t: Token.PLUS => t })
 
-  private def port = accept("port", { case t : Token.PORT => t })
+  private def port = accept("port", { case t: Token.PORT => t })
 
   private def postAnnotation: Parser[String] =
     accept("post annotation", { case Token.POST_ANNOTATION(s) => s })
@@ -1058,87 +1202,87 @@ object Parser extends Parsers {
   private def preAnnotation: Parser[String] =
     accept("pre annotation", { case Token.PRE_ANNOTATION(s) => s })
 
-  private def priority = accept("priority", { case t : Token.PRIORITY => t })
+  private def priority = accept("priority", { case t: Token.PRIORITY => t })
 
-  private def product = accept("product", { case t : Token.PRODUCT => t })
+  private def product = accept("product", { case t: Token.PRODUCT => t })
 
-  private def queue = accept("queue", { case t : Token.QUEUE => t })
+  private def queue = accept("queue", { case t: Token.QUEUE => t })
 
-  private def queued = accept("queued", { case t : Token.QUEUED => t })
+  private def queued = accept("queued", { case t: Token.QUEUED => t })
 
-  private def rarrow = accept("->", { case t : Token.RARROW => t })
+  private def rarrow = accept("->", { case t: Token.RARROW => t })
 
-  private def rbrace = accept("}", { case t : Token.RBRACE => t })
+  private def rbrace = accept("}", { case t: Token.RBRACE => t })
 
-  private def rbracket = accept("]", { case t : Token.RBRACKET => t })
+  private def rbracket = accept("]", { case t: Token.RBRACKET => t })
 
-  private def record = accept("record", { case t : Token.RECORD => t })
+  private def record = accept("record", { case t: Token.RECORD => t })
 
-  private def recv = accept("recv", { case t : Token.RECV => t })
+  private def recv = accept("recv", { case t: Token.RECV => t })
 
-  private def red = accept("red", { case t : Token.RED => t })
+  private def red = accept("red", { case t: Token.RED => t })
 
-  private def ref = accept("ref", { case t : Token.REF => t })
+  private def ref = accept("ref", { case t: Token.REF => t })
 
-  private def reg = accept("reg", { case t : Token.REG => t })
+  private def reg = accept("reg", { case t: Token.REG => t })
 
-  private def request = accept("request", { case t : Token.REQUEST => t })
+  private def request = accept("request", { case t: Token.REQUEST => t })
 
-  private def resp = accept("resp", { case t : Token.RESP => t })
+  private def resp = accept("resp", { case t: Token.RESP => t })
 
-  private def rparen = accept(")", { case t : Token.RPAREN => t })
+  private def rparen = accept(")", { case t: Token.RPAREN => t })
 
-  private def save = accept("save", { case t : Token.SAVE => t })
+  private def save = accept("save", { case t: Token.SAVE => t })
 
-  private def semi = accept(";", { case t : Token.SEMI => t })
+  private def semi = accept(";", { case t: Token.SEMI => t })
 
-  private def send = accept("send", { case t : Token.SEND => t })
+  private def send = accept("send", { case t: Token.SEND => t })
 
-  private def serial = accept("serial", { case t : Token.SERIAL => t })
+  private def serial = accept("serial", { case t: Token.SERIAL => t })
 
-  private def set = accept("set", { case t : Token.SET => t })
+  private def set = accept("set", { case t: Token.SET => t })
 
-  private def severity = accept("severity", { case t : Token.SEVERITY => t })
+  private def severity = accept("severity", { case t: Token.SEVERITY => t })
 
-  private def signal = accept("signal", { case t : Token.SIGNAL => t })
+  private def signal = accept("signal", { case t: Token.SIGNAL => t })
 
-  private def size = accept("size", { case t : Token.SIZE => t })
+  private def size = accept("size", { case t: Token.SIZE => t })
 
-  private def slash = accept("/", { case t : Token.SLASH => t })
+  private def slash = accept("/", { case t: Token.SLASH => t })
 
-  private def stack = accept("stack", { case t : Token.STACK => t })
+  private def stack = accept("stack", { case t: Token.STACK => t })
 
-  private def star = accept("*", { case t : Token.STAR => t  })
+  private def star = accept("*", { case t: Token.STAR => t })
 
-  private def state = accept("state", { case t : Token.STATE => t })
+  private def state = accept("state", { case t: Token.STATE => t })
 
-  private def string = accept("string", { case t : Token.STRING => t })
+  private def string = accept("string", { case t: Token.STRING => t })
 
-  private def struct = accept("struct", { case t : Token.STRUCT => t })
+  private def struct = accept("struct", { case t: Token.STRUCT => t })
 
-  private def sync = accept("sync", { case t : Token.SYNC => t })
+  private def sync = accept("sync", { case t: Token.SYNC => t })
 
-  private def telemetry = accept("telemetry", { case t : Token.TELEMETRY => t })
+  private def telemetry = accept("telemetry", { case t: Token.TELEMETRY => t })
 
-  private def text = accept("text", { case t : Token.TEXT => t })
+  private def text = accept("text", { case t: Token.TEXT => t })
 
-  private def throttle = accept("throttle", { case t : Token.THROTTLE => t })
+  private def throttle = accept("throttle", { case t: Token.THROTTLE => t })
 
-  private def time = accept("time", { case t : Token.TIME => t })
+  private def time = accept("time", { case t: Token.TIME => t })
 
-  private def topology = accept("topology", { case t : Token.TOPOLOGY => t })
+  private def topology = accept("topology", { case t: Token.TOPOLOGY => t })
 
-  private def trueToken = accept("true", { case t : Token.TRUE => t })
+  private def trueToken = accept("true", { case t: Token.TRUE => t })
 
-  private def typeToken = accept("type", { case t : Token.TYPE => t })
+  private def typeToken = accept("type", { case t: Token.TYPE => t })
 
-  private def unmatched = accept("unmatched", { case t : Token.UNMATCHED => t })
+  private def unmatched = accept("unmatched", { case t: Token.UNMATCHED => t })
 
-  private def update = accept("update", { case t : Token.UPDATE => t })
+  private def update = accept("update", { case t: Token.UPDATE => t })
 
-  private def warning = accept("warning", { case t : Token.WARNING => t })
+  private def warning = accept("warning", { case t: Token.WARNING => t })
 
-  private def yellow = accept("yellow", { case t : Token.YELLOW => t })
+  private def yellow = accept("yellow", { case t: Token.YELLOW => t })
 
   /** The first error seen */
   private var error: Option[Error] = None

--- a/compiler/lib/src/main/scala/syntax/Parser.scala
+++ b/compiler/lib/src/main/scala/syntax/Parser.scala
@@ -433,7 +433,7 @@ object Parser extends Parsers {
       case s@Success(out, in1) =>
         error match {
           case Some(e) => e
-          case None => if (in1.atEnd) s else Failure("unexpected token " + in1.first, in1)
+          case None => if (in1.atEnd) s else Failure("unexpected token", in1)
         }
       case other => other
     }

--- a/compiler/lib/src/main/scala/syntax/Token.scala
+++ b/compiler/lib/src/main/scala/syntax/Token.scala
@@ -5,6 +5,8 @@ import scala.util.parsing.input.Positional
 sealed trait Token extends Positional
 
 object Token {
+  case object EOF extends Token
+
   final case class ACTION() extends Token
   final case class ACTIVE() extends Token
   final case class ACTIVITY() extends Token
@@ -137,4 +139,150 @@ object Token {
   final case class WARNING() extends Token
   final case class WITH() extends Token
   final case class YELLOW() extends Token
+}
+
+enum TokenId {
+  case EOF
+
+  // Identifier (non keyword words)
+  case IDENTIFIER
+
+  // Annotations
+  case POST_ANNOTATION
+  case PRE_ANNOTATION
+
+  // Literals
+  case LITERAL_FLOAT
+  case LITERAL_INT
+  case LITERAL_STRING
+
+  // Keywords
+  case ACTION
+  case ACTIVE
+  case ACTIVITY
+  case ALWAYS
+  case ARRAY
+  case ASSERT
+  case ASYNC
+  case AT
+  case BASE
+  case BLOCK
+  case BOOL
+  case CHANGE
+  case COMMAND
+  case COMPONENT
+  case CONNECTIONS
+  case CONSTANT
+  case CONTAINER
+  case CPU
+  case DEFAULT
+  case DIAGNOSTIC
+  case DO
+  case DROP
+  case ELSE
+  case ENTER
+  case ENTRY
+  case ENUM
+  case EVENT
+  case EXIT
+  case F32
+  case F64
+  case FALSE
+  case FATAL
+  case FORMAT
+  case GET
+  case GROUP
+  case GUARD
+  case GUARDED
+  case HEALTH
+  case HIGH
+  case HOOK
+  case I16
+  case I32
+  case I64
+  case I8
+  case ID
+  case IF
+  case IMPORT
+  case INCLUDE
+  case INITIAL
+  case INPUT
+  case INSTANCE
+  case INTERNAL
+  case CHOICE
+  case LOCATE
+  case LOW
+  case MACHINE
+  case MATCH
+  case MODULE
+  case OMIT
+  case ON
+  case OPCODE
+  case ORANGE
+  case OUTPUT
+  case PACKET
+  case PACKETS
+  case PARAM
+  case PASSIVE
+  case PHASE
+  case PORT
+  case PRIORITY
+  case PRIVATE
+  case PRODUCT
+  case QUEUE
+  case QUEUED
+  case RECORD
+  case RECV
+  case RED
+  case REF
+  case REG
+  case REQUEST
+  case RESP
+  case SAVE
+  case SEND
+  case SERIAL
+  case SET
+  case SEVERITY
+  case SIGNAL
+  case SIZE
+  case STACK
+  case STATE
+  case STRING
+  case STRUCT
+  case SYNC
+  case TELEMETRY
+  case TEXT
+  case THROTTLE
+  case TIME
+  case TOPOLOGY
+  case TRUE
+  case TYPE
+  case U16
+  case U32
+  case U64
+  case U8
+  case UNMATCHED
+  case UPDATE
+  case WARNING
+  case WITH
+  case YELLOW
+
+  // Symbols
+  case COLON
+  case COMMA
+  case DOT
+  case EOL
+  case EQUALS
+  case LBRACE
+  case LBRACKET
+  case LPAREN
+  case MINUS
+  case PLUS
+  case RARROW
+  case RBRACE
+  case RBRACKET
+  case RPAREN
+  case SEMI
+  case SLASH
+  case STAR
 }

--- a/compiler/lib/src/main/scala/util/CharBuffer.scala
+++ b/compiler/lib/src/main/scala/util/CharBuffer.scala
@@ -1,0 +1,28 @@
+package fpp.compiler.util
+
+/** A character buffer that exposes the internal array for reading. That way we
+  * can avoid copying when converting to names.
+  */
+class CharBuffer(initialSize: Int = 1024) {
+  private var cs: Array[Char] = new Array[Char](initialSize)
+  private var len: Int = 0
+
+  def append(ch: Char): Unit = {
+    if (len == cs.length) {
+      val cs1 = new Array[Char](len * 2)
+      Array.copy(cs, 0, cs1, 0, len)
+      cs = cs1
+    }
+
+    cs(len) = ch
+    len += 1
+  }
+
+  def chars = cs
+  def length = len
+  def isEmpty: Boolean = len == 0
+  def last: Char = cs(len - 1)
+  def clear(): Unit = len = 0
+
+  override def toString = String(cs, 0, len)
+}

--- a/compiler/lib/src/main/scala/util/Chars.scala
+++ b/compiler/lib/src/main/scala/util/Chars.scala
@@ -1,0 +1,27 @@
+package fpp.compiler.util
+
+import scala.annotation.switch
+import Character.{LETTER_NUMBER, LOWERCASE_LETTER, OTHER_LETTER, TITLECASE_LETTER, UPPERCASE_LETTER}
+import Character.{MATH_SYMBOL, OTHER_SYMBOL}
+import Character.{isJavaIdentifierPart, isUnicodeIdentifierStart, isUnicodeIdentifierPart}
+
+/** Contains constants and classifier methods for characters */
+object Chars {
+  inline val LF = '\u000A'
+  inline val FF = '\u000C'
+  inline val CR = '\u000D'
+  inline val SU = '\u001A'
+
+  /** Convert a character digit to an Int according to given base,
+    *  -1 if no success
+    */
+  def digit2int(ch: Char, base: Int): Int = {
+    val num = if (ch <= '9') ch - '0'
+    else if ('a' <= ch && ch <= 'z') ch - 'a' + 10
+    else if ('A' <= ch && ch <= 'Z') ch - 'A' + 10
+    else -1
+    if (0 <= num && num < base) num else -1
+  }
+
+  def isIdentifierPart(c: Char): Boolean = isUnicodeIdentifierPart(c)
+}

--- a/compiler/lib/src/main/scala/util/Error.scala
+++ b/compiler/lib/src/main/scala/util/Error.scala
@@ -213,6 +213,8 @@ sealed trait Error {
         System.err.println(msg)
       case SemanticError.InvalidType(loc, msg) =>
         Error.print (Some(loc)) (msg)
+      case SemanticError.InvalidToken(loc, msg) =>
+        Error.print (Some(loc)) (s"invalid token: $msg")
       case SemanticError.MismatchedPortNumbers(
         p1Loc: Location,
         p1Number: Int,
@@ -233,6 +235,8 @@ sealed trait Error {
         Error.print (Some(loc)) ("unmatched connection must go from or to a matched port")
       case SemanticError.MissingPort(loc, specMsg, portMsg) =>
         Error.print (Some(loc)) (s"component with $specMsg must have $portMsg")
+      case SemanticError.MultiError(errors) =>
+        errors.foreach(_.print)
       case SemanticError.NoPortAvailableForMatchedNumbering(loc1, loc2, matchingLoc) =>
         Error.print (None) (s"no port available for matched numbering")
         System.err.println("matched connections are specified here:")
@@ -605,6 +609,10 @@ object SemanticError {
   final case class MissingPortMatching(
     loc: Location
   ) extends Error
+  /** A merged error */
+  final case class MultiError(
+    errors: List[Error]
+  ) extends Error
   /** Matched port numbering could not find a valid port number */
   final case class NoPortAvailableForMatchedNumbering(
     loc1: Location,
@@ -628,6 +636,11 @@ object SemanticError {
     name: String,
     loc: Location,
     prevLoc: Location
+  ) extends Error
+  /** Lexer Error */
+  final case class InvalidToken(
+    loc: Location,
+    msg: String,
   ) extends Error
   /** State machine semantic errors */
   object StateMachine {

--- a/compiler/lib/src/test/scala/syntax/Lexer.scala
+++ b/compiler/lib/src/test/scala/syntax/Lexer.scala
@@ -10,6 +10,8 @@ class LexerSpec extends AnyWordSpec {
   "Error" should {
     def error(file: File): Unit = {
       val reader = new FileReader(file)
+      val contents = LazyList.continually(reader.read).takeWhile(_ != -1).map(_.toChar).toArray
+      new Lexer.Scanner()
       Lexer.parse(Lexer.tokens, reader) match {
         case Lexer.Success(_, _) => assert(false)
         case _ => ()
@@ -91,7 +93,7 @@ class LexerSpec extends AnyWordSpec {
     "lex \"\\n\" to one EOL" in {
       val s = "\n"
       Lexer.parse(Lexer.tokens, s) match {
-        case Lexer.Success(Token.EOL() :: List(), _) => ()
+        case Lexer.Success(TokenId.EOL() :: List(), _) => ()
         case _ => assert(false)
       }
     }
@@ -107,7 +109,7 @@ class LexerSpec extends AnyWordSpec {
   "string literal" should {
     def lex(s: String): Unit = {
       Lexer.parse(Lexer.tokens, s) match {
-        case Lexer.Success(Token.LITERAL_STRING(_) :: List(), _) => ()
+        case Lexer.Success(TokenId.LITERAL_STRING(_) :: List(), _) => ()
         case _ => assert(false)
       }
     }

--- a/compiler/lib/src/test/scala/syntax/Lexer.scala
+++ b/compiler/lib/src/test/scala/syntax/Lexer.scala
@@ -1,20 +1,21 @@
 package fpp.compiler.test
 
-import fpp.compiler.syntax.{Lexer,Token}
+import fpp.compiler.syntax.{Lexer,Token,Context}
+import fpp.compiler.util.{File => FppFile}
 import java.io.File
-import java.io.FileReader
 import org.scalatest.wordspec.AnyWordSpec
 
 class LexerSpec extends AnyWordSpec {
 
   "Error" should {
     def error(file: File): Unit = {
-      val reader = new FileReader(file)
-      val contents = LazyList.continually(reader.read).takeWhile(_ != -1).map(_.toChar).toArray
-      new Lexer.Scanner()
-      Lexer.parse(Lexer.tokens, reader) match {
-        case Lexer.Success(_, _) => assert(false)
-        case _ => ()
+      val contents = scala.io.Source.fromFile(file)
+      Lexer.Scanner(
+        FppFile.Path(file.toPath),
+        contents.toArray
+      )(using Context()).list() match {
+        case Left(_) => ()
+        case Right(_) => assert(false)
       }
     }
     val dir = new File("lib/src/test/input/syntax/lexer/error")
@@ -25,9 +26,17 @@ class LexerSpec extends AnyWordSpec {
 
   "FP literal" should {
     def lex(s: String): Unit = {
-      Lexer.parse(Lexer.tokens, s) match {
-        case Lexer.Success(Token.LITERAL_FLOAT(s1) :: List(), _) => assert(s1 === s)
-        case _ => assert(false)
+      Lexer.Scanner(
+        FppFile.StdIn,
+        s.toCharArray
+      )(using Context()).list() match {
+        case Right(Token.LITERAL_FLOAT(s1) :: List()) => assert(s1 === s)
+        case Right(t) =>
+          System.err.println(t)
+          assert(false)
+        case Left(e) =>
+          e.print
+          assert(false)
       }
     }
     val literals = List(
@@ -42,16 +51,16 @@ class LexerSpec extends AnyWordSpec {
 
   "OK" should {
     def ok(file: File): Unit = {
-      val reader = new FileReader(file)
-      Lexer.parse(Lexer.tokens, reader) match {
-        case Lexer.Success(_, _) => ()
-        case Lexer.NoSuccess(msg, next) => {
-          println(msg)
-          println(next.pos.longString)
+      val contents = scala.io.Source.fromFile(file)
+      Lexer.Scanner(
+        FppFile.Path(file.toPath),
+        contents.toArray
+      )(using Context()).list() match {
+        case Right(_) => ()
+        case Left(msg) => {
+          msg.print
           assert(false)
         }
-        // Suppress false compiler warning
-        case _ => throw new InternalError("This cannot happen")
       }
     }
     val dir = new File("lib/src/test/input/syntax/lexer/ok")
@@ -62,14 +71,20 @@ class LexerSpec extends AnyWordSpec {
 
   "annotations" should {
     "lex \"@ abc\" to a pre-annotation" in {
-      Lexer.parse(Lexer.tokens, "@ abc") match {
-        case Lexer.Success(Token.PRE_ANNOTATION("abc") :: List(), _) => ()
+      Lexer.Scanner(
+        FppFile.StdIn,
+        "@ abc".toCharArray
+      )(using Context()).list() match {
+        case Right(Token.PRE_ANNOTATION("abc") :: List()) => ()
         case _ => assert(false)
       }
     }
     "lex \"@< abc\" to a post-annotation" in {
-      Lexer.parse(Lexer.tokens, "@< abc") match {
-        case Lexer.Success(Token.POST_ANNOTATION("abc") :: List(), _) => ()
+      Lexer.Scanner(
+        FppFile.StdIn,
+        "@< abc".toCharArray
+      )(using Context()).list() match {
+        case Right(Token.POST_ANNOTATION("abc") :: List()) => ()
         case _ => assert(false)
       }
     }
@@ -77,8 +92,11 @@ class LexerSpec extends AnyWordSpec {
 
   "int literal" should {
     def lex(s: String): Unit = {
-      Lexer.parse(Lexer.tokens, s) match {
-        case Lexer.Success(Token.LITERAL_INT(s1) :: List(), _) => assert(s1 === s)
+      Lexer.Scanner(
+        FppFile.StdIn,
+        s.toCharArray
+      )(using Context()).list() match {
+        case Right(Token.LITERAL_INT(s1) :: List()) => assert(s1 === s)
         case _ => assert(false)
       }
     }
@@ -92,15 +110,21 @@ class LexerSpec extends AnyWordSpec {
   "line continuation" should {
     "lex \"\\n\" to one EOL" in {
       val s = "\n"
-      Lexer.parse(Lexer.tokens, s) match {
-        case Lexer.Success(TokenId.EOL() :: List(), _) => ()
+      Lexer.Scanner(
+        FppFile.StdIn,
+        s.toCharArray
+      )(using Context()).list() match {
+        case Right(Token.EOL() :: List()) => ()
         case _ => assert(false)
       }
     }
     "lex \"\\\\n\" to zero tokens" in {
       val s = "\\\n"
-      Lexer.parse(Lexer.tokens, s) match {
-        case Lexer.Success(List(), _) => ()
+      Lexer.Scanner(
+        FppFile.StdIn,
+        s.toCharArray
+      )(using Context()).list() match {
+        case Right(List()) => ()
         case _ => assert(false)
       }
     }
@@ -108,8 +132,11 @@ class LexerSpec extends AnyWordSpec {
 
   "string literal" should {
     def lex(s: String): Unit = {
-      Lexer.parse(Lexer.tokens, s) match {
-        case Lexer.Success(TokenId.LITERAL_STRING(_) :: List(), _) => ()
+      Lexer.Scanner(
+        FppFile.StdIn,
+        s.toCharArray
+      )(using Context()).list() match {
+        case Right(Token.LITERAL_STRING(_) :: List()) => ()
         case _ => assert(false)
       }
     }

--- a/compiler/lib/src/test/scala/syntax/Parser.scala
+++ b/compiler/lib/src/test/scala/syntax/Parser.scala
@@ -1,7 +1,7 @@
 package fpp.compiler.test
 
 import fpp.compiler.ast._
-import fpp.compiler.syntax.{Lexer,Parser,Token}
+import fpp.compiler.syntax.{Lexer,Parser,TokenId}
 import java.io.File
 import java.io.FileReader
 import org.scalatest.wordspec.AnyWordSpec

--- a/compiler/project/build.properties
+++ b/compiler/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.10.11

--- a/compiler/project/scala3-migration.sbt
+++ b/compiler/project/scala3-migration.sbt
@@ -1,2 +1,0 @@
-// https://docs.scala-lang.org/scala3/guides/migration/scala3-migrate.html
-addSbtPlugin("ch.epfl.scala" % "sbt-scala3-migrate" % "0.5.0")

--- a/compiler/tools/fpp-syntax/test/embedded-tab.ref.txt
+++ b/compiler/tools/fpp-syntax/test/embedded-tab.ref.txt
@@ -2,6 +2,6 @@ fpp-syntax
 [ local path prefix ]/compiler/tools/fpp-syntax/test/embedded-tab.fpp:1.1
 	
 ^
-error: illegal character (unicode value 9, hex 0x9)
+error: invalid token: unicode value 9, hex 0x9
 note: embedded tab characters are not allowed in FPP source files
 try configuring your editor to convert tabs to spaces

--- a/compiler/tools/fpp-syntax/test/illegal-character.ref.txt
+++ b/compiler/tools/fpp-syntax/test/illegal-character.ref.txt
@@ -2,4 +2,4 @@ fpp-syntax
 [ local path prefix ]/compiler/tools/fpp-syntax/test/illegal-character.fpp:1.1
 %
 ^
-error: illegal character (unicode value 37, hex 0x25)
+error: invalid token: unicode value 37, hex 0x25

--- a/compiler/tools/fpp-to-cpp/test/array/String2ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/String2ArrayAc.ref.cpp
@@ -19,7 +19,7 @@ String2 ::
   // Construct using element-wise constructor
   *this = String2(
     Fw::String("\"\\"),
-    Fw::String("abc\ndef")
+    Fw::String("abc\ndef\n")
   );
 }
 

--- a/compiler/tools/fpp-to-cpp/test/array/StringArrayArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/StringArrayArrayAc.ref.cpp
@@ -17,11 +17,11 @@ StringArray ::
 {
   // Construct using element-wise constructor
   *this = StringArray(
-    String2(Fw::String("\"\\"), Fw::String("abc\ndef")),
-    String2(Fw::String("\"\\"), Fw::String("abc\ndef")),
-    String2(Fw::String("\"\\"), Fw::String("abc\ndef")),
-    String2(Fw::String("\"\\"), Fw::String("abc\ndef")),
-    String2(Fw::String("\"\\"), Fw::String("abc\ndef"))
+    String2(Fw::String("\"\\"), Fw::String("abc\ndef\n")),
+    String2(Fw::String("\"\\"), Fw::String("abc\ndef\n")),
+    String2(Fw::String("\"\\"), Fw::String("abc\ndef\n")),
+    String2(Fw::String("\"\\"), Fw::String("abc\ndef\n")),
+    String2(Fw::String("\"\\"), Fw::String("abc\ndef\n"))
   );
 }
 


### PR DESCRIPTION
This PR reimplements the lexing strategy that produces a hugely faster lexer (8-10x speedup). It uses the same design pattern as can be found in the Scala compiler using a manually written recursive descent parser that moves through the file character-by-character. I also included some fixes in the parser that speed up the parsing by ~30% using IntelliJ's static analysis and auto-fixes. Mainly the fixes removed some redunant syntax and added `private` to functions that could be internalized (allows inlining and other optimizations by Scala).

## Notable changes

There are some very minor discrepancies between the old and new lexer, @bocchino I didn't get exact feature parity because some behavior seems a little under defined so I'll wait for your input:

1. Trailing spaces after a `\` line continuation are disallowed. There is a single file in the FPrime repo that has some trailing spaces which throws an error in the lexer. I'm leaning toward keeping the functionality as is since it enforces cleaner syntax.
2. The lexer uses an error `Context` to track invalid tokens or tokenization errors.
3.  The string trimming of multi-line strings (3-strings) is pretty confusing (or bugged). The old behavior had odd behavior:

```
constant F: string = """
    indented
    keeps
    trailing newline
    """
```

Generates a string with value: `indented\nkeeps\ntrailing newline\n`

```
constant F: string = """
non-indented
does not keep
trailing newline
```

Generates string with value: `non-indented\ndoes not keep\ntrailing newline`

For now the new lexer will not string trailing newlines ever but I can easily add that in.

## Benchmarks

To benchmark I ran a JVM-based profiler to compare lexing times on the locs generation step of the FppTest build (this is a parsing intensive build stage). The images screenshots of the runtime of the lexer before and after this PR. I also `time`ed the runtime of the native GraalVM build of `fpp-locate-defs` before and after this PR. The stats are included below.

Before:
![image](https://github.com/user-attachments/assets/61bc0f98-fbfe-46ff-8581-2e9e2573119d)

```
real	0m3.460s
user	0m3.389s
sys	0m0.071s
```

After:
![image](https://github.com/user-attachments/assets/341b690e-35b5-47b0-ac1b-87c5cab094d4)
```
real	0m0.335s
user	0m0.284s
sys	0m0.052s
```
