### PR TITLE
Generate loop for toString() on Struct member arrays

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/StructCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/StructCppWriter.scala
@@ -402,7 +402,7 @@ case class StructCppWriter(
                       |${fillTmpString}
                       |
                       |FwSizeType size = ${n}Tmp.length() + (i > 0 ? 2 : 0);
-                      |if (size + ${n}Str.length() < ${n}Str.maxLength()) {
+                      |if ((size + ${n}Str.length()) <= ${n}Str.maxLength()) {
                       |  if (i > 0) {
                       |    ${n}Str += ", ";
                       |  }

--- a/compiler/lib/src/main/scala/codegen/CppWriter/StructCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/StructCppWriter.scala
@@ -402,8 +402,7 @@ case class StructCppWriter(
                       |${fillTmpString}
                       |
                       |FwSizeType size = ${n}Tmp.length() + (i > 0 ? 2 : 0);
-                      |FwSizeType remaining = ${n}Str.maxLength() - ${n}Str.length();
-                      |if (size < remaining) {
+                      |if (size + ${n}Str.length() < ${n}Str.maxLength()) {
                       |  if (i > 0) {
                       |    ${n}Str += ", ";
                       |  }

--- a/compiler/lib/src/main/scala/codegen/CppWriter/StructCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/StructCppWriter.scala
@@ -355,11 +355,14 @@ case class StructCppWriter(
   private def getFunctionMembers: List[CppDoc.Class.Member] = {
     // Members on which to call toString()
     val toStringMemberNames =
-      memberList.filter((n, tn) => typeMembers(n).getUnderlyingType match {
-        case _: Type.String => false
-        case t if s.isPrimitive(t, tn) => false
+      astMembers.map((_, node, _) => {
+        val t = typeMembers(node.data.name)
+        (node, node.data.name, typeCppWriter.write(t))
+      }).filter((n, _, tn) => (sizes.contains(n.data.name), typeMembers(n.data.name).getUnderlyingType) match {
+        case (false, _: Type.String) => false
+        case (false, t) if s.isPrimitive(t, tn) => false
         case _ => true
-      }).map((n, _) => n)
+      })
     // String initialization for arrays and serializable member types in toString()
     val initStrings = toStringMemberNames match {
       case Nil => Nil
@@ -367,20 +370,49 @@ case class StructCppWriter(
         List(
           Line.blank ::
             lines("// Declare strings to hold any serializable toString() arguments"),
-          names.flatMap(n =>
-            if sizes.contains(n) then
-              lines(s"Fw::String ${n}Str[${sizes(n)}];")
-            else
-              lines(s"Fw::String ${n}Str;")
-          ),
+          names.flatMap((_, n, _) => lines(s"Fw::String ${n}Str;")),
           Line.blank ::
             lines("// Call toString for arrays and serializable types"),
-          names.flatMap(n =>
-            if sizes.contains(n) then
-              iterateN(sizes(n), lines(s"this->m_$n[i].toString(${n}Str[i]);"))
-            else
-              lines(s"this->m_$n.toString(${n}Str);")
-          ),
+          names.flatMap((node, n, tn) => {
+            val formatStr = FormatCppWriter.write(
+              getFormatStr(n),
+              node.data.typeName
+            )
+
+            (sizes.contains(n), typeMembers(n).getUnderlyingType) match {
+              case (true, _: Type.String) =>
+              case (true, t) if s.isPrimitive(t, tn) => 
+              case (true, _) =>
+              case _ => lines(s"this->m_$n.toString(${n}Str);")
+            }
+
+            // Loop through and format each element if this is an array
+            if (sizes.contains(n)) {
+              val fillTmpString = (typeMembers(n).getUnderlyingType) match {
+                case (_: Type.String) =>
+                  s"${n}Tmp = this->m_$n[i];"
+                case t if s.isPrimitive(t, tn) =>
+                  s"""${n}Tmp.format("$formatStr", ${promoteF32ToF64 (t) (s"this->m_$n[i]")});"""
+                case _ =>
+                  s"this->m_$n[i].toString(${n}Tmp);"
+              }
+
+              iterateN(sizes(n), lines(
+                  s"""|Fw::String ${n}Tmp;
+                      |${fillTmpString}
+                      |
+                      |FwSizeType size = ${n}Tmp.length() + (i > 0 ? 2 : 0);
+                      |FwSizeType remaining = ${n}Str.maxLength() - ${n}Str.length();
+                      |if (size < remaining) {
+                      |  if (i > 0) {
+                      |    ${n}Str += ", ";
+                      |  }
+                      |  ${n}Str += ${n}Tmp;
+                      |} else {
+                      |  break;
+                      |}"""))
+            } else lines(s"this->m_$n.toString(${n}Str);")
+          }),
         ).flatten
     }
 
@@ -473,12 +505,7 @@ case class StructCppWriter(
                   node.data.typeName
                 )
                 if sizes.contains(n) then {
-                  if sizes(n) == 1 then
-                    List(s"$n = [ $formatStr ]")
-                  else
-                    s"$n = [ $formatStr" ::
-                      List.fill(sizes(n) - 2)(formatStr) ++
-                        List(s"$formatStr ]")
+                  List(s"$n = [ %s ]")
                 } else
                   List(s"$n = $formatStr")
               }).mkString("\"( \"\n\"", ", \"\n\"", "\"\n\" )\";")).map(indentIn),
@@ -494,14 +521,8 @@ case class StructCppWriter(
                         List(s"this->m_$n.toChar()")
                       case (false, t) if s.isPrimitive(t, tn) =>
                         List(promoteF32ToF64 (t) (s"this->m_$n"))
-                      case (false, _) =>
-                        List(s"${n}Str.toChar()")
-                      case (true, _: Type.String) =>
-                        List.range(0, sizes(n)).map(i => s"this->m_$n[$i].toChar()")
-                      case (true, t) if s.isPrimitive(t, tn) =>
-                        List.range(0, sizes(n)).map(i => promoteF32ToF64 (t) (s"this->m_$n[$i]"))
                       case _ =>
-                        List.range(0, sizes(n)).map(i => s"${n}Str[$i].toChar()")
+                        List(s"${n}Str.toChar()")
                     }).mkString(",\n"))
                 },
                 ");"

--- a/compiler/tools/fpp-to-cpp/test/array/S3SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/S3SerializableAc.ref.cpp
@@ -173,7 +173,7 @@ namespace S {
       mU32ArrayTmp.format("%" PRIu32 "", this->m_mU32Array[i]);
 
       FwSizeType size = mU32ArrayTmp.length() + (i > 0 ? 2 : 0);
-      if (size + mU32ArrayStr.length() < mU32ArrayStr.maxLength()) {
+      if ((size + mU32ArrayStr.length()) <= mU32ArrayStr.maxLength()) {
         if (i > 0) {
           mU32ArrayStr += ", ";
         }

--- a/compiler/tools/fpp-to-cpp/test/array/S3SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/S3SerializableAc.ref.cpp
@@ -160,17 +160,33 @@ namespace S {
   {
     static const char* formatString =
       "( "
-      "mU32Array = [ %" PRIu32 ", "
-      "%" PRIu32 ", "
-      "%" PRIu32 " ], "
+      "mU32Array = [ %s ], "
       "mF64 = %f"
       " )";
 
+    // Declare strings to hold any serializable toString() arguments
+    Fw::String mU32ArrayStr;
+
+    // Call toString for arrays and serializable types
+    for (FwSizeType i = 0; i < 3; i++) {
+      Fw::String mU32ArrayTmp;
+      mU32ArrayTmp.format("%" PRIu32 "", this->m_mU32Array[i]);
+
+      FwSizeType size = mU32ArrayTmp.length() + (i > 0 ? 2 : 0);
+      FwSizeType remaining = mU32ArrayStr.maxLength() - mU32ArrayStr.length();
+      if (size < remaining) {
+        if (i > 0) {
+          mU32ArrayStr += ", ";
+        }
+        mU32ArrayStr += mU32ArrayTmp;
+      } else {
+        break;
+      }
+    }
+
     sb.format(
       formatString,
-      this->m_mU32Array[0],
-      this->m_mU32Array[1],
-      this->m_mU32Array[2],
+      mU32ArrayStr.toChar(),
       this->m_mF64
     );
   }

--- a/compiler/tools/fpp-to-cpp/test/array/S3SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/S3SerializableAc.ref.cpp
@@ -173,8 +173,7 @@ namespace S {
       mU32ArrayTmp.format("%" PRIu32 "", this->m_mU32Array[i]);
 
       FwSizeType size = mU32ArrayTmp.length() + (i > 0 ? 2 : 0);
-      FwSizeType remaining = mU32ArrayStr.maxLength() - mU32ArrayStr.length();
-      if (size < remaining) {
+      if (size + mU32ArrayStr.length() < mU32ArrayStr.maxLength()) {
         if (i > 0) {
           mU32ArrayStr += ", ";
         }

--- a/compiler/tools/fpp-to-cpp/test/struct/AliasTypeSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/AliasTypeSerializableAc.ref.cpp
@@ -203,7 +203,7 @@ void AliasType ::
     zTmp = this->m_z[i];
 
     FwSizeType size = zTmp.length() + (i > 0 ? 2 : 0);
-    if (size + zStr.length() < zStr.maxLength()) {
+    if ((size + zStr.length()) <= zStr.maxLength()) {
       if (i > 0) {
         zStr += ", ";
       }

--- a/compiler/tools/fpp-to-cpp/test/struct/AliasTypeSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/AliasTypeSerializableAc.ref.cpp
@@ -203,8 +203,7 @@ void AliasType ::
     zTmp = this->m_z[i];
 
     FwSizeType size = zTmp.length() + (i > 0 ? 2 : 0);
-    FwSizeType remaining = zStr.maxLength() - zStr.length();
-    if (size < remaining) {
+    if (size + zStr.length() < zStr.maxLength()) {
       if (i > 0) {
         zStr += ", ";
       }

--- a/compiler/tools/fpp-to-cpp/test/struct/AliasTypeSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/AliasTypeSerializableAc.ref.cpp
@@ -189,38 +189,36 @@ void AliasType ::
     "( "
     "x = %s, "
     "y = %s, "
-    "z = [ %s, "
-    "%s, "
-    "%s, "
-    "%s, "
-    "%s, "
-    "%s, "
-    "%s, "
-    "%s, "
-    "%s, "
-    "%s ]"
+    "z = [ %s ]"
     " )";
 
   // Declare strings to hold any serializable toString() arguments
   Fw::String yStr;
+  Fw::String zStr;
 
   // Call toString for arrays and serializable types
   this->m_y.toString(yStr);
+  for (FwSizeType i = 0; i < 10; i++) {
+    Fw::String zTmp;
+    zTmp = this->m_z[i];
+
+    FwSizeType size = zTmp.length() + (i > 0 ? 2 : 0);
+    FwSizeType remaining = zStr.maxLength() - zStr.length();
+    if (size < remaining) {
+      if (i > 0) {
+        zStr += ", ";
+      }
+      zStr += zTmp;
+    } else {
+      break;
+    }
+  }
 
   sb.format(
     formatString,
     this->m_x,
     yStr.toChar(),
-    this->m_z[0].toChar(),
-    this->m_z[1].toChar(),
-    this->m_z[2].toChar(),
-    this->m_z[3].toChar(),
-    this->m_z[4].toChar(),
-    this->m_z[5].toChar(),
-    this->m_z[6].toChar(),
-    this->m_z[7].toChar(),
-    this->m_z[8].toChar(),
-    this->m_z[9].toChar()
+    zStr.toChar()
   );
 }
 

--- a/compiler/tools/fpp-to-cpp/test/struct/EnumSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/EnumSerializableAc.ref.cpp
@@ -173,7 +173,7 @@ void Enum ::
     this->m_eArr[i].toString(eArrTmp);
 
     FwSizeType size = eArrTmp.length() + (i > 0 ? 2 : 0);
-    if (size + eArrStr.length() < eArrStr.maxLength()) {
+    if ((size + eArrStr.length()) <= eArrStr.maxLength()) {
       if (i > 0) {
         eArrStr += ", ";
       }

--- a/compiler/tools/fpp-to-cpp/test/struct/EnumSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/EnumSerializableAc.ref.cpp
@@ -173,8 +173,7 @@ void Enum ::
     this->m_eArr[i].toString(eArrTmp);
 
     FwSizeType size = eArrTmp.length() + (i > 0 ? 2 : 0);
-    FwSizeType remaining = eArrStr.maxLength() - eArrStr.length();
-    if (size < remaining) {
+    if (size + eArrStr.length() < eArrStr.maxLength()) {
       if (i > 0) {
         eArrStr += ", ";
       }

--- a/compiler/tools/fpp-to-cpp/test/struct/EnumSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/EnumSerializableAc.ref.cpp
@@ -159,27 +159,35 @@ void Enum ::
   static const char* formatString =
     "( "
     "e = %s, "
-    "eArr = [ %s, "
-    "%s, "
-    "%s ]"
+    "eArr = [ %s ]"
     " )";
 
   // Declare strings to hold any serializable toString() arguments
   Fw::String eStr;
-  Fw::String eArrStr[3];
+  Fw::String eArrStr;
 
   // Call toString for arrays and serializable types
   this->m_e.toString(eStr);
   for (FwSizeType i = 0; i < 3; i++) {
-    this->m_eArr[i].toString(eArrStr[i]);
+    Fw::String eArrTmp;
+    this->m_eArr[i].toString(eArrTmp);
+
+    FwSizeType size = eArrTmp.length() + (i > 0 ? 2 : 0);
+    FwSizeType remaining = eArrStr.maxLength() - eArrStr.length();
+    if (size < remaining) {
+      if (i > 0) {
+        eArrStr += ", ";
+      }
+      eArrStr += eArrTmp;
+    } else {
+      break;
+    }
   }
 
   sb.format(
     formatString,
     eStr.toChar(),
-    eArrStr[0].toChar(),
-    eArrStr[1].toChar(),
-    eArrStr[2].toChar()
+    eArrStr.toChar()
   );
 }
 

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules3SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules3SerializableAc.ref.cpp
@@ -173,7 +173,7 @@ void Modules3 ::
     this->m_arr[i].toString(arrTmp);
 
     FwSizeType size = arrTmp.length() + (i > 0 ? 2 : 0);
-    if (size + arrStr.length() < arrStr.maxLength()) {
+    if ((size + arrStr.length()) <= arrStr.maxLength()) {
       if (i > 0) {
         arrStr += ", ";
       }

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules3SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules3SerializableAc.ref.cpp
@@ -159,27 +159,35 @@ void Modules3 ::
   static const char* formatString =
     "( "
     "x = %s, "
-    "arr = [ %s, "
-    "%s, "
-    "%s ]"
+    "arr = [ %s ]"
     " )";
 
   // Declare strings to hold any serializable toString() arguments
   Fw::String xStr;
-  Fw::String arrStr[3];
+  Fw::String arrStr;
 
   // Call toString for arrays and serializable types
   this->m_x.toString(xStr);
   for (FwSizeType i = 0; i < 3; i++) {
-    this->m_arr[i].toString(arrStr[i]);
+    Fw::String arrTmp;
+    this->m_arr[i].toString(arrTmp);
+
+    FwSizeType size = arrTmp.length() + (i > 0 ? 2 : 0);
+    FwSizeType remaining = arrStr.maxLength() - arrStr.length();
+    if (size < remaining) {
+      if (i > 0) {
+        arrStr += ", ";
+      }
+      arrStr += arrTmp;
+    } else {
+      break;
+    }
   }
 
   sb.format(
     formatString,
     xStr.toChar(),
-    arrStr[0].toChar(),
-    arrStr[1].toChar(),
-    arrStr[2].toChar()
+    arrStr.toChar()
   );
 }
 

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules3SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules3SerializableAc.ref.cpp
@@ -173,8 +173,7 @@ void Modules3 ::
     this->m_arr[i].toString(arrTmp);
 
     FwSizeType size = arrTmp.length() + (i > 0 ? 2 : 0);
-    FwSizeType remaining = arrStr.maxLength() - arrStr.length();
-    if (size < remaining) {
+    if (size + arrStr.length() < arrStr.maxLength()) {
       if (i > 0) {
         arrStr += ", ";
       }

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules4SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules4SerializableAc.ref.cpp
@@ -172,40 +172,50 @@ void Modules4 ::
 {
   static const char* formatString =
     "( "
-    "arr1 = [ %s, "
-    "%s, "
-    "%s ], "
-    "arr2 = [ %s, "
-    "%s, "
-    "%s, "
-    "%s, "
-    "%s, "
-    "%s ]"
+    "arr1 = [ %s ], "
+    "arr2 = [ %s ]"
     " )";
 
   // Declare strings to hold any serializable toString() arguments
-  Fw::String arr1Str[3];
-  Fw::String arr2Str[6];
+  Fw::String arr1Str;
+  Fw::String arr2Str;
 
   // Call toString for arrays and serializable types
   for (FwSizeType i = 0; i < 3; i++) {
-    this->m_arr1[i].toString(arr1Str[i]);
+    Fw::String arr1Tmp;
+    this->m_arr1[i].toString(arr1Tmp);
+
+    FwSizeType size = arr1Tmp.length() + (i > 0 ? 2 : 0);
+    FwSizeType remaining = arr1Str.maxLength() - arr1Str.length();
+    if (size < remaining) {
+      if (i > 0) {
+        arr1Str += ", ";
+      }
+      arr1Str += arr1Tmp;
+    } else {
+      break;
+    }
   }
   for (FwSizeType i = 0; i < 6; i++) {
-    this->m_arr2[i].toString(arr2Str[i]);
+    Fw::String arr2Tmp;
+    this->m_arr2[i].toString(arr2Tmp);
+
+    FwSizeType size = arr2Tmp.length() + (i > 0 ? 2 : 0);
+    FwSizeType remaining = arr2Str.maxLength() - arr2Str.length();
+    if (size < remaining) {
+      if (i > 0) {
+        arr2Str += ", ";
+      }
+      arr2Str += arr2Tmp;
+    } else {
+      break;
+    }
   }
 
   sb.format(
     formatString,
-    arr1Str[0].toChar(),
-    arr1Str[1].toChar(),
-    arr1Str[2].toChar(),
-    arr2Str[0].toChar(),
-    arr2Str[1].toChar(),
-    arr2Str[2].toChar(),
-    arr2Str[3].toChar(),
-    arr2Str[4].toChar(),
-    arr2Str[5].toChar()
+    arr1Str.toChar(),
+    arr2Str.toChar()
   );
 }
 

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules4SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules4SerializableAc.ref.cpp
@@ -186,7 +186,7 @@ void Modules4 ::
     this->m_arr1[i].toString(arr1Tmp);
 
     FwSizeType size = arr1Tmp.length() + (i > 0 ? 2 : 0);
-    if (size + arr1Str.length() < arr1Str.maxLength()) {
+    if ((size + arr1Str.length()) <= arr1Str.maxLength()) {
       if (i > 0) {
         arr1Str += ", ";
       }
@@ -200,7 +200,7 @@ void Modules4 ::
     this->m_arr2[i].toString(arr2Tmp);
 
     FwSizeType size = arr2Tmp.length() + (i > 0 ? 2 : 0);
-    if (size + arr2Str.length() < arr2Str.maxLength()) {
+    if ((size + arr2Str.length()) <= arr2Str.maxLength()) {
       if (i > 0) {
         arr2Str += ", ";
       }

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules4SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules4SerializableAc.ref.cpp
@@ -186,8 +186,7 @@ void Modules4 ::
     this->m_arr1[i].toString(arr1Tmp);
 
     FwSizeType size = arr1Tmp.length() + (i > 0 ? 2 : 0);
-    FwSizeType remaining = arr1Str.maxLength() - arr1Str.length();
-    if (size < remaining) {
+    if (size + arr1Str.length() < arr1Str.maxLength()) {
       if (i > 0) {
         arr1Str += ", ";
       }
@@ -201,8 +200,7 @@ void Modules4 ::
     this->m_arr2[i].toString(arr2Tmp);
 
     FwSizeType size = arr2Tmp.length() + (i > 0 ? 2 : 0);
-    FwSizeType remaining = arr2Str.maxLength() - arr2Str.length();
-    if (size < remaining) {
+    if (size + arr2Str.length() < arr2Str.maxLength()) {
       if (i > 0) {
         arr2Str += ", ";
       }

--- a/compiler/tools/fpp-to-cpp/test/struct/PrimitiveSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/PrimitiveSerializableAc.ref.cpp
@@ -310,9 +310,7 @@ void Primitive ::
 {
   static const char* formatString =
     "( "
-    "mF32 = [ %f, "
-    "%f, "
-    "%f ], "
+    "mF32 = [ %s ], "
     "mF64 = %f, "
     "mI16 = %" PRIi16 ", "
     "mI32 = %" PRIi32 ", "
@@ -326,11 +324,29 @@ void Primitive ::
     "m_string = %s"
     " )";
 
+  // Declare strings to hold any serializable toString() arguments
+  Fw::String mF32Str;
+
+  // Call toString for arrays and serializable types
+  for (FwSizeType i = 0; i < 3; i++) {
+    Fw::String mF32Tmp;
+    mF32Tmp.format("%f", static_cast<F64>(this->m_mF32[i]));
+
+    FwSizeType size = mF32Tmp.length() + (i > 0 ? 2 : 0);
+    FwSizeType remaining = mF32Str.maxLength() - mF32Str.length();
+    if (size < remaining) {
+      if (i > 0) {
+        mF32Str += ", ";
+      }
+      mF32Str += mF32Tmp;
+    } else {
+      break;
+    }
+  }
+
   sb.format(
     formatString,
-    static_cast<F64>(this->m_mF32[0]),
-    static_cast<F64>(this->m_mF32[1]),
-    static_cast<F64>(this->m_mF32[2]),
+    mF32Str.toChar(),
     this->m_mF64,
     this->m_mI16,
     this->m_mI32,

--- a/compiler/tools/fpp-to-cpp/test/struct/PrimitiveSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/PrimitiveSerializableAc.ref.cpp
@@ -333,7 +333,7 @@ void Primitive ::
     mF32Tmp.format("%f", static_cast<F64>(this->m_mF32[i]));
 
     FwSizeType size = mF32Tmp.length() + (i > 0 ? 2 : 0);
-    if (size + mF32Str.length() < mF32Str.maxLength()) {
+    if ((size + mF32Str.length()) <= mF32Str.maxLength()) {
       if (i > 0) {
         mF32Str += ", ";
       }

--- a/compiler/tools/fpp-to-cpp/test/struct/PrimitiveSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/PrimitiveSerializableAc.ref.cpp
@@ -333,8 +333,7 @@ void Primitive ::
     mF32Tmp.format("%f", static_cast<F64>(this->m_mF32[i]));
 
     FwSizeType size = mF32Tmp.length() + (i > 0 ? 2 : 0);
-    FwSizeType remaining = mF32Str.maxLength() - mF32Str.length();
-    if (size < remaining) {
+    if (size + mF32Str.length() < mF32Str.maxLength()) {
       if (i > 0) {
         mF32Str += ", ";
       }

--- a/compiler/tools/fpp-to-cpp/test/struct/StringArraySerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/StringArraySerializableAc.ref.cpp
@@ -171,43 +171,33 @@ void StringArray ::
   static const char* formatString =
     "( "
     "s1 = %s, "
-    "s2 = [ %s, "
-    "%s, "
-    "%s, "
-    "%s, "
-    "%s, "
-    "%s, "
-    "%s, "
-    "%s, "
-    "%s, "
-    "%s, "
-    "%s, "
-    "%s, "
-    "%s, "
-    "%s, "
-    "%s, "
-    "%s ]"
+    "s2 = [ %s ]"
     " )";
+
+  // Declare strings to hold any serializable toString() arguments
+  Fw::String s2Str;
+
+  // Call toString for arrays and serializable types
+  for (FwSizeType i = 0; i < 16; i++) {
+    Fw::String s2Tmp;
+    s2Tmp = this->m_s2[i];
+
+    FwSizeType size = s2Tmp.length() + (i > 0 ? 2 : 0);
+    FwSizeType remaining = s2Str.maxLength() - s2Str.length();
+    if (size < remaining) {
+      if (i > 0) {
+        s2Str += ", ";
+      }
+      s2Str += s2Tmp;
+    } else {
+      break;
+    }
+  }
 
   sb.format(
     formatString,
     this->m_s1.toChar(),
-    this->m_s2[0].toChar(),
-    this->m_s2[1].toChar(),
-    this->m_s2[2].toChar(),
-    this->m_s2[3].toChar(),
-    this->m_s2[4].toChar(),
-    this->m_s2[5].toChar(),
-    this->m_s2[6].toChar(),
-    this->m_s2[7].toChar(),
-    this->m_s2[8].toChar(),
-    this->m_s2[9].toChar(),
-    this->m_s2[10].toChar(),
-    this->m_s2[11].toChar(),
-    this->m_s2[12].toChar(),
-    this->m_s2[13].toChar(),
-    this->m_s2[14].toChar(),
-    this->m_s2[15].toChar()
+    s2Str.toChar()
   );
 }
 

--- a/compiler/tools/fpp-to-cpp/test/struct/StringArraySerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/StringArraySerializableAc.ref.cpp
@@ -183,8 +183,7 @@ void StringArray ::
     s2Tmp = this->m_s2[i];
 
     FwSizeType size = s2Tmp.length() + (i > 0 ? 2 : 0);
-    FwSizeType remaining = s2Str.maxLength() - s2Str.length();
-    if (size < remaining) {
+    if (size + s2Str.length() < s2Str.maxLength()) {
       if (i > 0) {
         s2Str += ", ";
       }

--- a/compiler/tools/fpp-to-cpp/test/struct/StringArraySerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/StringArraySerializableAc.ref.cpp
@@ -183,7 +183,7 @@ void StringArray ::
     s2Tmp = this->m_s2[i];
 
     FwSizeType size = s2Tmp.length() + (i > 0 ? 2 : 0);
-    if (size + s2Str.length() < s2Str.maxLength()) {
+    if ((size + s2Str.length()) <= s2Str.maxLength()) {
       if (i > 0) {
         s2Str += ", ";
       }


### PR DESCRIPTION
This cleans up `toString()` for struct member arrays by concatenating a string to format the array. I ran FppTest in addition to our normal testing to validate the toString() formatting still matches.

Closes #689 