### PR TITLE
Fix F' config include path

### DIFF
--- a/compiler/scripts/fprime-gcc
+++ b/compiler/scripts/fprime-gcc
@@ -2,7 +2,7 @@
 
 # ======================================================================
 # Compile F Prime source files
-# ---------------------------------------------------------------------- 
+# ----------------------------------------------------------------------
 # Setup:
 #
 # 1. Set FPRIME to point to the root of your F Prime working repo
@@ -48,7 +48,7 @@ g++ --std=c++11 \
   $os_flags \
   -DTGT_OS_TYPE_$os_type \
   -I $FPRIME \
-  -I $FPRIME/config \
+  -I $FPRIME/default \
   -I $FPRIME/cmake/platform/types \
   -I . \
   $FPRIME_GCC_FLAGS \

--- a/compiler/tools/fpp-to-cpp/test/component/compile_base_cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/compile_base_cpp
@@ -4,7 +4,7 @@
 # Compile base class C++ files with guards for conditional compilation
 #
 # By default, each file is compiled with three different sets of values of F
-# Prime guards: 
+# Prime guards:
 # - Default values as found in fprime/config/FpConfig.h
 # - All guards turned on
 # - All guards turned off (except FW_PORT_SERIALIZATION for components
@@ -29,7 +29,7 @@ done
 fprime_gcc=../../../../../scripts/fprime-gcc
 
 # Set compiler flags
-include_flags="-I.. -I../.. -I../../fprime -I../../fprime/config"
+include_flags="-I.. -I../.. -I../../fprime -I../../fprime/default"
 # F Prime components sometimes provide parameter arguments that are unused
 # F Prime components use variable-length arrays for managing buffers
 warning_flags="

--- a/compiler/tools/fpp-to-cpp/test/component/compile_base_cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/compile_base_cpp
@@ -29,7 +29,7 @@ done
 fprime_gcc=../../../../../scripts/fprime-gcc
 
 # Set compiler flags
-include_flags="-I.. -I../.. -I../../fprime -I../../fprime/default"
+include_flags="-I.. -I../.. -I../../fprime"
 # F Prime components sometimes provide parameter arguments that are unused
 # F Prime components use variable-length arrays for managing buffers
 warning_flags="


### PR DESCRIPTION
This fixes the include path change that was made in https://github.com/nasa/fprime/pull/3563.

Without this fix I get numerous compilation errors when running `fpp-to-cpp/test/check-cpp`

```sh
compiling AArrayAc.cpp with default guards
In file included from /home/campuzan/projects/fprime/Fw/Types/BasicTypes.hpp:14,
                 from /home/campuzan/projects/fprime/Fw/FPrimeBasicTypes.h:24,
                 from /home/campuzan/projects/fprime/Fw/FPrimeBasicTypes.hpp:21,
                 from /home/campuzan/projects/fprime/Fw/Types/Assert.hpp:4,
                 from AArrayAc.cpp:7:
/home/campuzan/projects/fprime/Fw/Types/BasicTypes.h:41:10: fatal error: config/FPrimeNumericalConfig.h: No such file or directory
   41 | #include <config/FPrimeNumericalConfig.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```