### PR TITLE
Implement interfaces syntax

### DIFF
--- a/compiler/lib/src/main/scala/ast/Ast.scala
+++ b/compiler/lib/src/main/scala/ast/Ast.scala
@@ -69,6 +69,7 @@ object Ast {
     final case class SpecRecord(node: AstNode[Ast.SpecRecord]) extends Node
     final case class SpecStateMachineInstance(node: AstNode[Ast.SpecStateMachineInstance]) extends Node
     final case class SpecTlmChannel(node: AstNode[Ast.SpecTlmChannel]) extends Node
+    final case class SpecImportInterface(node: AstNode[Ast.SpecImport]) extends Node
   }
 
   /** Abstract type definition */
@@ -144,6 +145,7 @@ object Ast {
     final case class DefComponentInstance(node: AstNode[Ast.DefComponentInstance]) extends Node
     final case class DefConstant(node: AstNode[Ast.DefConstant]) extends Node
     final case class DefEnum(node: AstNode[Ast.DefEnum]) extends Node
+    final case class DefInterface(node: AstNode[Ast.DefInterface]) extends Node
     final case class DefModule(node: AstNode[Ast.DefModule]) extends Node
     final case class DefPort(node: AstNode[Ast.DefPort]) extends Node
     final case class DefStateMachine(node: AstNode[Ast.DefStateMachine]) extends Node
@@ -259,6 +261,20 @@ object Ast {
     final case class Do(actions: List[AstNode[Ident]]) extends TransitionOrDo
   }
 
+  /** Interface member */
+  final case class InterfaceMember(node: Annotated[InterfaceMember.Node])
+  object InterfaceMember {
+    sealed trait Node
+    final case class SpecPortInstance(node: AstNode[Ast.SpecPortInstance]) extends Node
+    final case class SpecImportInterface(node: AstNode[Ast.SpecImport]) extends Node
+  }
+
+  /** Interface definition */
+  final case class DefInterface(
+    name: Ident,
+    members: List[InterfaceMember]
+  )
+
   /** Struct definition */
   final case class DefStruct(
     name: Ident,
@@ -294,7 +310,7 @@ object Ast {
     final case class SpecConnectionGraph(node: AstNode[Ast.SpecConnectionGraph]) extends Node
     final case class SpecInclude(node: AstNode[Ast.SpecInclude]) extends Node
     final case class SpecTlmPacketSet(node: AstNode[Ast.SpecTlmPacketSet]) extends Node
-    final case class SpecTopImport(node: AstNode[Ast.SpecTopImport]) extends Node
+    final case class SpecTopImport(node: AstNode[Ast.SpecImport]) extends Node
   }
 
   /** Formal parameter */
@@ -582,6 +598,9 @@ object Ast {
     case object Type extends Kind {
       override def toString = "type"
     }
+    case object Interface extends Kind {
+      override def toString = "interface"
+    }
   }
 
   /** Parameter specifier */
@@ -763,8 +782,8 @@ object Ast {
     omitted: List[AstNode[TlmChannelIdentifier]]
   )
 
-  /** Topology import specifier */
-  final case class SpecTopImport(top: AstNode[QualIdent])
+  /** Import specifier */
+  final case class SpecImport(sym: AstNode[QualIdent])
 
   /** Struct member */
   final case class StructMember(name: Ident, value: AstNode[Expr])

--- a/compiler/lib/src/main/scala/ast/AstTransformer.scala
+++ b/compiler/lib/src/main/scala/ast/AstTransformer.scala
@@ -40,6 +40,9 @@ trait AstTransformer {
     node: Ast.Annotated[AstNode[Ast.DefComponentInstance]]
   ): ResultAnnotatedNode[Ast.DefComponentInstance] = Right(default(in), node)
 
+  def defInterfaceAnnotatedNode(in: In, node: Ast.Annotated[AstNode[Ast.DefInterface]]): ResultAnnotatedNode[Ast.DefInterface] =
+    Right(default(in), node)
+
   def defConstantAnnotatedNode(
     in: In,
     node: Ast.Annotated[AstNode[Ast.DefConstant]]
@@ -195,8 +198,13 @@ trait AstTransformer {
 
   def specTopImportAnnotatedNode(
     in: In,
-    node: Ast.Annotated[AstNode[Ast.SpecTopImport]]
-  ): ResultAnnotatedNode[Ast.SpecTopImport] = Right(default(in), node)
+    node: Ast.Annotated[AstNode[Ast.SpecImport]]
+  ): ResultAnnotatedNode[Ast.SpecImport] = Right(default(in), node)
+
+  def specInterfaceImportAnnotatedNode(
+    in: In,
+    node: Ast.Annotated[AstNode[Ast.SpecImport]]
+  ): ResultAnnotatedNode[Ast.SpecImport] = Right(default(in), node)
 
   def transUnit(in: In, tu: Ast.TransUnit): Result[Ast.TransUnit] =
     Right(default(in), tu)
@@ -264,6 +272,27 @@ trait AstTransformer {
         transform(specStateMachineInstanceAnnotatedNode(in, (pre, node1, post)), Ast.ComponentMember.SpecStateMachineInstance(_))
       case Ast.ComponentMember.SpecTlmChannel(node1) =>
         transform(specTlmChannelAnnotatedNode(in, (pre, node1, post)), Ast.ComponentMember.SpecTlmChannel(_))
+      case Ast.ComponentMember.SpecImportInterface(node1) =>
+        transform(specInterfaceImportAnnotatedNode(in, (pre, node1, post)), Ast.ComponentMember.SpecImportInterface(_))
+    }
+  }
+
+  final def matchInterfaceMember(in: In, member: Ast.InterfaceMember): Result[Ast.InterfaceMember] = {
+    def transform[T](
+      result: ResultAnnotatedNode[T],
+      f: AstNode[T] => Ast.InterfaceMember.Node
+    ) = {
+      for { pair <- result } yield {
+        val (out, (pre, node, post)) = pair
+        (out, Ast.InterfaceMember(pre, f(node), post))
+      }
+    }
+    val (pre, node, post) =  member.node
+    node match {
+      case Ast.InterfaceMember.SpecPortInstance(node1) =>
+        transform(specPortInstanceAnnotatedNode(in, (pre, node1, post)), Ast.InterfaceMember.SpecPortInstance(_))
+      case Ast.InterfaceMember.SpecImportInterface(node1) =>
+        transform(specInterfaceImportAnnotatedNode(in, (pre, node1, post)), Ast.InterfaceMember.SpecImportInterface(_))
     }
   }
 
@@ -304,6 +333,8 @@ trait AstTransformer {
         transform(defComponentAnnotatedNode(in, (pre, node1, post)), Ast.ModuleMember.DefComponent(_))
       case Ast.ModuleMember.DefComponentInstance(node1) =>
         transform(defComponentInstanceAnnotatedNode(in, (pre, node1, post)), Ast.ModuleMember.DefComponentInstance(_))
+      case Ast.ModuleMember.DefInterface(node1) =>
+        transform(defInterfaceAnnotatedNode(in, (pre, node1, post)), Ast.ModuleMember.DefInterface(_))
       case Ast.ModuleMember.DefConstant(node1) =>
         transform(defConstantAnnotatedNode(in, (pre, node1, post)), Ast.ModuleMember.DefConstant(_))
       case Ast.ModuleMember.DefEnum(node1) =>

--- a/compiler/lib/src/main/scala/ast/AstVisitor.scala
+++ b/compiler/lib/src/main/scala/ast/AstVisitor.scala
@@ -21,6 +21,8 @@ trait AstVisitor {
 
   def defComponentAnnotatedNode(in: In, node: Ast.Annotated[AstNode[Ast.DefComponent]]): Out = default(in)
 
+  def defInterfaceAnnotatedNode(in: In, node: Ast.Annotated[AstNode[Ast.DefInterface]]): Out = default(in)
+
   def defComponentInstanceAnnotatedNode(in: In, node: Ast.Annotated[AstNode[Ast.DefComponentInstance]]): Out = default(in)
 
   def defConstantAnnotatedNode(in: In, node: Ast.Annotated[AstNode[Ast.DefConstant]]): Out = default(in)
@@ -122,7 +124,9 @@ trait AstVisitor {
 
   def specTlmPacketSetAnnotatedNode(in: In, node: Ast.Annotated[AstNode[Ast.SpecTlmPacketSet]]): Out = default(in)
 
-  def specTopImportAnnotatedNode(in: In, node: Ast.Annotated[AstNode[Ast.SpecTopImport]]): Out = default(in)
+  def specTopImportAnnotatedNode(in: In, node: Ast.Annotated[AstNode[Ast.SpecImport]]): Out = default(in)
+
+  def specInterfaceImportAnnotatedNode(in: In, node: Ast.Annotated[AstNode[Ast.SpecImport]]): Out = default(in)
 
   def transUnit(in: In, tu: Ast.TransUnit): Out = default(in)
 
@@ -157,6 +161,15 @@ trait AstVisitor {
       case Ast.ComponentMember.SpecRecord(node1) => specRecordAnnotatedNode(in, (pre, node1, post))
       case Ast.ComponentMember.SpecStateMachineInstance(node1) => specStateMachineInstanceAnnotatedNode(in, (pre, node1, post))
       case Ast.ComponentMember.SpecTlmChannel(node1) => specTlmChannelAnnotatedNode(in, (pre, node1, post))
+      case Ast.ComponentMember.SpecImportInterface(node1) => specInterfaceImportAnnotatedNode(in, (pre, node1, post))
+    }
+  }
+
+  final def matchInterfaceMember(in: In, member: Ast.InterfaceMember): Out = {
+    val (pre, node, post) =  member.node
+    node match {
+      case Ast.InterfaceMember.SpecPortInstance(node1) => specPortInstanceAnnotatedNode(in, (pre, node1, post))
+      case Ast.InterfaceMember.SpecImportInterface(node1) => specInterfaceImportAnnotatedNode(in, (pre, node1, post))
     }
   }
 
@@ -182,6 +195,7 @@ trait AstVisitor {
       case Ast.ModuleMember.DefAliasType(node1) => defAliasTypeAnnotatedNode(in, (pre, node1, post))
       case Ast.ModuleMember.DefArray(node1) => defArrayAnnotatedNode(in, (pre, node1, post))
       case Ast.ModuleMember.DefComponent(node1) => defComponentAnnotatedNode(in, (pre, node1, post))
+      case Ast.ModuleMember.DefInterface(node1) => defInterfaceAnnotatedNode(in, (pre, node1, post))
       case Ast.ModuleMember.DefComponentInstance(node1) => defComponentInstanceAnnotatedNode(in, (pre, node1, post))
       case Ast.ModuleMember.DefConstant(node1) => defConstantAnnotatedNode(in, (pre, node1, post))
       case Ast.ModuleMember.DefEnum(node1) => defEnumAnnotatedNode(in, (pre, node1, post))

--- a/compiler/lib/src/main/scala/syntax/Lexer.scala
+++ b/compiler/lib/src/main/scala/syntax/Lexer.scala
@@ -72,6 +72,7 @@ object Lexer {
     ("initial", INITIAL),
     ("input", INPUT),
     ("instance", INSTANCE),
+    ("interface", INTERFACE),
     ("internal", INTERNAL),
     ("locate", LOCATE),
     ("low", LOW),
@@ -271,6 +272,7 @@ object Lexer {
         case INITIAL => Token.INITIAL()
         case INPUT => Token.INPUT()
         case INSTANCE => Token.INSTANCE()
+        case INTERFACE => Token.INTERFACE()
         case INTERNAL => Token.INTERNAL()
         case CHOICE => Token.CHOICE()
         case LBRACE => Token.LBRACE()

--- a/compiler/lib/src/main/scala/syntax/Token.scala
+++ b/compiler/lib/src/main/scala/syntax/Token.scala
@@ -64,6 +64,7 @@ object Token {
   final case class INITIAL() extends Token
   final case class INPUT() extends Token
   final case class INSTANCE() extends Token
+  final case class INTERFACE() extends Token
   final case class INTERNAL() extends Token
   final case class CHOICE() extends Token
   final case class LBRACE() extends Token
@@ -208,6 +209,7 @@ enum TokenId {
   case INITIAL
   case INPUT
   case INSTANCE
+  case INTERFACE
   case INTERNAL
   case CHOICE
   case LOCATE


### PR DESCRIPTION
Implements the syntax for interfaces.

Generalized the SpecTopImport AST Node type into a SpecImport so that we could reuse the same grammar rule in both types of imports. The nodes themselves are still different in the final AST so that visitors don't need additional context.

Closes #698 
