### PR TITLE
FPP to build on cloud aarch64 instance

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -108,16 +108,15 @@ jobs:
                 "runner": "ubuntu-22.04",
                 "tag": "manylinux_2_28_x86_64",
                 "container": "quay.io/pypa/manylinux_2_28_x86_64"
+              },
+              {
+                "runner": "ubuntu-22.04-arm",
+                "tag": "manylinux_2_28_aarch64",
+                "container": "quay.io/pypa/manylinux_2_28_aarch64"
               }
+              
             ]
           }
-          if "${{ github.event_name }}" == 'release':
-            matrix["run"].append(
-              {
-                "runner": "odroid",
-                "tag": "manylinux_2_28_aarch64"
-              }
-            )
           tags = {"tag": ["jar"] + [run["tag"] for run in matrix["run"]]}
           with open(os.environ["GITHUB_OUTPUT"], "a") as file_handle:
             for file_stream in [sys.stdout, file_handle]:


### PR DESCRIPTION
This will update the FPP action that builds native images to run on aarch64 via cloud-hosting instead or requiring the odroid runner.  This will bring those packages more inline with standard packages.

Closes #713