### PR TITLE
Require DP constants and enums in dictionary

### DIFF
--- a/compiler/lib/src/main/scala/analysis/Analysis.scala
+++ b/compiler/lib/src/main/scala/analysis/Analysis.scala
@@ -73,8 +73,8 @@ case class Analysis(
   tlmPacketSet: Option[TlmPacketSet] = None,
   /** Whether a dictionary is needed in code generation */
   dictionaryNeeded: Boolean = false,
-  /** The set of alias type symbols used by the dictionary */
-  dictionaryAliasSymbolSet: Set[Symbol] = Set(),
+  /** The set of type symbols used by the dictionary */
+  dictionaryTypeSymbolSet: Set[Symbol] = Set(),
   /** The set of constant symbols used by the dictionary */
   dictionaryConstantSymbolSet: Set[Symbol] = Set(),
   /** The set of enum symbols used by the dictionary */

--- a/compiler/lib/src/main/scala/analysis/Analysis.scala
+++ b/compiler/lib/src/main/scala/analysis/Analysis.scala
@@ -73,8 +73,12 @@ case class Analysis(
   tlmPacketSet: Option[TlmPacketSet] = None,
   /** Whether a dictionary is needed in code generation */
   dictionaryNeeded: Boolean = false,
-  /** The set of type symbols used by the dictionary */
-  dictionaryTypeSymbolSet: Set[Symbol] = Set()
+  /** The set of integer symbols used by the dictionary */
+  dictionaryIntegerSymbolSet: Set[Symbol] = Set(),
+  /** The set of constant symbols used by the dictionary */
+  dictionaryConstantSymbolSet: Set[Symbol] = Set(),
+  /** The set of enum symbols used by the dictionary */
+  dictionaryEnumSymbolSet: Set[Symbol] = Set()
 ) {
 
   /** Gets the qualified name of a symbol */

--- a/compiler/lib/src/main/scala/analysis/Analysis.scala
+++ b/compiler/lib/src/main/scala/analysis/Analysis.scala
@@ -73,8 +73,8 @@ case class Analysis(
   tlmPacketSet: Option[TlmPacketSet] = None,
   /** Whether a dictionary is needed in code generation */
   dictionaryNeeded: Boolean = false,
-  /** The set of integer symbols used by the dictionary */
-  dictionaryIntegerSymbolSet: Set[Symbol] = Set(),
+  /** The set of alias type symbols used by the dictionary */
+  dictionaryAliasSymbolSet: Set[Symbol] = Set(),
   /** The set of constant symbols used by the dictionary */
   dictionaryConstantSymbolSet: Set[Symbol] = Set(),
   /** The set of enum symbols used by the dictionary */

--- a/compiler/lib/src/main/scala/analysis/CheckSemantics/CheckUses.scala
+++ b/compiler/lib/src/main/scala/analysis/CheckSemantics/CheckUses.scala
@@ -120,7 +120,7 @@ object CheckUses extends UseAnalyzer {
   override def defTopologyAnnotatedNode(a: Analysis, node: Ast.Annotated[AstNode[Ast.DefTopology]]) = {
     a.dictionaryNeeded match {
       case true => {
-        val impliedAliasTypeUses = List(
+        val impliedTypeUses = List(
           List("FwChanIdType"),
           List("FwDpIdType"),
           List("FwDpPriorityType"),  
@@ -169,12 +169,12 @@ object CheckUses extends UseAnalyzer {
         }
 
         for {
-          s1 <- checkImpliedUses(impliedAliasTypeUses, node1.id, "alias", NameGroup.Type)
+          s1 <- checkImpliedUses(impliedTypeUses, node1.id, "alias", NameGroup.Type)
           s2 <- checkImpliedUses(impliedEnumUses, node1.id, "enum", NameGroup.Type)
           s3 <- checkImpliedUses(impliedConstantUses, node1.id, "constant", NameGroup.Value)
           a <- super.defTopologyAnnotatedNode(a, node)
         } yield a.copy(
-            dictionaryAliasSymbolSet = a.dictionaryAliasSymbolSet ++ s1,
+            dictionaryTypeSymbolSet = a.dictionaryTypeSymbolSet ++ s1,
             dictionaryEnumSymbolSet = a.dictionaryEnumSymbolSet ++ s2,
             dictionaryConstantSymbolSet = a.dictionaryConstantSymbolSet ++ s3
           )

--- a/compiler/lib/src/main/scala/analysis/CheckSemantics/CheckUses.scala
+++ b/compiler/lib/src/main/scala/analysis/CheckSemantics/CheckUses.scala
@@ -128,6 +128,7 @@ object CheckUses extends UseAnalyzer {
           List("FwOpcodeType"), 
           List("FwPacketDescriptorType"), 
           List("FwSizeType"),
+          List("FwSizeStoreType"),
           List("FwTimeBaseStoreType"),
           List("FwTimeContextStoreType"),
           List("FwTlmPacketizeIdType")

--- a/compiler/lib/src/main/scala/analysis/CheckSemantics/CheckUses.scala
+++ b/compiler/lib/src/main/scala/analysis/CheckSemantics/CheckUses.scala
@@ -123,10 +123,10 @@ object CheckUses extends UseAnalyzer {
         val impliedTypeUses = List(
           List("FwChanIdType"),
           List("FwDpIdType"),
-          List("FwDpPriorityType"),  
-          List("FwEventIdType"), 
-          List("FwOpcodeType"), 
-          List("FwPacketDescriptorType"), 
+          List("FwDpPriorityType"),
+          List("FwEventIdType"),
+          List("FwOpcodeType"),
+          List("FwPacketDescriptorType"),
           List("FwSizeType"),
           List("FwSizeStoreType"),
           List("FwTimeBaseStoreType"),
@@ -142,7 +142,7 @@ object CheckUses extends UseAnalyzer {
         )
         val (_, node1, _) = node
         def checkImpliedUses(
-          impliedUses: List[List[String]], 
+          impliedUses: List[List[String]],
           id: AstNode.Id,
           typeName: String,
           ng: NameGroup
@@ -155,7 +155,7 @@ object CheckUses extends UseAnalyzer {
               symbol <- impliedUse.data match {
                 case Ast.QualIdent.Unqualified(name) =>
                   Result.annotateResult(
-                    helpers.getSymbolForName(a.nestedScope.get (ng) _)(id, name), 
+                    helpers.getSymbolForName(a.nestedScope.get (ng) _)(id, name),
                     s"when constructing a dictionary, the $typeName $name must be defined"
                   )
                 case Ast.QualIdent.Qualified(qualifier, name) =>

--- a/compiler/lib/src/main/scala/analysis/CheckSemantics/CheckUses.scala
+++ b/compiler/lib/src/main/scala/analysis/CheckSemantics/CheckUses.scala
@@ -173,7 +173,7 @@ object CheckUses extends UseAnalyzer {
           s3 <- checkImpliedUses(impliedConstantUses, node1.id, "constant", NameGroup.Value)
           a <- super.defTopologyAnnotatedNode(a, node)
         } yield a.copy(
-            dictionaryIntegerSymbolSet = a.dictionaryIntegerSymbolSet ++ s1,
+            dictionaryAliasSymbolSet = a.dictionaryAliasSymbolSet ++ s1,
             dictionaryEnumSymbolSet = a.dictionaryEnumSymbolSet ++ s2,
             dictionaryConstantSymbolSet = a.dictionaryConstantSymbolSet ++ s3
           )

--- a/compiler/lib/src/main/scala/analysis/CheckSemantics/CheckUsesHelpers.scala
+++ b/compiler/lib/src/main/scala/analysis/CheckSemantics/CheckUsesHelpers.scala
@@ -52,7 +52,7 @@ case class CheckUsesHelpers[A,NG,S <: SymbolInterface](
     }
   }
 
-  private def visitQualifiedName (ng: NG) (
+  def getSymbolForQualifiedName (ng: NG) (
     a: A,
     id: AstNode.Id,
     qualifier: AstNode[Ast.QualIdent],
@@ -77,6 +77,18 @@ case class CheckUsesHelpers[A,NG,S <: SymbolInterface](
         val mapping = scope.get (ng) _
         getSymbolForName(mapping)(name.id, name.data)
       }
+    }
+    yield symbol
+
+  private def visitQualifiedName (ng: NG) (
+    a: A,
+    id: AstNode.Id,
+    qualifier: AstNode[Ast.QualIdent],
+    name: AstNode[Ast.Ident]
+  ) =
+    for {
+      a <- visitQualIdentNode (ng) (a, qualifier)
+      symbol <- getSymbolForQualifiedName (ng) (a, id, qualifier, name)
     }
     yield {
       val useDefMap = getUseDefMap(a) + (id -> symbol)

--- a/compiler/lib/src/main/scala/analysis/CheckSemantics/ConstructDictionaryMap.scala
+++ b/compiler/lib/src/main/scala/analysis/CheckSemantics/ConstructDictionaryMap.scala
@@ -33,7 +33,7 @@ object ConstructDictionaryMap
     val a1 = a.copy(topology = Some(t), dictionary = Some(d))
     for {
       a <- checkIntegerType(a.dictionaryTypeSymbolSet, "this F Prime framework type must be an alias of an integer type")
-      a <- checkIntegerType(a.dictionaryConstantSymbolSet, "this F Prime constant must have an integer type")
+      a <- checkIntegerType(a.dictionaryConstantSymbolSet, "this F Prime framework constant must have an integer type")
       a <- super.defTopologyAnnotatedNode(a1, aNode)
     }
     yield {

--- a/compiler/lib/src/main/scala/analysis/CheckSemantics/ConstructDictionaryMap.scala
+++ b/compiler/lib/src/main/scala/analysis/CheckSemantics/ConstructDictionaryMap.scala
@@ -32,8 +32,8 @@ object ConstructDictionaryMap
     }
     val a1 = a.copy(topology = Some(t), dictionary = Some(d))
     for {
-      a <- checkIntegerType(a.dictionaryAliasSymbolSet, "this F Prime framework type must be an alias of an integer type")
-      a <- checkIntegerType(a.dictionaryConstantSymbolSet, "this F Prime framework type must be a constant with a value of integer type")
+      a <- checkIntegerType(a.dictionaryTypeSymbolSet, "this F Prime framework type must be an alias of an integer type")
+      a <- checkIntegerType(a.dictionaryConstantSymbolSet, "this F Prime constant must have an integer type")
       a <- super.defTopologyAnnotatedNode(a1, aNode)
     }
     yield {

--- a/compiler/lib/src/main/scala/analysis/CheckSemantics/ConstructDictionaryMap.scala
+++ b/compiler/lib/src/main/scala/analysis/CheckSemantics/ConstructDictionaryMap.scala
@@ -32,7 +32,7 @@ object ConstructDictionaryMap
     }
     val a1 = a.copy(topology = Some(t), dictionary = Some(d))
     for {
-      a <- checkIntegerType(a.dictionaryIntegerSymbolSet, "this F Prime framework type must be an alias of an integer type")
+      a <- checkIntegerType(a.dictionaryAliasSymbolSet, "this F Prime framework type must be an alias of an integer type")
       a <- checkIntegerType(a.dictionaryConstantSymbolSet, "this F Prime framework type must be a constant with a value of integer type")
       a <- super.defTopologyAnnotatedNode(a1, aNode)
     }

--- a/compiler/lib/src/main/scala/analysis/Semantics/ConstructDictionary/DictionaryUsedSymbols.scala
+++ b/compiler/lib/src/main/scala/analysis/Semantics/ConstructDictionary/DictionaryUsedSymbols.scala
@@ -9,7 +9,10 @@ final case class DictionaryUsedSymbols(a: Analysis, t: Topology) {
     d.copy(usedSymbolSet = getUsedSymbolSet)
 
   private def getUsedSymbolSet: Set[Symbol] =
-    t.instanceMap.keys.toSet.flatMap(getUsedSymbolsForInstance) ++ a.dictionaryTypeSymbolSet
+    t.instanceMap.keys.toSet.flatMap(getUsedSymbolsForInstance) 
+      ++ a.dictionaryIntegerSymbolSet 
+      ++ a.dictionaryConstantSymbolSet 
+      ++ a.dictionaryEnumSymbolSet
 
   private def getUsedSymbolsForInstance(ci: ComponentInstance) = {
     val component = ci.component

--- a/compiler/lib/src/main/scala/analysis/Semantics/ConstructDictionary/DictionaryUsedSymbols.scala
+++ b/compiler/lib/src/main/scala/analysis/Semantics/ConstructDictionary/DictionaryUsedSymbols.scala
@@ -10,7 +10,7 @@ final case class DictionaryUsedSymbols(a: Analysis, t: Topology) {
 
   private def getUsedSymbolSet: Set[Symbol] =
     t.instanceMap.keys.toSet.flatMap(getUsedSymbolsForInstance) 
-      ++ a.dictionaryIntegerSymbolSet 
+      ++ a.dictionaryAliasSymbolSet 
       ++ a.dictionaryConstantSymbolSet 
       ++ a.dictionaryEnumSymbolSet
 

--- a/compiler/lib/src/main/scala/analysis/Semantics/ConstructDictionary/DictionaryUsedSymbols.scala
+++ b/compiler/lib/src/main/scala/analysis/Semantics/ConstructDictionary/DictionaryUsedSymbols.scala
@@ -10,7 +10,7 @@ final case class DictionaryUsedSymbols(a: Analysis, t: Topology) {
 
   private def getUsedSymbolSet: Set[Symbol] =
     t.instanceMap.keys.toSet.flatMap(getUsedSymbolsForInstance) 
-      ++ a.dictionaryAliasSymbolSet 
+      ++ a.dictionaryTypeSymbolSet 
       ++ a.dictionaryConstantSymbolSet 
       ++ a.dictionaryEnumSymbolSet
 

--- a/compiler/lib/src/main/scala/codegen/DictionaryJsonWriter/DictionaryJsonEncoder.scala
+++ b/compiler/lib/src/main/scala/codegen/DictionaryJsonWriter/DictionaryJsonEncoder.scala
@@ -568,7 +568,7 @@ case class DictionaryJsonEncoder(
     def dictionaryAsJson: Json = {
         /** Split set into individual sets consisting of each symbol type (arrays, enums, structs, aliases, and constants) */
         val typeDefSymbols = getTypeDefSymbols(dictionary.usedSymbolSet, Set())
-        val constantSymbols = getConstantSymbolSet(dictionary.usedSymbolSet, Set())
+        val constantSymbols = getConstantSymbols(dictionary.usedSymbolSet, Set())
         /** Convert each dictionary element to JSON and return the complete dictionary JSON */
         Json.obj(
             "metadata" -> dictionaryState.metadata.asJson,
@@ -632,13 +632,13 @@ case class DictionaryJsonEncoder(
     }
 
     /** Given a set of symbols, returns subset consisting of constant symbols only */
-    private def getConstantSymbolSet(symbolSet: Set[Symbol], outSet: Set[Symbol]): (Set[Symbol]) = {
+    private def getConstantSymbols(symbolSet: Set[Symbol], outSet: Set[Symbol]): (Set[Symbol]) = {
         if (symbolSet.isEmpty) (outSet) else {
             val (tail, out) = symbolSet.head match {
                 case h: (Symbol.Constant) => (symbolSet.tail, outSet + h)
                 case _ => (symbolSet.tail, outSet)
             }
-            getConstantSymbolSet(tail, out)
+            getConstantSymbols(tail, out)
         }
     }
 

--- a/compiler/tools/fpp-to-dict/test/dictionary.schema.json
+++ b/compiler/tools/fpp-to-dict/test/dictionary.schema.json
@@ -148,6 +148,46 @@
                 }
             }
         },
+        "constants": {
+            "type": "array",
+            "items": {
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "kind": {
+                                "type": "string",
+                                "enum": [
+                                    "constant"
+                                ]
+                            },
+                            "qualifiedName": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "$ref": "#/$defs/typeDescriptor"
+                            },
+                            "value": {
+                                "type": [
+                                    "boolean",
+                                    "number",
+                                    "string"
+                                ]
+                            },
+                            "annotation": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "kind",
+                            "qualifiedName",
+                            "type",
+                            "value"
+                        ]
+                    }
+                ]
+            }
+        },
         "typeDefinitions": {
             "type": "array",
             "items": {

--- a/compiler/tools/fpp-to-dict/test/top/BasicDpTopologyDictionary.ref.json
+++ b/compiler/tools/fpp-to-dict/test/top/BasicDpTopologyDictionary.ref.json
@@ -57,7 +57,7 @@
     },
     {
       "kind" : "enum",
-      "qualifiedName" : "ProcType",
+      "qualifiedName" : "Fw.DpState",
       "representationType" : {
         "name" : "U8",
         "kind" : "integer",
@@ -66,23 +66,22 @@
       },
       "enumeratedConstants" : [
         {
-          "name" : "PROC_TYPE_ZERO",
+          "name" : "UNTRANSMITTED",
+          "value" : 0,
+          "annotation" : "The untransmitted state"
+        },
+        {
+          "name" : "PARTIAL",
           "value" : 1,
-          "annotation" : "Processing type 0"
+          "annotation" : "The partially transmitted state\nA data product is in this state from the start of transmission\nuntil transmission is complete."
         },
         {
-          "name" : "PROC_TYPE_ONE",
+          "name" : "TRANSMITTED",
           "value" : 2,
-          "annotation" : "Processing type 1"
-        },
-        {
-          "name" : "PROC_TYPE_TWO",
-          "value" : 4,
-          "annotation" : "Processing type 2"
+          "annotation" : "The transmitted state"
         }
       ],
-      "default" : "ProcType.PROC_TYPE_ZERO",
-      "annotation" : "A bit mask for selecting the type of processing to perform on\na container before writing it to disk."
+      "default" : "Fw.DpState.UNTRANSMITTED"
     },
     {
       "kind" : "alias",
@@ -150,16 +149,49 @@
       }
     },
     {
-      "kind" : "constant",
-      "qualifiedName" : "CONTAINER_USER_DATA_SIZE",
-      "type" : {
-        "name" : "U64",
+      "kind" : "enum",
+      "qualifiedName" : "Fw.DpCfg.ProcType",
+      "representationType" : {
+        "name" : "U8",
         "kind" : "integer",
-        "size" : 64,
+        "size" : 8,
         "signed" : false
       },
-      "value" : 1,
-      "annotation" : "The container user data size"
+      "enumeratedConstants" : [
+        {
+          "name" : "PROC_TYPE_ZERO",
+          "value" : 1,
+          "annotation" : "Processing type 0"
+        },
+        {
+          "name" : "PROC_TYPE_ONE",
+          "value" : 2,
+          "annotation" : "Processing type 1"
+        },
+        {
+          "name" : "PROC_TYPE_TWO",
+          "value" : 4,
+          "annotation" : "Processing type 2"
+        }
+      ],
+      "default" : "Fw.DpCfg.ProcType.PROC_TYPE_ZERO",
+      "annotation" : "A bit mask for selecting the type of processing to perform on\na container before writing it to disk."
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FwPacketDescriptorType",
+      "type" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      }
     },
     {
       "kind" : "alias",
@@ -193,50 +225,6 @@
         "size" : 32,
         "signed" : false
       }
-    },
-    {
-      "kind" : "alias",
-      "qualifiedName" : "FwPacketDescriptorType",
-      "type" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
-      },
-      "underlyingType" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
-      }
-    },
-    {
-      "kind" : "enum",
-      "qualifiedName" : "DpState",
-      "representationType" : {
-        "name" : "U8",
-        "kind" : "integer",
-        "size" : 8,
-        "signed" : false
-      },
-      "enumeratedConstants" : [
-        {
-          "name" : "UNTRANSMITTED",
-          "value" : 0,
-          "annotation" : "The untransmitted state"
-        },
-        {
-          "name" : "PARTIAL",
-          "value" : 1,
-          "annotation" : "The partially transmitted state\nA data product is in this state from the start of transmission\nuntil transmission is complete."
-        },
-        {
-          "name" : "TRANSMITTED",
-          "value" : 2,
-          "annotation" : "The transmitted state"
-        }
-      ],
-      "default" : "DpState.UNTRANSMITTED"
     },
     {
       "kind" : "alias",
@@ -304,6 +292,20 @@
         "u16Field" : 0
       },
       "annotation" : "Data for a DataRecord"
+    }
+  ],
+  "constants" : [
+    {
+      "kind" : "constant",
+      "qualifiedName" : "Fw.DpCfg.CONTAINER_USER_DATA_SIZE",
+      "type" : {
+        "name" : "U64",
+        "kind" : "integer",
+        "size" : 64,
+        "signed" : false
+      },
+      "value" : 1,
+      "annotation" : "The container user data size"
     }
   ],
   "commands" : [

--- a/compiler/tools/fpp-to-dict/test/top/BasicDpTopologyDictionary.ref.json
+++ b/compiler/tools/fpp-to-dict/test/top/BasicDpTopologyDictionary.ref.json
@@ -179,6 +179,22 @@
     },
     {
       "kind" : "alias",
+      "qualifiedName" : "FwSizeStoreType",
+      "type" : {
+        "name" : "U16",
+        "kind" : "integer",
+        "size" : 16,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U16",
+        "kind" : "integer",
+        "size" : 16,
+        "signed" : false
+      }
+    },
+    {
+      "kind" : "alias",
       "qualifiedName" : "FwPacketDescriptorType",
       "type" : {
         "name" : "U32",
@@ -304,7 +320,7 @@
         "size" : 64,
         "signed" : false
       },
-      "value" : 1,
+      "value" : 32,
       "annotation" : "The container user data size"
     }
   ],

--- a/compiler/tools/fpp-to-dict/test/top/BasicDpTopologyDictionary.ref.json
+++ b/compiler/tools/fpp-to-dict/test/top/BasicDpTopologyDictionary.ref.json
@@ -56,8 +56,131 @@
       }
     },
     {
+      "kind" : "enum",
+      "qualifiedName" : "ProcType",
+      "representationType" : {
+        "name" : "U8",
+        "kind" : "integer",
+        "size" : 8,
+        "signed" : false
+      },
+      "enumeratedConstants" : [
+        {
+          "name" : "PROC_TYPE_ZERO",
+          "value" : 1,
+          "annotation" : "Processing type 0"
+        },
+        {
+          "name" : "PROC_TYPE_ONE",
+          "value" : 2,
+          "annotation" : "Processing type 1"
+        },
+        {
+          "name" : "PROC_TYPE_TWO",
+          "value" : 4,
+          "annotation" : "Processing type 2"
+        }
+      ],
+      "default" : "ProcType.PROC_TYPE_ZERO",
+      "annotation" : "A bit mask for selecting the type of processing to perform on\na container before writing it to disk."
+    },
+    {
       "kind" : "alias",
       "qualifiedName" : "FwEventIdType",
+      "type" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      }
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FwSizeType",
+      "type" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      }
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FwTimeContextStoreType",
+      "type" : {
+        "name" : "U8",
+        "kind" : "integer",
+        "size" : 8,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U8",
+        "kind" : "integer",
+        "size" : 8,
+        "signed" : false
+      },
+      "annotation" : "The type used to serialize a time context value"
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FwDpIdType",
+      "type" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      }
+    },
+    {
+      "kind" : "constant",
+      "qualifiedName" : "CONTAINER_USER_DATA_SIZE",
+      "type" : {
+        "name" : "U64",
+        "kind" : "integer",
+        "size" : 64,
+        "signed" : false
+      },
+      "value" : 1,
+      "annotation" : "The container user data size"
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FppTest.DpTestComponent.AliasU16",
+      "type" : {
+        "name" : "U16",
+        "kind" : "integer",
+        "size" : 16,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U16",
+        "kind" : "integer",
+        "size" : 16,
+        "signed" : false
+      },
+      "annotation" : "Alias of type U16"
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FwDpPriorityType",
       "type" : {
         "name" : "U32",
         "kind" : "integer",
@@ -88,39 +211,32 @@
       }
     },
     {
-      "kind" : "alias",
-      "qualifiedName" : "FppTest.DpTestComponent.AliasU16",
-      "type" : {
-        "name" : "U16",
+      "kind" : "enum",
+      "qualifiedName" : "DpState",
+      "representationType" : {
+        "name" : "U8",
         "kind" : "integer",
-        "size" : 16,
+        "size" : 8,
         "signed" : false
       },
-      "underlyingType" : {
-        "name" : "U16",
-        "kind" : "integer",
-        "size" : 16,
-        "signed" : false
-      },
-      "annotation" : "Alias of type U16"
-    },
-    {
-      "kind" : "struct",
-      "qualifiedName" : "FppTest.DpTestComponent.Data",
-      "members" : {
-        "u16Field" : {
-          "type" : {
-            "name" : "FppTest.DpTestComponent.AliasU16",
-            "kind" : "qualifiedIdentifier"
-          },
-          "index" : 0,
-          "annotation" : "A U16 field"
+      "enumeratedConstants" : [
+        {
+          "name" : "UNTRANSMITTED",
+          "value" : 0,
+          "annotation" : "The untransmitted state"
+        },
+        {
+          "name" : "PARTIAL",
+          "value" : 1,
+          "annotation" : "The partially transmitted state\nA data product is in this state from the start of transmission\nuntil transmission is complete."
+        },
+        {
+          "name" : "TRANSMITTED",
+          "value" : 2,
+          "annotation" : "The transmitted state"
         }
-      },
-      "default" : {
-        "u16Field" : 0
-      },
-      "annotation" : "Data for a DataRecord"
+      ],
+      "default" : "DpState.UNTRANSMITTED"
     },
     {
       "kind" : "alias",
@@ -153,6 +269,41 @@
         "size" : 32,
         "signed" : false
       }
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FwTimeBaseStoreType",
+      "type" : {
+        "name" : "U16",
+        "kind" : "integer",
+        "size" : 16,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U16",
+        "kind" : "integer",
+        "size" : 16,
+        "signed" : false
+      },
+      "annotation" : "The type used to serialize a time base value"
+    },
+    {
+      "kind" : "struct",
+      "qualifiedName" : "FppTest.DpTestComponent.Data",
+      "members" : {
+        "u16Field" : {
+          "type" : {
+            "name" : "FppTest.DpTestComponent.AliasU16",
+            "kind" : "qualifiedIdentifier"
+          },
+          "index" : 0,
+          "annotation" : "A U16 field"
+        }
+      },
+      "default" : {
+        "u16Field" : 0
+      },
+      "annotation" : "Data for a DataRecord"
     }
   ],
   "commands" : [

--- a/compiler/tools/fpp-to-dict/test/top/BasicTopologyDictionary.ref.json
+++ b/compiler/tools/fpp-to-dict/test/top/BasicTopologyDictionary.ref.json
@@ -25,6 +25,35 @@
       }
     },
     {
+      "kind" : "enum",
+      "qualifiedName" : "ProcType",
+      "representationType" : {
+        "name" : "U8",
+        "kind" : "integer",
+        "size" : 8,
+        "signed" : false
+      },
+      "enumeratedConstants" : [
+        {
+          "name" : "PROC_TYPE_ZERO",
+          "value" : 1,
+          "annotation" : "Processing type 0"
+        },
+        {
+          "name" : "PROC_TYPE_ONE",
+          "value" : 2,
+          "annotation" : "Processing type 1"
+        },
+        {
+          "name" : "PROC_TYPE_TWO",
+          "value" : 4,
+          "annotation" : "Processing type 2"
+        }
+      ],
+      "default" : "ProcType.PROC_TYPE_ZERO",
+      "annotation" : "A bit mask for selecting the type of processing to perform on\na container before writing it to disk."
+    },
+    {
       "kind" : "alias",
       "qualifiedName" : "FwEventIdType",
       "type" : {
@@ -42,6 +71,100 @@
     },
     {
       "kind" : "alias",
+      "qualifiedName" : "FwSizeType",
+      "type" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      }
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FwTimeContextStoreType",
+      "type" : {
+        "name" : "U8",
+        "kind" : "integer",
+        "size" : 8,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U8",
+        "kind" : "integer",
+        "size" : 8,
+        "signed" : false
+      },
+      "annotation" : "The type used to serialize a time context value"
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FwDpIdType",
+      "type" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      }
+    },
+    {
+      "kind" : "constant",
+      "qualifiedName" : "CONTAINER_USER_DATA_SIZE",
+      "type" : {
+        "name" : "U64",
+        "kind" : "integer",
+        "size" : 64,
+        "signed" : false
+      },
+      "value" : 1,
+      "annotation" : "The container user data size"
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FwDpPriorityType",
+      "type" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      }
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FwTimeBaseStoreType",
+      "type" : {
+        "name" : "U16",
+        "kind" : "integer",
+        "size" : 16,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U16",
+        "kind" : "integer",
+        "size" : 16,
+        "signed" : false
+      },
+      "annotation" : "The type used to serialize a time base value"
+    },
+    {
+      "kind" : "alias",
       "qualifiedName" : "FwPacketDescriptorType",
       "type" : {
         "name" : "U32",
@@ -55,6 +178,34 @@
         "size" : 32,
         "signed" : false
       }
+    },
+    {
+      "kind" : "enum",
+      "qualifiedName" : "DpState",
+      "representationType" : {
+        "name" : "U8",
+        "kind" : "integer",
+        "size" : 8,
+        "signed" : false
+      },
+      "enumeratedConstants" : [
+        {
+          "name" : "UNTRANSMITTED",
+          "value" : 0,
+          "annotation" : "The untransmitted state"
+        },
+        {
+          "name" : "PARTIAL",
+          "value" : 1,
+          "annotation" : "The partially transmitted state\nA data product is in this state from the start of transmission\nuntil transmission is complete."
+        },
+        {
+          "name" : "TRANSMITTED",
+          "value" : 2,
+          "annotation" : "The transmitted state"
+        }
+      ],
+      "default" : "DpState.UNTRANSMITTED"
     },
     {
       "kind" : "alias",

--- a/compiler/tools/fpp-to-dict/test/top/BasicTopologyDictionary.ref.json
+++ b/compiler/tools/fpp-to-dict/test/top/BasicTopologyDictionary.ref.json
@@ -148,6 +148,22 @@
     },
     {
       "kind" : "alias",
+      "qualifiedName" : "FwSizeStoreType",
+      "type" : {
+        "name" : "U16",
+        "kind" : "integer",
+        "size" : 16,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U16",
+        "kind" : "integer",
+        "size" : 16,
+        "signed" : false
+      }
+    },
+    {
+      "kind" : "alias",
       "qualifiedName" : "FwPacketDescriptorType",
       "type" : {
         "name" : "U32",
@@ -238,7 +254,7 @@
         "size" : 64,
         "signed" : false
       },
-      "value" : 1,
+      "value" : 32,
       "annotation" : "The container user data size"
     }
   ],

--- a/compiler/tools/fpp-to-dict/test/top/BasicTopologyDictionary.ref.json
+++ b/compiler/tools/fpp-to-dict/test/top/BasicTopologyDictionary.ref.json
@@ -26,7 +26,7 @@
     },
     {
       "kind" : "enum",
-      "qualifiedName" : "ProcType",
+      "qualifiedName" : "Fw.DpState",
       "representationType" : {
         "name" : "U8",
         "kind" : "integer",
@@ -35,23 +35,22 @@
       },
       "enumeratedConstants" : [
         {
-          "name" : "PROC_TYPE_ZERO",
+          "name" : "UNTRANSMITTED",
+          "value" : 0,
+          "annotation" : "The untransmitted state"
+        },
+        {
+          "name" : "PARTIAL",
           "value" : 1,
-          "annotation" : "Processing type 0"
+          "annotation" : "The partially transmitted state\nA data product is in this state from the start of transmission\nuntil transmission is complete."
         },
         {
-          "name" : "PROC_TYPE_ONE",
+          "name" : "TRANSMITTED",
           "value" : 2,
-          "annotation" : "Processing type 1"
-        },
-        {
-          "name" : "PROC_TYPE_TWO",
-          "value" : 4,
-          "annotation" : "Processing type 2"
+          "annotation" : "The transmitted state"
         }
       ],
-      "default" : "ProcType.PROC_TYPE_ZERO",
-      "annotation" : "A bit mask for selecting the type of processing to perform on\na container before writing it to disk."
+      "default" : "Fw.DpState.UNTRANSMITTED"
     },
     {
       "kind" : "alias",
@@ -119,16 +118,49 @@
       }
     },
     {
-      "kind" : "constant",
-      "qualifiedName" : "CONTAINER_USER_DATA_SIZE",
-      "type" : {
-        "name" : "U64",
+      "kind" : "enum",
+      "qualifiedName" : "Fw.DpCfg.ProcType",
+      "representationType" : {
+        "name" : "U8",
         "kind" : "integer",
-        "size" : 64,
+        "size" : 8,
         "signed" : false
       },
-      "value" : 1,
-      "annotation" : "The container user data size"
+      "enumeratedConstants" : [
+        {
+          "name" : "PROC_TYPE_ZERO",
+          "value" : 1,
+          "annotation" : "Processing type 0"
+        },
+        {
+          "name" : "PROC_TYPE_ONE",
+          "value" : 2,
+          "annotation" : "Processing type 1"
+        },
+        {
+          "name" : "PROC_TYPE_TWO",
+          "value" : 4,
+          "annotation" : "Processing type 2"
+        }
+      ],
+      "default" : "Fw.DpCfg.ProcType.PROC_TYPE_ZERO",
+      "annotation" : "A bit mask for selecting the type of processing to perform on\na container before writing it to disk."
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FwPacketDescriptorType",
+      "type" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      }
     },
     {
       "kind" : "alias",
@@ -165,50 +197,6 @@
     },
     {
       "kind" : "alias",
-      "qualifiedName" : "FwPacketDescriptorType",
-      "type" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
-      },
-      "underlyingType" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
-      }
-    },
-    {
-      "kind" : "enum",
-      "qualifiedName" : "DpState",
-      "representationType" : {
-        "name" : "U8",
-        "kind" : "integer",
-        "size" : 8,
-        "signed" : false
-      },
-      "enumeratedConstants" : [
-        {
-          "name" : "UNTRANSMITTED",
-          "value" : 0,
-          "annotation" : "The untransmitted state"
-        },
-        {
-          "name" : "PARTIAL",
-          "value" : 1,
-          "annotation" : "The partially transmitted state\nA data product is in this state from the start of transmission\nuntil transmission is complete."
-        },
-        {
-          "name" : "TRANSMITTED",
-          "value" : 2,
-          "annotation" : "The transmitted state"
-        }
-      ],
-      "default" : "DpState.UNTRANSMITTED"
-    },
-    {
-      "kind" : "alias",
       "qualifiedName" : "FwOpcodeType",
       "type" : {
         "name" : "U32",
@@ -238,6 +226,20 @@
         "size" : 32,
         "signed" : false
       }
+    }
+  ],
+  "constants" : [
+    {
+      "kind" : "constant",
+      "qualifiedName" : "Fw.DpCfg.CONTAINER_USER_DATA_SIZE",
+      "type" : {
+        "name" : "U64",
+        "kind" : "integer",
+        "size" : 64,
+        "signed" : false
+      },
+      "value" : 1,
+      "annotation" : "The container user data size"
     }
   ],
   "commands" : [

--- a/compiler/tools/fpp-to-dict/test/top/FirstTopTopologyDictionary.ref.json
+++ b/compiler/tools/fpp-to-dict/test/top/FirstTopTopologyDictionary.ref.json
@@ -212,35 +212,6 @@
       "annotation" : "A bit mask for selecting the type of processing to perform on\na container before writing it to disk."
     },
     {
-      "kind" : "struct",
-      "qualifiedName" : "Module1.S1",
-      "members" : {
-        "x" : {
-          "type" : {
-            "name" : "U64",
-            "kind" : "integer",
-            "size" : 64,
-            "signed" : false
-          },
-          "index" : 0,
-          "format" : "The value of x is {}"
-        },
-        "y" : {
-          "type" : {
-            "name" : "F32",
-            "kind" : "float",
-            "size" : 32
-          },
-          "index" : 1,
-          "format" : "The value of y is {.2f}"
-        }
-      },
-      "default" : {
-        "x" : 1,
-        "y" : 1.5
-      }
-    },
-    {
       "kind" : "array",
       "qualifiedName" : "Module1.StringArray",
       "size" : 2,
@@ -501,6 +472,51 @@
       "annotation" : "Alias of type AliasT1 (with underlying type U32)"
     },
     {
+      "kind" : "struct",
+      "qualifiedName" : "Module1.S1",
+      "members" : {
+        "x" : {
+          "type" : {
+            "name" : "U64",
+            "kind" : "integer",
+            "size" : 64,
+            "signed" : false
+          },
+          "index" : 0,
+          "format" : "The value of x is {}"
+        },
+        "y" : {
+          "type" : {
+            "name" : "F32",
+            "kind" : "float",
+            "size" : 32
+          },
+          "index" : 1,
+          "format" : "The value of y is {.2f}"
+        }
+      },
+      "default" : {
+        "x" : 1,
+        "y" : 1.5
+      }
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FwSizeStoreType",
+      "type" : {
+        "name" : "U16",
+        "kind" : "integer",
+        "size" : 16,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U16",
+        "kind" : "integer",
+        "size" : 16,
+        "signed" : false
+      }
+    },
+    {
       "kind" : "alias",
       "qualifiedName" : "FwOpcodeType",
       "type" : {
@@ -585,7 +601,7 @@
         "size" : 64,
         "signed" : false
       },
-      "value" : 1,
+      "value" : 32,
       "annotation" : "The container user data size"
     }
   ],

--- a/compiler/tools/fpp-to-dict/test/top/FirstTopTopologyDictionary.ref.json
+++ b/compiler/tools/fpp-to-dict/test/top/FirstTopTopologyDictionary.ref.json
@@ -12,6 +12,35 @@
   "typeDefinitions" : [
     {
       "kind" : "enum",
+      "qualifiedName" : "ProcType",
+      "representationType" : {
+        "name" : "U8",
+        "kind" : "integer",
+        "size" : 8,
+        "signed" : false
+      },
+      "enumeratedConstants" : [
+        {
+          "name" : "PROC_TYPE_ZERO",
+          "value" : 1,
+          "annotation" : "Processing type 0"
+        },
+        {
+          "name" : "PROC_TYPE_ONE",
+          "value" : 2,
+          "annotation" : "Processing type 1"
+        },
+        {
+          "name" : "PROC_TYPE_TWO",
+          "value" : 4,
+          "annotation" : "Processing type 2"
+        }
+      ],
+      "default" : "ProcType.PROC_TYPE_ZERO",
+      "annotation" : "A bit mask for selecting the type of processing to perform on\na container before writing it to disk."
+    },
+    {
+      "kind" : "enum",
       "qualifiedName" : "Module1.E2",
       "representationType" : {
         "name" : "I32",
@@ -46,6 +75,39 @@
         "size" : 32,
         "signed" : false
       }
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FwSizeType",
+      "type" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      }
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FwTimeContextStoreType",
+      "type" : {
+        "name" : "U8",
+        "kind" : "integer",
+        "size" : 8,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U8",
+        "kind" : "integer",
+        "size" : 8,
+        "signed" : false
+      },
+      "annotation" : "The type used to serialize a time context value"
     },
     {
       "kind" : "alias",
@@ -171,19 +233,16 @@
       }
     },
     {
-      "kind" : "alias",
-      "qualifiedName" : "Module1.AliasT2",
+      "kind" : "constant",
+      "qualifiedName" : "CONTAINER_USER_DATA_SIZE",
       "type" : {
-        "name" : "Module1.AliasT1",
-        "kind" : "qualifiedIdentifier"
-      },
-      "underlyingType" : {
-        "name" : "U32",
+        "name" : "U64",
         "kind" : "integer",
-        "size" : 32,
+        "size" : 64,
         "signed" : false
       },
-      "annotation" : "Alias of type AliasT1 (with underlying type U32)"
+      "value" : 1,
+      "annotation" : "The container user data size"
     },
     {
       "kind" : "struct",
@@ -231,22 +290,6 @@
     },
     {
       "kind" : "alias",
-      "qualifiedName" : "FwPacketDescriptorType",
-      "type" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
-      },
-      "underlyingType" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
-      }
-    },
-    {
-      "kind" : "alias",
       "qualifiedName" : "Module1.AliasT3",
       "type" : {
         "name" : "string",
@@ -260,29 +303,20 @@
       }
     },
     {
-      "kind" : "enum",
-      "qualifiedName" : "Module1.E1",
-      "representationType" : {
+      "kind" : "alias",
+      "qualifiedName" : "FwDpPriorityType",
+      "type" : {
         "name" : "U32",
         "kind" : "integer",
         "size" : 32,
         "signed" : false
       },
-      "enumeratedConstants" : [
-        {
-          "name" : "X",
-          "value" : 0
-        },
-        {
-          "name" : "Y",
-          "value" : 1
-        },
-        {
-          "name" : "Z",
-          "value" : 2
-        }
-      ],
-      "default" : "Module1.E1.X"
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      }
     },
     {
       "kind" : "enum",
@@ -405,6 +439,81 @@
     },
     {
       "kind" : "alias",
+      "qualifiedName" : "FwDpIdType",
+      "type" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      }
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "Module1.AliasT2",
+      "type" : {
+        "name" : "Module1.AliasT1",
+        "kind" : "qualifiedIdentifier"
+      },
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      },
+      "annotation" : "Alias of type AliasT1 (with underlying type U32)"
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FwPacketDescriptorType",
+      "type" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      }
+    },
+    {
+      "kind" : "enum",
+      "qualifiedName" : "DpState",
+      "representationType" : {
+        "name" : "U8",
+        "kind" : "integer",
+        "size" : 8,
+        "signed" : false
+      },
+      "enumeratedConstants" : [
+        {
+          "name" : "UNTRANSMITTED",
+          "value" : 0,
+          "annotation" : "The untransmitted state"
+        },
+        {
+          "name" : "PARTIAL",
+          "value" : 1,
+          "annotation" : "The partially transmitted state\nA data product is in this state from the start of transmission\nuntil transmission is complete."
+        },
+        {
+          "name" : "TRANSMITTED",
+          "value" : 2,
+          "annotation" : "The transmitted state"
+        }
+      ],
+      "default" : "DpState.UNTRANSMITTED"
+    },
+    {
+      "kind" : "alias",
       "qualifiedName" : "FwOpcodeType",
       "type" : {
         "name" : "U32",
@@ -434,6 +543,48 @@
         "size" : 32,
         "signed" : false
       }
+    },
+    {
+      "kind" : "enum",
+      "qualifiedName" : "Module1.E1",
+      "representationType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      },
+      "enumeratedConstants" : [
+        {
+          "name" : "X",
+          "value" : 0
+        },
+        {
+          "name" : "Y",
+          "value" : 1
+        },
+        {
+          "name" : "Z",
+          "value" : 2
+        }
+      ],
+      "default" : "Module1.E1.X"
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FwTimeBaseStoreType",
+      "type" : {
+        "name" : "U16",
+        "kind" : "integer",
+        "size" : 16,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U16",
+        "kind" : "integer",
+        "size" : 16,
+        "signed" : false
+      },
+      "annotation" : "The type used to serialize a time base value"
     }
   ],
   "commands" : [

--- a/compiler/tools/fpp-to-dict/test/top/FirstTopTopologyDictionary.ref.json
+++ b/compiler/tools/fpp-to-dict/test/top/FirstTopTopologyDictionary.ref.json
@@ -11,56 +11,6 @@
   },
   "typeDefinitions" : [
     {
-      "kind" : "enum",
-      "qualifiedName" : "ProcType",
-      "representationType" : {
-        "name" : "U8",
-        "kind" : "integer",
-        "size" : 8,
-        "signed" : false
-      },
-      "enumeratedConstants" : [
-        {
-          "name" : "PROC_TYPE_ZERO",
-          "value" : 1,
-          "annotation" : "Processing type 0"
-        },
-        {
-          "name" : "PROC_TYPE_ONE",
-          "value" : 2,
-          "annotation" : "Processing type 1"
-        },
-        {
-          "name" : "PROC_TYPE_TWO",
-          "value" : 4,
-          "annotation" : "Processing type 2"
-        }
-      ],
-      "default" : "ProcType.PROC_TYPE_ZERO",
-      "annotation" : "A bit mask for selecting the type of processing to perform on\na container before writing it to disk."
-    },
-    {
-      "kind" : "enum",
-      "qualifiedName" : "Module1.E2",
-      "representationType" : {
-        "name" : "I32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : true
-      },
-      "enumeratedConstants" : [
-        {
-          "name" : "PASS",
-          "value" : 0
-        },
-        {
-          "name" : "FAIL",
-          "value" : 1
-        }
-      ],
-      "default" : "Module1.E2.PASS"
-    },
-    {
       "kind" : "alias",
       "qualifiedName" : "FwEventIdType",
       "type" : {
@@ -233,16 +183,33 @@
       }
     },
     {
-      "kind" : "constant",
-      "qualifiedName" : "CONTAINER_USER_DATA_SIZE",
-      "type" : {
-        "name" : "U64",
+      "kind" : "enum",
+      "qualifiedName" : "Fw.DpCfg.ProcType",
+      "representationType" : {
+        "name" : "U8",
         "kind" : "integer",
-        "size" : 64,
+        "size" : 8,
         "signed" : false
       },
-      "value" : 1,
-      "annotation" : "The container user data size"
+      "enumeratedConstants" : [
+        {
+          "name" : "PROC_TYPE_ZERO",
+          "value" : 1,
+          "annotation" : "Processing type 0"
+        },
+        {
+          "name" : "PROC_TYPE_ONE",
+          "value" : 2,
+          "annotation" : "Processing type 1"
+        },
+        {
+          "name" : "PROC_TYPE_TWO",
+          "value" : 4,
+          "annotation" : "Processing type 2"
+        }
+      ],
+      "default" : "Fw.DpCfg.ProcType.PROC_TYPE_ZERO",
+      "annotation" : "A bit mask for selecting the type of processing to perform on\na container before writing it to disk."
     },
     {
       "kind" : "struct",
@@ -287,6 +254,22 @@
         "B"
       ],
       "annotation" : "An array of 2 String values"
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FwPacketDescriptorType",
+      "type" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      }
     },
     {
       "kind" : "alias",
@@ -403,6 +386,55 @@
       }
     },
     {
+      "kind" : "enum",
+      "qualifiedName" : "Fw.DpState",
+      "representationType" : {
+        "name" : "U8",
+        "kind" : "integer",
+        "size" : 8,
+        "signed" : false
+      },
+      "enumeratedConstants" : [
+        {
+          "name" : "UNTRANSMITTED",
+          "value" : 0,
+          "annotation" : "The untransmitted state"
+        },
+        {
+          "name" : "PARTIAL",
+          "value" : 1,
+          "annotation" : "The partially transmitted state\nA data product is in this state from the start of transmission\nuntil transmission is complete."
+        },
+        {
+          "name" : "TRANSMITTED",
+          "value" : 2,
+          "annotation" : "The transmitted state"
+        }
+      ],
+      "default" : "Fw.DpState.UNTRANSMITTED"
+    },
+    {
+      "kind" : "enum",
+      "qualifiedName" : "Module1.E2",
+      "representationType" : {
+        "name" : "I32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : true
+      },
+      "enumeratedConstants" : [
+        {
+          "name" : "PASS",
+          "value" : 0
+        },
+        {
+          "name" : "FAIL",
+          "value" : 1
+        }
+      ],
+      "default" : "Module1.E2.PASS"
+    },
+    {
       "kind" : "array",
       "qualifiedName" : "Module1.F64x4",
       "size" : 4,
@@ -467,50 +499,6 @@
         "signed" : false
       },
       "annotation" : "Alias of type AliasT1 (with underlying type U32)"
-    },
-    {
-      "kind" : "alias",
-      "qualifiedName" : "FwPacketDescriptorType",
-      "type" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
-      },
-      "underlyingType" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
-      }
-    },
-    {
-      "kind" : "enum",
-      "qualifiedName" : "DpState",
-      "representationType" : {
-        "name" : "U8",
-        "kind" : "integer",
-        "size" : 8,
-        "signed" : false
-      },
-      "enumeratedConstants" : [
-        {
-          "name" : "UNTRANSMITTED",
-          "value" : 0,
-          "annotation" : "The untransmitted state"
-        },
-        {
-          "name" : "PARTIAL",
-          "value" : 1,
-          "annotation" : "The partially transmitted state\nA data product is in this state from the start of transmission\nuntil transmission is complete."
-        },
-        {
-          "name" : "TRANSMITTED",
-          "value" : 2,
-          "annotation" : "The transmitted state"
-        }
-      ],
-      "default" : "DpState.UNTRANSMITTED"
     },
     {
       "kind" : "alias",
@@ -585,6 +573,20 @@
         "signed" : false
       },
       "annotation" : "The type used to serialize a time base value"
+    }
+  ],
+  "constants" : [
+    {
+      "kind" : "constant",
+      "qualifiedName" : "Fw.DpCfg.CONTAINER_USER_DATA_SIZE",
+      "type" : {
+        "name" : "U64",
+        "kind" : "integer",
+        "size" : 64,
+        "signed" : false
+      },
+      "value" : 1,
+      "annotation" : "The container user data size"
     }
   ],
   "commands" : [

--- a/compiler/tools/fpp-to-dict/test/top/QualifiedCompInstTopologyDictionary.ref.json
+++ b/compiler/tools/fpp-to-dict/test/top/QualifiedCompInstTopologyDictionary.ref.json
@@ -28,6 +28,35 @@
     },
     {
       "kind" : "enum",
+      "qualifiedName" : "ProcType",
+      "representationType" : {
+        "name" : "U8",
+        "kind" : "integer",
+        "size" : 8,
+        "signed" : false
+      },
+      "enumeratedConstants" : [
+        {
+          "name" : "PROC_TYPE_ZERO",
+          "value" : 1,
+          "annotation" : "Processing type 0"
+        },
+        {
+          "name" : "PROC_TYPE_ONE",
+          "value" : 2,
+          "annotation" : "Processing type 1"
+        },
+        {
+          "name" : "PROC_TYPE_TWO",
+          "value" : 4,
+          "annotation" : "Processing type 2"
+        }
+      ],
+      "default" : "ProcType.PROC_TYPE_ZERO",
+      "annotation" : "A bit mask for selecting the type of processing to perform on\na container before writing it to disk."
+    },
+    {
+      "kind" : "enum",
       "qualifiedName" : "M.E1",
       "representationType" : {
         "name" : "U32",
@@ -69,6 +98,100 @@
     },
     {
       "kind" : "alias",
+      "qualifiedName" : "FwSizeType",
+      "type" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      }
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FwTimeContextStoreType",
+      "type" : {
+        "name" : "U8",
+        "kind" : "integer",
+        "size" : 8,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U8",
+        "kind" : "integer",
+        "size" : 8,
+        "signed" : false
+      },
+      "annotation" : "The type used to serialize a time context value"
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FwDpIdType",
+      "type" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      }
+    },
+    {
+      "kind" : "constant",
+      "qualifiedName" : "CONTAINER_USER_DATA_SIZE",
+      "type" : {
+        "name" : "U64",
+        "kind" : "integer",
+        "size" : 64,
+        "signed" : false
+      },
+      "value" : 1,
+      "annotation" : "The container user data size"
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FwDpPriorityType",
+      "type" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      }
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FwTimeBaseStoreType",
+      "type" : {
+        "name" : "U16",
+        "kind" : "integer",
+        "size" : 16,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U16",
+        "kind" : "integer",
+        "size" : 16,
+        "signed" : false
+      },
+      "annotation" : "The type used to serialize a time base value"
+    },
+    {
+      "kind" : "alias",
       "qualifiedName" : "FwPacketDescriptorType",
       "type" : {
         "name" : "U32",
@@ -82,6 +205,34 @@
         "size" : 32,
         "signed" : false
       }
+    },
+    {
+      "kind" : "enum",
+      "qualifiedName" : "DpState",
+      "representationType" : {
+        "name" : "U8",
+        "kind" : "integer",
+        "size" : 8,
+        "signed" : false
+      },
+      "enumeratedConstants" : [
+        {
+          "name" : "UNTRANSMITTED",
+          "value" : 0,
+          "annotation" : "The untransmitted state"
+        },
+        {
+          "name" : "PARTIAL",
+          "value" : 1,
+          "annotation" : "The partially transmitted state\nA data product is in this state from the start of transmission\nuntil transmission is complete."
+        },
+        {
+          "name" : "TRANSMITTED",
+          "value" : 2,
+          "annotation" : "The transmitted state"
+        }
+      ],
+      "default" : "DpState.UNTRANSMITTED"
     },
     {
       "kind" : "alias",

--- a/compiler/tools/fpp-to-dict/test/top/QualifiedCompInstTopologyDictionary.ref.json
+++ b/compiler/tools/fpp-to-dict/test/top/QualifiedCompInstTopologyDictionary.ref.json
@@ -28,7 +28,7 @@
     },
     {
       "kind" : "enum",
-      "qualifiedName" : "ProcType",
+      "qualifiedName" : "Fw.DpState",
       "representationType" : {
         "name" : "U8",
         "kind" : "integer",
@@ -37,23 +37,22 @@
       },
       "enumeratedConstants" : [
         {
-          "name" : "PROC_TYPE_ZERO",
+          "name" : "UNTRANSMITTED",
+          "value" : 0,
+          "annotation" : "The untransmitted state"
+        },
+        {
+          "name" : "PARTIAL",
           "value" : 1,
-          "annotation" : "Processing type 0"
+          "annotation" : "The partially transmitted state\nA data product is in this state from the start of transmission\nuntil transmission is complete."
         },
         {
-          "name" : "PROC_TYPE_ONE",
+          "name" : "TRANSMITTED",
           "value" : 2,
-          "annotation" : "Processing type 1"
-        },
-        {
-          "name" : "PROC_TYPE_TWO",
-          "value" : 4,
-          "annotation" : "Processing type 2"
+          "annotation" : "The transmitted state"
         }
       ],
-      "default" : "ProcType.PROC_TYPE_ZERO",
-      "annotation" : "A bit mask for selecting the type of processing to perform on\na container before writing it to disk."
+      "default" : "Fw.DpState.UNTRANSMITTED"
     },
     {
       "kind" : "enum",
@@ -146,16 +145,49 @@
       }
     },
     {
-      "kind" : "constant",
-      "qualifiedName" : "CONTAINER_USER_DATA_SIZE",
-      "type" : {
-        "name" : "U64",
+      "kind" : "enum",
+      "qualifiedName" : "Fw.DpCfg.ProcType",
+      "representationType" : {
+        "name" : "U8",
         "kind" : "integer",
-        "size" : 64,
+        "size" : 8,
         "signed" : false
       },
-      "value" : 1,
-      "annotation" : "The container user data size"
+      "enumeratedConstants" : [
+        {
+          "name" : "PROC_TYPE_ZERO",
+          "value" : 1,
+          "annotation" : "Processing type 0"
+        },
+        {
+          "name" : "PROC_TYPE_ONE",
+          "value" : 2,
+          "annotation" : "Processing type 1"
+        },
+        {
+          "name" : "PROC_TYPE_TWO",
+          "value" : 4,
+          "annotation" : "Processing type 2"
+        }
+      ],
+      "default" : "Fw.DpCfg.ProcType.PROC_TYPE_ZERO",
+      "annotation" : "A bit mask for selecting the type of processing to perform on\na container before writing it to disk."
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FwPacketDescriptorType",
+      "type" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      }
     },
     {
       "kind" : "alias",
@@ -192,50 +224,6 @@
     },
     {
       "kind" : "alias",
-      "qualifiedName" : "FwPacketDescriptorType",
-      "type" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
-      },
-      "underlyingType" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
-      }
-    },
-    {
-      "kind" : "enum",
-      "qualifiedName" : "DpState",
-      "representationType" : {
-        "name" : "U8",
-        "kind" : "integer",
-        "size" : 8,
-        "signed" : false
-      },
-      "enumeratedConstants" : [
-        {
-          "name" : "UNTRANSMITTED",
-          "value" : 0,
-          "annotation" : "The untransmitted state"
-        },
-        {
-          "name" : "PARTIAL",
-          "value" : 1,
-          "annotation" : "The partially transmitted state\nA data product is in this state from the start of transmission\nuntil transmission is complete."
-        },
-        {
-          "name" : "TRANSMITTED",
-          "value" : 2,
-          "annotation" : "The transmitted state"
-        }
-      ],
-      "default" : "DpState.UNTRANSMITTED"
-    },
-    {
-      "kind" : "alias",
       "qualifiedName" : "FwOpcodeType",
       "type" : {
         "name" : "U32",
@@ -265,6 +253,20 @@
         "size" : 32,
         "signed" : false
       }
+    }
+  ],
+  "constants" : [
+    {
+      "kind" : "constant",
+      "qualifiedName" : "Fw.DpCfg.CONTAINER_USER_DATA_SIZE",
+      "type" : {
+        "name" : "U64",
+        "kind" : "integer",
+        "size" : 64,
+        "signed" : false
+      },
+      "value" : 1,
+      "annotation" : "The container user data size"
     }
   ],
   "commands" : [

--- a/compiler/tools/fpp-to-dict/test/top/QualifiedCompInstTopologyDictionary.ref.json
+++ b/compiler/tools/fpp-to-dict/test/top/QualifiedCompInstTopologyDictionary.ref.json
@@ -175,6 +175,22 @@
     },
     {
       "kind" : "alias",
+      "qualifiedName" : "FwSizeStoreType",
+      "type" : {
+        "name" : "U16",
+        "kind" : "integer",
+        "size" : 16,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U16",
+        "kind" : "integer",
+        "size" : 16,
+        "signed" : false
+      }
+    },
+    {
+      "kind" : "alias",
       "qualifiedName" : "FwPacketDescriptorType",
       "type" : {
         "name" : "U32",
@@ -265,7 +281,7 @@
         "size" : 64,
         "signed" : false
       },
-      "value" : 1,
+      "value" : 32,
       "annotation" : "The container user data size"
     }
   ],

--- a/compiler/tools/fpp-to-dict/test/top/SecondTopTopologyDictionary.ref.json
+++ b/compiler/tools/fpp-to-dict/test/top/SecondTopTopologyDictionary.ref.json
@@ -212,35 +212,6 @@
       "annotation" : "A bit mask for selecting the type of processing to perform on\na container before writing it to disk."
     },
     {
-      "kind" : "struct",
-      "qualifiedName" : "Module1.S1",
-      "members" : {
-        "x" : {
-          "type" : {
-            "name" : "U64",
-            "kind" : "integer",
-            "size" : 64,
-            "signed" : false
-          },
-          "index" : 0,
-          "format" : "The value of x is {}"
-        },
-        "y" : {
-          "type" : {
-            "name" : "F32",
-            "kind" : "float",
-            "size" : 32
-          },
-          "index" : 1,
-          "format" : "The value of y is {.2f}"
-        }
-      },
-      "default" : {
-        "x" : 1,
-        "y" : 1.5
-      }
-    },
-    {
       "kind" : "array",
       "qualifiedName" : "Module1.StringArray",
       "size" : 2,
@@ -501,6 +472,51 @@
       "annotation" : "Alias of type AliasT1 (with underlying type U32)"
     },
     {
+      "kind" : "struct",
+      "qualifiedName" : "Module1.S1",
+      "members" : {
+        "x" : {
+          "type" : {
+            "name" : "U64",
+            "kind" : "integer",
+            "size" : 64,
+            "signed" : false
+          },
+          "index" : 0,
+          "format" : "The value of x is {}"
+        },
+        "y" : {
+          "type" : {
+            "name" : "F32",
+            "kind" : "float",
+            "size" : 32
+          },
+          "index" : 1,
+          "format" : "The value of y is {.2f}"
+        }
+      },
+      "default" : {
+        "x" : 1,
+        "y" : 1.5
+      }
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FwSizeStoreType",
+      "type" : {
+        "name" : "U16",
+        "kind" : "integer",
+        "size" : 16,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U16",
+        "kind" : "integer",
+        "size" : 16,
+        "signed" : false
+      }
+    },
+    {
       "kind" : "alias",
       "qualifiedName" : "FwOpcodeType",
       "type" : {
@@ -585,7 +601,7 @@
         "size" : 64,
         "signed" : false
       },
-      "value" : 1,
+      "value" : 32,
       "annotation" : "The container user data size"
     }
   ],

--- a/compiler/tools/fpp-to-dict/test/top/SecondTopTopologyDictionary.ref.json
+++ b/compiler/tools/fpp-to-dict/test/top/SecondTopTopologyDictionary.ref.json
@@ -12,6 +12,35 @@
   "typeDefinitions" : [
     {
       "kind" : "enum",
+      "qualifiedName" : "ProcType",
+      "representationType" : {
+        "name" : "U8",
+        "kind" : "integer",
+        "size" : 8,
+        "signed" : false
+      },
+      "enumeratedConstants" : [
+        {
+          "name" : "PROC_TYPE_ZERO",
+          "value" : 1,
+          "annotation" : "Processing type 0"
+        },
+        {
+          "name" : "PROC_TYPE_ONE",
+          "value" : 2,
+          "annotation" : "Processing type 1"
+        },
+        {
+          "name" : "PROC_TYPE_TWO",
+          "value" : 4,
+          "annotation" : "Processing type 2"
+        }
+      ],
+      "default" : "ProcType.PROC_TYPE_ZERO",
+      "annotation" : "A bit mask for selecting the type of processing to perform on\na container before writing it to disk."
+    },
+    {
+      "kind" : "enum",
       "qualifiedName" : "Module1.E2",
       "representationType" : {
         "name" : "I32",
@@ -46,6 +75,39 @@
         "size" : 32,
         "signed" : false
       }
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FwSizeType",
+      "type" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      }
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FwTimeContextStoreType",
+      "type" : {
+        "name" : "U8",
+        "kind" : "integer",
+        "size" : 8,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U8",
+        "kind" : "integer",
+        "size" : 8,
+        "signed" : false
+      },
+      "annotation" : "The type used to serialize a time context value"
     },
     {
       "kind" : "alias",
@@ -171,19 +233,16 @@
       }
     },
     {
-      "kind" : "alias",
-      "qualifiedName" : "Module1.AliasT2",
+      "kind" : "constant",
+      "qualifiedName" : "CONTAINER_USER_DATA_SIZE",
       "type" : {
-        "name" : "Module1.AliasT1",
-        "kind" : "qualifiedIdentifier"
-      },
-      "underlyingType" : {
-        "name" : "U32",
+        "name" : "U64",
         "kind" : "integer",
-        "size" : 32,
+        "size" : 64,
         "signed" : false
       },
-      "annotation" : "Alias of type AliasT1 (with underlying type U32)"
+      "value" : 1,
+      "annotation" : "The container user data size"
     },
     {
       "kind" : "struct",
@@ -231,22 +290,6 @@
     },
     {
       "kind" : "alias",
-      "qualifiedName" : "FwPacketDescriptorType",
-      "type" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
-      },
-      "underlyingType" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
-      }
-    },
-    {
-      "kind" : "alias",
       "qualifiedName" : "Module1.AliasT3",
       "type" : {
         "name" : "string",
@@ -260,29 +303,20 @@
       }
     },
     {
-      "kind" : "enum",
-      "qualifiedName" : "Module1.E1",
-      "representationType" : {
+      "kind" : "alias",
+      "qualifiedName" : "FwDpPriorityType",
+      "type" : {
         "name" : "U32",
         "kind" : "integer",
         "size" : 32,
         "signed" : false
       },
-      "enumeratedConstants" : [
-        {
-          "name" : "X",
-          "value" : 0
-        },
-        {
-          "name" : "Y",
-          "value" : 1
-        },
-        {
-          "name" : "Z",
-          "value" : 2
-        }
-      ],
-      "default" : "Module1.E1.X"
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      }
     },
     {
       "kind" : "enum",
@@ -405,6 +439,81 @@
     },
     {
       "kind" : "alias",
+      "qualifiedName" : "FwDpIdType",
+      "type" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      }
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "Module1.AliasT2",
+      "type" : {
+        "name" : "Module1.AliasT1",
+        "kind" : "qualifiedIdentifier"
+      },
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      },
+      "annotation" : "Alias of type AliasT1 (with underlying type U32)"
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FwPacketDescriptorType",
+      "type" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      }
+    },
+    {
+      "kind" : "enum",
+      "qualifiedName" : "DpState",
+      "representationType" : {
+        "name" : "U8",
+        "kind" : "integer",
+        "size" : 8,
+        "signed" : false
+      },
+      "enumeratedConstants" : [
+        {
+          "name" : "UNTRANSMITTED",
+          "value" : 0,
+          "annotation" : "The untransmitted state"
+        },
+        {
+          "name" : "PARTIAL",
+          "value" : 1,
+          "annotation" : "The partially transmitted state\nA data product is in this state from the start of transmission\nuntil transmission is complete."
+        },
+        {
+          "name" : "TRANSMITTED",
+          "value" : 2,
+          "annotation" : "The transmitted state"
+        }
+      ],
+      "default" : "DpState.UNTRANSMITTED"
+    },
+    {
+      "kind" : "alias",
       "qualifiedName" : "FwOpcodeType",
       "type" : {
         "name" : "U32",
@@ -434,6 +543,48 @@
         "size" : 32,
         "signed" : false
       }
+    },
+    {
+      "kind" : "enum",
+      "qualifiedName" : "Module1.E1",
+      "representationType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      },
+      "enumeratedConstants" : [
+        {
+          "name" : "X",
+          "value" : 0
+        },
+        {
+          "name" : "Y",
+          "value" : 1
+        },
+        {
+          "name" : "Z",
+          "value" : 2
+        }
+      ],
+      "default" : "Module1.E1.X"
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FwTimeBaseStoreType",
+      "type" : {
+        "name" : "U16",
+        "kind" : "integer",
+        "size" : 16,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U16",
+        "kind" : "integer",
+        "size" : 16,
+        "signed" : false
+      },
+      "annotation" : "The type used to serialize a time base value"
     }
   ],
   "commands" : [

--- a/compiler/tools/fpp-to-dict/test/top/SecondTopTopologyDictionary.ref.json
+++ b/compiler/tools/fpp-to-dict/test/top/SecondTopTopologyDictionary.ref.json
@@ -11,56 +11,6 @@
   },
   "typeDefinitions" : [
     {
-      "kind" : "enum",
-      "qualifiedName" : "ProcType",
-      "representationType" : {
-        "name" : "U8",
-        "kind" : "integer",
-        "size" : 8,
-        "signed" : false
-      },
-      "enumeratedConstants" : [
-        {
-          "name" : "PROC_TYPE_ZERO",
-          "value" : 1,
-          "annotation" : "Processing type 0"
-        },
-        {
-          "name" : "PROC_TYPE_ONE",
-          "value" : 2,
-          "annotation" : "Processing type 1"
-        },
-        {
-          "name" : "PROC_TYPE_TWO",
-          "value" : 4,
-          "annotation" : "Processing type 2"
-        }
-      ],
-      "default" : "ProcType.PROC_TYPE_ZERO",
-      "annotation" : "A bit mask for selecting the type of processing to perform on\na container before writing it to disk."
-    },
-    {
-      "kind" : "enum",
-      "qualifiedName" : "Module1.E2",
-      "representationType" : {
-        "name" : "I32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : true
-      },
-      "enumeratedConstants" : [
-        {
-          "name" : "PASS",
-          "value" : 0
-        },
-        {
-          "name" : "FAIL",
-          "value" : 1
-        }
-      ],
-      "default" : "Module1.E2.PASS"
-    },
-    {
       "kind" : "alias",
       "qualifiedName" : "FwEventIdType",
       "type" : {
@@ -233,16 +183,33 @@
       }
     },
     {
-      "kind" : "constant",
-      "qualifiedName" : "CONTAINER_USER_DATA_SIZE",
-      "type" : {
-        "name" : "U64",
+      "kind" : "enum",
+      "qualifiedName" : "Fw.DpCfg.ProcType",
+      "representationType" : {
+        "name" : "U8",
         "kind" : "integer",
-        "size" : 64,
+        "size" : 8,
         "signed" : false
       },
-      "value" : 1,
-      "annotation" : "The container user data size"
+      "enumeratedConstants" : [
+        {
+          "name" : "PROC_TYPE_ZERO",
+          "value" : 1,
+          "annotation" : "Processing type 0"
+        },
+        {
+          "name" : "PROC_TYPE_ONE",
+          "value" : 2,
+          "annotation" : "Processing type 1"
+        },
+        {
+          "name" : "PROC_TYPE_TWO",
+          "value" : 4,
+          "annotation" : "Processing type 2"
+        }
+      ],
+      "default" : "Fw.DpCfg.ProcType.PROC_TYPE_ZERO",
+      "annotation" : "A bit mask for selecting the type of processing to perform on\na container before writing it to disk."
     },
     {
       "kind" : "struct",
@@ -287,6 +254,22 @@
         "B"
       ],
       "annotation" : "An array of 2 String values"
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FwPacketDescriptorType",
+      "type" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      }
     },
     {
       "kind" : "alias",
@@ -403,6 +386,55 @@
       }
     },
     {
+      "kind" : "enum",
+      "qualifiedName" : "Fw.DpState",
+      "representationType" : {
+        "name" : "U8",
+        "kind" : "integer",
+        "size" : 8,
+        "signed" : false
+      },
+      "enumeratedConstants" : [
+        {
+          "name" : "UNTRANSMITTED",
+          "value" : 0,
+          "annotation" : "The untransmitted state"
+        },
+        {
+          "name" : "PARTIAL",
+          "value" : 1,
+          "annotation" : "The partially transmitted state\nA data product is in this state from the start of transmission\nuntil transmission is complete."
+        },
+        {
+          "name" : "TRANSMITTED",
+          "value" : 2,
+          "annotation" : "The transmitted state"
+        }
+      ],
+      "default" : "Fw.DpState.UNTRANSMITTED"
+    },
+    {
+      "kind" : "enum",
+      "qualifiedName" : "Module1.E2",
+      "representationType" : {
+        "name" : "I32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : true
+      },
+      "enumeratedConstants" : [
+        {
+          "name" : "PASS",
+          "value" : 0
+        },
+        {
+          "name" : "FAIL",
+          "value" : 1
+        }
+      ],
+      "default" : "Module1.E2.PASS"
+    },
+    {
       "kind" : "array",
       "qualifiedName" : "Module1.F64x4",
       "size" : 4,
@@ -467,50 +499,6 @@
         "signed" : false
       },
       "annotation" : "Alias of type AliasT1 (with underlying type U32)"
-    },
-    {
-      "kind" : "alias",
-      "qualifiedName" : "FwPacketDescriptorType",
-      "type" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
-      },
-      "underlyingType" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
-      }
-    },
-    {
-      "kind" : "enum",
-      "qualifiedName" : "DpState",
-      "representationType" : {
-        "name" : "U8",
-        "kind" : "integer",
-        "size" : 8,
-        "signed" : false
-      },
-      "enumeratedConstants" : [
-        {
-          "name" : "UNTRANSMITTED",
-          "value" : 0,
-          "annotation" : "The untransmitted state"
-        },
-        {
-          "name" : "PARTIAL",
-          "value" : 1,
-          "annotation" : "The partially transmitted state\nA data product is in this state from the start of transmission\nuntil transmission is complete."
-        },
-        {
-          "name" : "TRANSMITTED",
-          "value" : 2,
-          "annotation" : "The transmitted state"
-        }
-      ],
-      "default" : "DpState.UNTRANSMITTED"
     },
     {
       "kind" : "alias",
@@ -585,6 +573,20 @@
         "signed" : false
       },
       "annotation" : "The type used to serialize a time base value"
+    }
+  ],
+  "constants" : [
+    {
+      "kind" : "constant",
+      "qualifiedName" : "Fw.DpCfg.CONTAINER_USER_DATA_SIZE",
+      "type" : {
+        "name" : "U64",
+        "kind" : "integer",
+        "size" : 64,
+        "signed" : false
+      },
+      "value" : 1,
+      "annotation" : "The container user data size"
     }
   ],
   "commands" : [

--- a/compiler/tools/fpp-to-dict/test/top/UnqualifiedCompInstTopologyDictionary.ref.json
+++ b/compiler/tools/fpp-to-dict/test/top/UnqualifiedCompInstTopologyDictionary.ref.json
@@ -28,6 +28,35 @@
     },
     {
       "kind" : "enum",
+      "qualifiedName" : "ProcType",
+      "representationType" : {
+        "name" : "U8",
+        "kind" : "integer",
+        "size" : 8,
+        "signed" : false
+      },
+      "enumeratedConstants" : [
+        {
+          "name" : "PROC_TYPE_ZERO",
+          "value" : 1,
+          "annotation" : "Processing type 0"
+        },
+        {
+          "name" : "PROC_TYPE_ONE",
+          "value" : 2,
+          "annotation" : "Processing type 1"
+        },
+        {
+          "name" : "PROC_TYPE_TWO",
+          "value" : 4,
+          "annotation" : "Processing type 2"
+        }
+      ],
+      "default" : "ProcType.PROC_TYPE_ZERO",
+      "annotation" : "A bit mask for selecting the type of processing to perform on\na container before writing it to disk."
+    },
+    {
+      "kind" : "enum",
       "qualifiedName" : "M.E1",
       "representationType" : {
         "name" : "U32",
@@ -69,6 +98,100 @@
     },
     {
       "kind" : "alias",
+      "qualifiedName" : "FwSizeType",
+      "type" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      }
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FwTimeContextStoreType",
+      "type" : {
+        "name" : "U8",
+        "kind" : "integer",
+        "size" : 8,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U8",
+        "kind" : "integer",
+        "size" : 8,
+        "signed" : false
+      },
+      "annotation" : "The type used to serialize a time context value"
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FwDpIdType",
+      "type" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      }
+    },
+    {
+      "kind" : "constant",
+      "qualifiedName" : "CONTAINER_USER_DATA_SIZE",
+      "type" : {
+        "name" : "U64",
+        "kind" : "integer",
+        "size" : 64,
+        "signed" : false
+      },
+      "value" : 1,
+      "annotation" : "The container user data size"
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FwDpPriorityType",
+      "type" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      }
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FwTimeBaseStoreType",
+      "type" : {
+        "name" : "U16",
+        "kind" : "integer",
+        "size" : 16,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U16",
+        "kind" : "integer",
+        "size" : 16,
+        "signed" : false
+      },
+      "annotation" : "The type used to serialize a time base value"
+    },
+    {
+      "kind" : "alias",
       "qualifiedName" : "FwPacketDescriptorType",
       "type" : {
         "name" : "U32",
@@ -82,6 +205,34 @@
         "size" : 32,
         "signed" : false
       }
+    },
+    {
+      "kind" : "enum",
+      "qualifiedName" : "DpState",
+      "representationType" : {
+        "name" : "U8",
+        "kind" : "integer",
+        "size" : 8,
+        "signed" : false
+      },
+      "enumeratedConstants" : [
+        {
+          "name" : "UNTRANSMITTED",
+          "value" : 0,
+          "annotation" : "The untransmitted state"
+        },
+        {
+          "name" : "PARTIAL",
+          "value" : 1,
+          "annotation" : "The partially transmitted state\nA data product is in this state from the start of transmission\nuntil transmission is complete."
+        },
+        {
+          "name" : "TRANSMITTED",
+          "value" : 2,
+          "annotation" : "The transmitted state"
+        }
+      ],
+      "default" : "DpState.UNTRANSMITTED"
     },
     {
       "kind" : "alias",

--- a/compiler/tools/fpp-to-dict/test/top/UnqualifiedCompInstTopologyDictionary.ref.json
+++ b/compiler/tools/fpp-to-dict/test/top/UnqualifiedCompInstTopologyDictionary.ref.json
@@ -28,7 +28,7 @@
     },
     {
       "kind" : "enum",
-      "qualifiedName" : "ProcType",
+      "qualifiedName" : "Fw.DpState",
       "representationType" : {
         "name" : "U8",
         "kind" : "integer",
@@ -37,23 +37,22 @@
       },
       "enumeratedConstants" : [
         {
-          "name" : "PROC_TYPE_ZERO",
+          "name" : "UNTRANSMITTED",
+          "value" : 0,
+          "annotation" : "The untransmitted state"
+        },
+        {
+          "name" : "PARTIAL",
           "value" : 1,
-          "annotation" : "Processing type 0"
+          "annotation" : "The partially transmitted state\nA data product is in this state from the start of transmission\nuntil transmission is complete."
         },
         {
-          "name" : "PROC_TYPE_ONE",
+          "name" : "TRANSMITTED",
           "value" : 2,
-          "annotation" : "Processing type 1"
-        },
-        {
-          "name" : "PROC_TYPE_TWO",
-          "value" : 4,
-          "annotation" : "Processing type 2"
+          "annotation" : "The transmitted state"
         }
       ],
-      "default" : "ProcType.PROC_TYPE_ZERO",
-      "annotation" : "A bit mask for selecting the type of processing to perform on\na container before writing it to disk."
+      "default" : "Fw.DpState.UNTRANSMITTED"
     },
     {
       "kind" : "enum",
@@ -146,16 +145,49 @@
       }
     },
     {
-      "kind" : "constant",
-      "qualifiedName" : "CONTAINER_USER_DATA_SIZE",
-      "type" : {
-        "name" : "U64",
+      "kind" : "enum",
+      "qualifiedName" : "Fw.DpCfg.ProcType",
+      "representationType" : {
+        "name" : "U8",
         "kind" : "integer",
-        "size" : 64,
+        "size" : 8,
         "signed" : false
       },
-      "value" : 1,
-      "annotation" : "The container user data size"
+      "enumeratedConstants" : [
+        {
+          "name" : "PROC_TYPE_ZERO",
+          "value" : 1,
+          "annotation" : "Processing type 0"
+        },
+        {
+          "name" : "PROC_TYPE_ONE",
+          "value" : 2,
+          "annotation" : "Processing type 1"
+        },
+        {
+          "name" : "PROC_TYPE_TWO",
+          "value" : 4,
+          "annotation" : "Processing type 2"
+        }
+      ],
+      "default" : "Fw.DpCfg.ProcType.PROC_TYPE_ZERO",
+      "annotation" : "A bit mask for selecting the type of processing to perform on\na container before writing it to disk."
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FwPacketDescriptorType",
+      "type" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      }
     },
     {
       "kind" : "alias",
@@ -192,50 +224,6 @@
     },
     {
       "kind" : "alias",
-      "qualifiedName" : "FwPacketDescriptorType",
-      "type" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
-      },
-      "underlyingType" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
-      }
-    },
-    {
-      "kind" : "enum",
-      "qualifiedName" : "DpState",
-      "representationType" : {
-        "name" : "U8",
-        "kind" : "integer",
-        "size" : 8,
-        "signed" : false
-      },
-      "enumeratedConstants" : [
-        {
-          "name" : "UNTRANSMITTED",
-          "value" : 0,
-          "annotation" : "The untransmitted state"
-        },
-        {
-          "name" : "PARTIAL",
-          "value" : 1,
-          "annotation" : "The partially transmitted state\nA data product is in this state from the start of transmission\nuntil transmission is complete."
-        },
-        {
-          "name" : "TRANSMITTED",
-          "value" : 2,
-          "annotation" : "The transmitted state"
-        }
-      ],
-      "default" : "DpState.UNTRANSMITTED"
-    },
-    {
-      "kind" : "alias",
       "qualifiedName" : "FwOpcodeType",
       "type" : {
         "name" : "U32",
@@ -265,6 +253,20 @@
         "size" : 32,
         "signed" : false
       }
+    }
+  ],
+  "constants" : [
+    {
+      "kind" : "constant",
+      "qualifiedName" : "Fw.DpCfg.CONTAINER_USER_DATA_SIZE",
+      "type" : {
+        "name" : "U64",
+        "kind" : "integer",
+        "size" : 64,
+        "signed" : false
+      },
+      "value" : 1,
+      "annotation" : "The container user data size"
     }
   ],
   "commands" : [

--- a/compiler/tools/fpp-to-dict/test/top/UnqualifiedCompInstTopologyDictionary.ref.json
+++ b/compiler/tools/fpp-to-dict/test/top/UnqualifiedCompInstTopologyDictionary.ref.json
@@ -175,6 +175,22 @@
     },
     {
       "kind" : "alias",
+      "qualifiedName" : "FwSizeStoreType",
+      "type" : {
+        "name" : "U16",
+        "kind" : "integer",
+        "size" : 16,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U16",
+        "kind" : "integer",
+        "size" : 16,
+        "signed" : false
+      }
+    },
+    {
+      "kind" : "alias",
       "qualifiedName" : "FwPacketDescriptorType",
       "type" : {
         "name" : "U32",
@@ -265,7 +281,7 @@
         "size" : 64,
         "signed" : false
       },
-      "value" : 1,
+      "value" : 32,
       "annotation" : "The container user data size"
     }
   ],

--- a/compiler/tools/fpp-to-dict/test/top/arrayFwEventIdType.fpp
+++ b/compiler/tools/fpp-to-dict/test/top/arrayFwEventIdType.fpp
@@ -6,6 +6,7 @@ type FwOpcodeType = U32
 type FwPacketDescriptorType = U32
 type FwTlmPacketizeIdType = U16
 type FwSizeType = U32
+type FwSizeStoreType = U16
 
 @ The type used to serialize a time base value
 type FwTimeBaseStoreType = U16

--- a/compiler/tools/fpp-to-dict/test/top/arrayFwEventIdType.fpp
+++ b/compiler/tools/fpp-to-dict/test/top/arrayFwEventIdType.fpp
@@ -13,30 +13,34 @@ type FwTimeBaseStoreType = U16
 @ The type used to serialize a time context value
 type FwTimeContextStoreType = U8
 
-@ The container user data size
-constant CONTAINER_USER_DATA_SIZE = 1
+module Fw {
+    enum DpState: U8 {
+        @ The untransmitted state
+        UNTRANSMITTED
+        @ The partially transmitted state
+        @ A data product is in this state from the start of transmission
+        @ until transmission is complete.
+        PARTIAL
+        @ The transmitted state
+        TRANSMITTED
+    } default UNTRANSMITTED
 
-@ A bit mask for selecting the type of processing to perform on
-@ a container before writing it to disk.
-enum ProcType: U8 {
-    @ Processing type 0
-    PROC_TYPE_ZERO = 0x01
-    @ Processing type 1
-    PROC_TYPE_ONE = 0x02
-    @ Processing type 2
-    PROC_TYPE_TWO = 0x04
+    module DpCfg {
+        @ The container user data size
+        constant CONTAINER_USER_DATA_SIZE = 1
+
+        @ A bit mask for selecting the type of processing to perform on
+        @ a container before writing it to disk.
+        enum ProcType: U8 {
+            @ Processing type 0
+            PROC_TYPE_ZERO = 0x01
+            @ Processing type 1
+            PROC_TYPE_ONE = 0x02
+            @ Processing type 2
+            PROC_TYPE_TWO = 0x04
+        }
+    }
 }
-
-enum DpState: U8 {
-    @ The untransmitted state
-    UNTRANSMITTED
-    @ The partially transmitted state
-    @ A data product is in this state from the start of transmission
-    @ until transmission is complete.
-    PARTIAL
-    @ The transmitted state
-    TRANSMITTED
-} default UNTRANSMITTED
 
 topology T {
   

--- a/compiler/tools/fpp-to-dict/test/top/arrayFwEventIdType.fpp
+++ b/compiler/tools/fpp-to-dict/test/top/arrayFwEventIdType.fpp
@@ -1,8 +1,42 @@
-type FwPacketDescriptorType = U32
-type FwOpcodeType = U32
 type FwChanIdType = U32
-type FwTlmPacketizeIdType = U16
+type FwDpIdType = U32
+type FwDpPriorityType = U32
 array FwEventIdType = [3] F32
+type FwOpcodeType = U32
+type FwPacketDescriptorType = U32
+type FwTlmPacketizeIdType = U16
+type FwSizeType = U32
+
+@ The type used to serialize a time base value
+type FwTimeBaseStoreType = U16
+
+@ The type used to serialize a time context value
+type FwTimeContextStoreType = U8
+
+@ The container user data size
+constant CONTAINER_USER_DATA_SIZE = 1
+
+@ A bit mask for selecting the type of processing to perform on
+@ a container before writing it to disk.
+enum ProcType: U8 {
+    @ Processing type 0
+    PROC_TYPE_ZERO = 0x01
+    @ Processing type 1
+    PROC_TYPE_ONE = 0x02
+    @ Processing type 2
+    PROC_TYPE_TWO = 0x04
+}
+
+enum DpState: U8 {
+    @ The untransmitted state
+    UNTRANSMITTED
+    @ The partially transmitted state
+    @ A data product is in this state from the start of transmission
+    @ until transmission is complete.
+    PARTIAL
+    @ The transmitted state
+    TRANSMITTED
+} default UNTRANSMITTED
 
 topology T {
   

--- a/compiler/tools/fpp-to-dict/test/top/arrayFwEventIdType.ref.txt
+++ b/compiler/tools/fpp-to-dict/test/top/arrayFwEventIdType.ref.txt
@@ -1,5 +1,5 @@
 fpp-to-dict
-[ local path prefix ]/tools/fpp-to-dict/test/top/arrayFwEventIdType.fpp:5.1
+[ local path prefix ]/tools/fpp-to-dict/test/top/arrayFwEventIdType.fpp:4.1
 array FwEventIdType = [3] F32
 ^
 error: this F Prime framework type must be an alias of an integer type

--- a/compiler/tools/fpp-to-dict/test/top/config.fpp
+++ b/compiler/tools/fpp-to-dict/test/top/config.fpp
@@ -6,6 +6,7 @@ type FwOpcodeType = U32
 type FwPacketDescriptorType = U32
 type FwTlmPacketizeIdType = U16
 type FwSizeType = U32
+type FwSizeStoreType = U16
 
 @ The type used to serialize a time base value
 type FwTimeBaseStoreType = U16
@@ -27,7 +28,7 @@ module Fw {
 
     module DpCfg {
         @ The container user data size
-        constant CONTAINER_USER_DATA_SIZE = 1
+        constant CONTAINER_USER_DATA_SIZE = 32
 
         @ A bit mask for selecting the type of processing to perform on
         @ a container before writing it to disk.

--- a/compiler/tools/fpp-to-dict/test/top/config.fpp
+++ b/compiler/tools/fpp-to-dict/test/top/config.fpp
@@ -2,6 +2,7 @@ type FwChanIdType = U32
 type FwDpIdType = U32
 type FwDpPriorityType = U32
 type FwEventIdType = U32
+type FwOpcodeType = U32
 type FwPacketDescriptorType = U32
 type FwTlmPacketizeIdType = U16
 type FwSizeType = U32
@@ -36,6 +37,3 @@ enum DpState: U8 {
     @ The transmitted state
     TRANSMITTED
 } default UNTRANSMITTED
-topology T {
-
-}

--- a/compiler/tools/fpp-to-dict/test/top/floatFwEventIdType.fpp
+++ b/compiler/tools/fpp-to-dict/test/top/floatFwEventIdType.fpp
@@ -6,6 +6,7 @@ type FwOpcodeType = U32
 type FwPacketDescriptorType = U32
 type FwTlmPacketizeIdType = U16
 type FwSizeType = U32
+type FwSizeStoreType = U16
 
 @ The type used to serialize a time base value
 type FwTimeBaseStoreType = U16

--- a/compiler/tools/fpp-to-dict/test/top/floatFwEventIdType.fpp
+++ b/compiler/tools/fpp-to-dict/test/top/floatFwEventIdType.fpp
@@ -1,8 +1,42 @@
-type FwPacketDescriptorType = U32
-type FwOpcodeType = U32
 type FwChanIdType = U32
-type FwTlmPacketizeIdType = U16
+type FwDpIdType = U32
+type FwDpPriorityType = U32
 type FwEventIdType = F32
+type FwOpcodeType = U32
+type FwPacketDescriptorType = U32
+type FwTlmPacketizeIdType = U16
+type FwSizeType = U32
+
+@ The type used to serialize a time base value
+type FwTimeBaseStoreType = U16
+
+@ The type used to serialize a time context value
+type FwTimeContextStoreType = U8
+
+@ The container user data size
+constant CONTAINER_USER_DATA_SIZE = 1
+
+@ A bit mask for selecting the type of processing to perform on
+@ a container before writing it to disk.
+enum ProcType: U8 {
+    @ Processing type 0
+    PROC_TYPE_ZERO = 0x01
+    @ Processing type 1
+    PROC_TYPE_ONE = 0x02
+    @ Processing type 2
+    PROC_TYPE_TWO = 0x04
+}
+
+enum DpState: U8 {
+    @ The untransmitted state
+    UNTRANSMITTED
+    @ The partially transmitted state
+    @ A data product is in this state from the start of transmission
+    @ until transmission is complete.
+    PARTIAL
+    @ The transmitted state
+    TRANSMITTED
+} default UNTRANSMITTED
 
 topology T {
   

--- a/compiler/tools/fpp-to-dict/test/top/floatFwEventIdType.fpp
+++ b/compiler/tools/fpp-to-dict/test/top/floatFwEventIdType.fpp
@@ -13,30 +13,34 @@ type FwTimeBaseStoreType = U16
 @ The type used to serialize a time context value
 type FwTimeContextStoreType = U8
 
-@ The container user data size
-constant CONTAINER_USER_DATA_SIZE = 1
+module Fw {
+    enum DpState: U8 {
+        @ The untransmitted state
+        UNTRANSMITTED
+        @ The partially transmitted state
+        @ A data product is in this state from the start of transmission
+        @ until transmission is complete.
+        PARTIAL
+        @ The transmitted state
+        TRANSMITTED
+    } default UNTRANSMITTED
 
-@ A bit mask for selecting the type of processing to perform on
-@ a container before writing it to disk.
-enum ProcType: U8 {
-    @ Processing type 0
-    PROC_TYPE_ZERO = 0x01
-    @ Processing type 1
-    PROC_TYPE_ONE = 0x02
-    @ Processing type 2
-    PROC_TYPE_TWO = 0x04
+    module DpCfg {
+        @ The container user data size
+        constant CONTAINER_USER_DATA_SIZE = 1
+
+        @ A bit mask for selecting the type of processing to perform on
+        @ a container before writing it to disk.
+        enum ProcType: U8 {
+            @ Processing type 0
+            PROC_TYPE_ZERO = 0x01
+            @ Processing type 1
+            PROC_TYPE_ONE = 0x02
+            @ Processing type 2
+            PROC_TYPE_TWO = 0x04
+        }
+    }
 }
-
-enum DpState: U8 {
-    @ The untransmitted state
-    UNTRANSMITTED
-    @ The partially transmitted state
-    @ A data product is in this state from the start of transmission
-    @ until transmission is complete.
-    PARTIAL
-    @ The transmitted state
-    TRANSMITTED
-} default UNTRANSMITTED
 
 topology T {
   

--- a/compiler/tools/fpp-to-dict/test/top/floatFwEventIdType.ref.txt
+++ b/compiler/tools/fpp-to-dict/test/top/floatFwEventIdType.ref.txt
@@ -1,5 +1,5 @@
 fpp-to-dict
-[ local path prefix ]/tools/fpp-to-dict/test/top/floatFwEventIdType.fpp:5.1
+[ local path prefix ]/tools/fpp-to-dict/test/top/floatFwEventIdType.fpp:4.1
 type FwEventIdType = F32
 ^
 error: this F Prime framework type must be an alias of an integer type

--- a/compiler/tools/fpp-to-dict/test/top/floatUserDataSizeConstant.fpp
+++ b/compiler/tools/fpp-to-dict/test/top/floatUserDataSizeConstant.fpp
@@ -1,0 +1,48 @@
+type FwChanIdType = U32
+type FwDpIdType = U32
+type FwDpPriorityType = U32
+type FwEventIdType = U32
+type FwOpcodeType = U32
+type FwPacketDescriptorType = U32
+type FwTlmPacketizeIdType = U16
+type FwSizeType = U32
+type FwSizeStoreType = U16
+
+@ The type used to serialize a time base value
+type FwTimeBaseStoreType = U16
+
+@ The type used to serialize a time context value
+type FwTimeContextStoreType = U8
+
+module Fw {
+    enum DpState: U8 {
+        @ The untransmitted state
+        UNTRANSMITTED
+        @ The partially transmitted state
+        @ A data product is in this state from the start of transmission
+        @ until transmission is complete.
+        PARTIAL
+        @ The transmitted state
+        TRANSMITTED
+    } default UNTRANSMITTED
+
+    module DpCfg {
+        @ The container user data size
+        constant CONTAINER_USER_DATA_SIZE = 1.5
+
+        @ A bit mask for selecting the type of processing to perform on
+        @ a container before writing it to disk.
+        enum ProcType: U8 {
+            @ Processing type 0
+            PROC_TYPE_ZERO = 0x01
+            @ Processing type 1
+            PROC_TYPE_ONE = 0x02
+            @ Processing type 2
+            PROC_TYPE_TWO = 0x04
+        }
+    }
+}
+
+topology T {
+  
+}

--- a/compiler/tools/fpp-to-dict/test/top/floatUserDataSizeConstant.ref.txt
+++ b/compiler/tools/fpp-to-dict/test/top/floatUserDataSizeConstant.ref.txt
@@ -1,0 +1,5 @@
+fpp-to-dict
+[ local path prefix ]/tools/fpp-to-dict/test/top/floatUserDataSizeConstant.fpp:31.9
+        constant CONTAINER_USER_DATA_SIZE = 1.5
+        ^
+error: this F Prime constant must have an integer type

--- a/compiler/tools/fpp-to-dict/test/top/fwTypes.fpp
+++ b/compiler/tools/fpp-to-dict/test/top/fwTypes.fpp
@@ -1,5 +1,0 @@
-type FwEventIdType = U32
-type FwChanIdType = U32
-type FwOpcodeType = U32
-type FwPacketDescriptorType = U32
-type FwTlmPacketizeIdType = U16

--- a/compiler/tools/fpp-to-dict/test/top/missingFwOpcodeType.fpp
+++ b/compiler/tools/fpp-to-dict/test/top/missingFwOpcodeType.fpp
@@ -12,30 +12,35 @@ type FwTimeBaseStoreType = U16
 @ The type used to serialize a time context value
 type FwTimeContextStoreType = U8
 
-@ The container user data size
-constant CONTAINER_USER_DATA_SIZE = 1
+module Fw {
+    enum DpState: U8 {
+        @ The untransmitted state
+        UNTRANSMITTED
+        @ The partially transmitted state
+        @ A data product is in this state from the start of transmission
+        @ until transmission is complete.
+        PARTIAL
+        @ The transmitted state
+        TRANSMITTED
+    } default UNTRANSMITTED
 
-@ A bit mask for selecting the type of processing to perform on
-@ a container before writing it to disk.
-enum ProcType: U8 {
-    @ Processing type 0
-    PROC_TYPE_ZERO = 0x01
-    @ Processing type 1
-    PROC_TYPE_ONE = 0x02
-    @ Processing type 2
-    PROC_TYPE_TWO = 0x04
+    module DpCfg {
+        @ The container user data size
+        constant CONTAINER_USER_DATA_SIZE = 1
+
+        @ A bit mask for selecting the type of processing to perform on
+        @ a container before writing it to disk.
+        enum ProcType: U8 {
+            @ Processing type 0
+            PROC_TYPE_ZERO = 0x01
+            @ Processing type 1
+            PROC_TYPE_ONE = 0x02
+            @ Processing type 2
+            PROC_TYPE_TWO = 0x04
+        }
+    }
 }
 
-enum DpState: U8 {
-    @ The untransmitted state
-    UNTRANSMITTED
-    @ The partially transmitted state
-    @ A data product is in this state from the start of transmission
-    @ until transmission is complete.
-    PARTIAL
-    @ The transmitted state
-    TRANSMITTED
-} default UNTRANSMITTED
 topology T {
-
+  
 }

--- a/compiler/tools/fpp-to-dict/test/top/missingFwOpcodeType.fpp
+++ b/compiler/tools/fpp-to-dict/test/top/missingFwOpcodeType.fpp
@@ -5,6 +5,7 @@ type FwEventIdType = U32
 type FwPacketDescriptorType = U32
 type FwTlmPacketizeIdType = U16
 type FwSizeType = U32
+type FwSizeStoreType = U16
 
 @ The type used to serialize a time base value
 type FwTimeBaseStoreType = U16

--- a/compiler/tools/fpp-to-dict/test/top/missingFwOpcodeType.ref.txt
+++ b/compiler/tools/fpp-to-dict/test/top/missingFwOpcodeType.ref.txt
@@ -1,6 +1,6 @@
 fpp-to-dict
-[ local path prefix ]/tools/fpp-to-dict/test/top/missingFwOpcodeType.fpp:6.1
+[ local path prefix ]/tools/fpp-to-dict/test/top/missingFwOpcodeType.fpp:39.1
 topology T {
 ^
 error: undefined symbol FwOpcodeType
-note: when constructing a dictionary, the type FwOpcodeType must be defined
+note: when constructing a dictionary, the alias FwOpcodeType must be defined

--- a/compiler/tools/fpp-to-dict/test/top/missingFwOpcodeType.ref.txt
+++ b/compiler/tools/fpp-to-dict/test/top/missingFwOpcodeType.ref.txt
@@ -1,5 +1,5 @@
 fpp-to-dict
-[ local path prefix ]/tools/fpp-to-dict/test/top/missingFwOpcodeType.fpp:44.1
+[ local path prefix ]/tools/fpp-to-dict/test/top/missingFwOpcodeType.fpp:45.1
 topology T {
 ^
 error: undefined symbol FwOpcodeType

--- a/compiler/tools/fpp-to-dict/test/top/missingFwOpcodeType.ref.txt
+++ b/compiler/tools/fpp-to-dict/test/top/missingFwOpcodeType.ref.txt
@@ -1,5 +1,5 @@
 fpp-to-dict
-[ local path prefix ]/tools/fpp-to-dict/test/top/missingFwOpcodeType.fpp:39.1
+[ local path prefix ]/tools/fpp-to-dict/test/top/missingFwOpcodeType.fpp:44.1
 topology T {
 ^
 error: undefined symbol FwOpcodeType

--- a/compiler/tools/fpp-to-dict/test/top/missingUserDataSizeConstant.fpp
+++ b/compiler/tools/fpp-to-dict/test/top/missingUserDataSizeConstant.fpp
@@ -6,6 +6,7 @@ type FwOpcodeType = U32
 type FwPacketDescriptorType = U32
 type FwTlmPacketizeIdType = U16
 type FwSizeType = U32
+type FwSizeStoreType = U16
 
 @ The type used to serialize a time base value
 type FwTimeBaseStoreType = U16

--- a/compiler/tools/fpp-to-dict/test/top/missingUserDataSizeConstant.fpp
+++ b/compiler/tools/fpp-to-dict/test/top/missingUserDataSizeConstant.fpp
@@ -26,9 +26,6 @@ module Fw {
     } default UNTRANSMITTED
 
     module DpCfg {
-        @ The container user data size
-        constant CONTAINER_USER_DATA_SIZE = 1
-
         @ A bit mask for selecting the type of processing to perform on
         @ a container before writing it to disk.
         enum ProcType: U8 {
@@ -40,4 +37,8 @@ module Fw {
             PROC_TYPE_TWO = 0x04
         }
     }
+}
+
+topology T {
+  
 }

--- a/compiler/tools/fpp-to-dict/test/top/missingUserDataSizeConstant.ref.txt
+++ b/compiler/tools/fpp-to-dict/test/top/missingUserDataSizeConstant.ref.txt
@@ -1,0 +1,6 @@
+fpp-to-dict
+[ local path prefix ]/tools/fpp-to-dict/test/top/missingUserDataSizeConstant.fpp:42.1
+topology T {
+^
+error: undefined symbol CONTAINER_USER_DATA_SIZE
+note: when constructing a dictionary, the constant Fw.DpCfg.CONTAINER_USER_DATA_SIZE must be defined

--- a/compiler/tools/fpp-to-dict/test/top/missingUserDataSizeConstant.ref.txt
+++ b/compiler/tools/fpp-to-dict/test/top/missingUserDataSizeConstant.ref.txt
@@ -1,5 +1,5 @@
 fpp-to-dict
-[ local path prefix ]/tools/fpp-to-dict/test/top/missingUserDataSizeConstant.fpp:42.1
+[ local path prefix ]/tools/fpp-to-dict/test/top/missingUserDataSizeConstant.fpp:43.1
 topology T {
 ^
 error: undefined symbol CONTAINER_USER_DATA_SIZE

--- a/compiler/tools/fpp-to-dict/test/top/run.sh
+++ b/compiler/tools/fpp-to-dict/test/top/run.sh
@@ -52,6 +52,12 @@ floatFwEventType()
     compare floatFwEventType
 }
 
+floatUserDataSizeConstant()
+{
+  run_test '' floatUserDataSizeConstant && \
+    compare floatUserDataSizeConstant
+}
+
 unqualifiedComponentInstances()
 {
   run_test "-i builtin.fpp,config.fpp -p 1.0.0 -f 3.4.3 -l lib1-1.0.0,lib2-2.0.0" unqualifiedComponentInstances && \

--- a/compiler/tools/fpp-to-dict/test/top/run.sh
+++ b/compiler/tools/fpp-to-dict/test/top/run.sh
@@ -1,6 +1,6 @@
 multipleTops()
 {
-  run_test "-i builtin.fpp,fwTypes.fpp -p 1.0.0 -f 3.4.3 -l lib1-1.0.0,lib2-2.0.0" multipleTops && \
+  run_test "-i builtin.fpp,config.fpp -p 1.0.0 -f 3.4.3 -l lib1-1.0.0,lib2-2.0.0" multipleTops && \
     validate_json_schema FirstTop && \
     validate_json_schema SecondTop && \
     diff_json FirstTop && \
@@ -9,21 +9,21 @@ multipleTops()
 
 basic()
 {
-  run_test "-i fwTypes.fpp -p 1.0.0 -f 3.4.3" basic && \
+  run_test "-i config.fpp -p 1.0.0 -f 3.4.3" basic && \
     validate_json_schema Basic && \
     diff_json Basic
 }
 
 dataProducts()
 {
-  run_test "-i builtin.fpp,fwTypes.fpp -p 1.0.0 -f 3.4.3" dataProducts && \
+  run_test "-i builtin.fpp,config.fpp -p 1.0.0 -f 3.4.3" dataProducts && \
     validate_json_schema BasicDp && \
     diff_json BasicDp
 }
 
 duplicate()
 {
-  run_test '-i fwTypes.fpp' duplicate && \
+  run_test '-i config.fpp' duplicate && \
     compare duplicate
 }
 
@@ -47,7 +47,7 @@ floatFwEventType()
 
 unqualifiedComponentInstances()
 {
-  run_test "-i builtin.fpp,fwTypes.fpp -p 1.0.0 -f 3.4.3 -l lib1-1.0.0,lib2-2.0.0" unqualifiedComponentInstances && \
+  run_test "-i builtin.fpp,config.fpp -p 1.0.0 -f 3.4.3 -l lib1-1.0.0,lib2-2.0.0" unqualifiedComponentInstances && \
     validate_json_schema QualifiedCompInst && \
     validate_json_schema UnqualifiedCompInst && \
     diff_json QualifiedCompInst && \

--- a/compiler/tools/fpp-to-dict/test/top/run.sh
+++ b/compiler/tools/fpp-to-dict/test/top/run.sh
@@ -33,6 +33,13 @@ missingFwOpcodeType()
     compare missingFwOpcodeType
 }
 
+missingUserDataSizeConstant()
+{
+  run_test '' missingUserDataSizeConstant && \
+    compare missingUserDataSizeConstant
+}
+
+
 arrayFwEventType()
 {
   run_test '' arrayFwEventType && \

--- a/compiler/tools/fpp-to-dict/test/top/tests.sh
+++ b/compiler/tools/fpp-to-dict/test/top/tests.sh
@@ -7,5 +7,6 @@ missingFwOpcodeType
 missingUserDataSizeConstant
 arrayFwEventIdType
 floatFwEventIdType
+floatUserDataSizeConstant
 unqualifiedComponentInstances
 "

--- a/compiler/tools/fpp-to-dict/test/top/tests.sh
+++ b/compiler/tools/fpp-to-dict/test/top/tests.sh
@@ -4,6 +4,7 @@ basic
 dataProducts
 duplicate
 missingFwOpcodeType
+missingUserDataSizeConstant
 arrayFwEventIdType
 floatFwEventIdType
 unqualifiedComponentInstances

--- a/compiler/tools/fpp-to-dict/test/top/update-ref.sh
+++ b/compiler/tools/fpp-to-dict/test/top/update-ref.sh
@@ -1,30 +1,30 @@
 multipleTops()
 {
-  update "-i builtin.fpp,fwTypes.fpp -p 1.0.0 -f 3.4.3 -l lib1-1.0.0,lib2-2.0.0" multipleTops
+  update "-i builtin.fpp,config.fpp -p 1.0.0 -f 3.4.3 -l lib1-1.0.0,lib2-2.0.0" multipleTops
   move_json FirstTop
   move_json SecondTop
 }
 
 basic()
 {
-  update "-i fwTypes.fpp -p 1.0.0 -f 3.4.3" basic
+  update "-i config.fpp -p 1.0.0 -f 3.4.3" basic
   move_json Basic
 }
 
 dataProducts()
 {
-  update "-i builtin.fpp,fwTypes.fpp -p 1.0.0 -f 3.4.3" dataProducts
+  update "-i builtin.fpp,config.fpp -p 1.0.0 -f 3.4.3" dataProducts
   move_json BasicDp
 }
 
 duplicate()
 {
-  update '-i fwTypes.fpp' duplicate
+  update '-i config.fpp' duplicate
 }
 
 unqualifiedComponentInstances()
 {
-  update "-i builtin.fpp,fwTypes.fpp -p 1.0.0 -f 3.4.3 -l lib1-1.0.0,lib2-2.0.0" unqualifiedComponentInstances
+  update "-i builtin.fpp,config.fpp -p 1.0.0 -f 3.4.3 -l lib1-1.0.0,lib2-2.0.0" unqualifiedComponentInstances
   move_json QualifiedCompInst
   move_json UnqualifiedCompInst
 }

--- a/docs/fpp-spec.html
+++ b/docs/fpp-spec.html
@@ -11171,7 +11171,7 @@ equivalent.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2025-06-11 10:55:39 -0700
+Last updated 2025-06-10 16:17:44 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-spec.html
+++ b/docs/fpp-spec.html
@@ -11171,7 +11171,7 @@ equivalent.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2025-05-21 16:29:07 -0700
+Last updated 2025-06-10 16:17:44 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-spec.html
+++ b/docs/fpp-spec.html
@@ -11171,7 +11171,7 @@ equivalent.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2025-06-10 16:17:44 -0700
+Last updated 2025-06-11 10:55:39 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-users-guide.html
+++ b/docs/fpp-users-guide.html
@@ -14757,71 +14757,76 @@ These definitions are required by the F Prime GDS.</p>
 <td class="tableblock halign-left valign-top"><p class="tableblock">The type of a telemetry channel identifier</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Underlying type must be an integer type</p></td>
 </tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>FwEventIdType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Alias type definition</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The type of an event identifier</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Underlying type must be an integer type</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>FwOpcodeType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Alias type definition</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The type of a command opcode</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Underlying type must be an integer type</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>FwPacketDescriptorType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Alias type definition</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The type of a com packet descriptor</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Underlying type must be an integer type</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>FwDpIdType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Alias type definition</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The type of a data product identifier</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Underlying type must be an integer type</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>FwDpPriorityType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Alias type definition</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The type of a data product priority</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Underlying type must be an integer type</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>FwSizeStoreType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Alias type definition</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The type used to serialize a size value</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Underlying type must be an integer type</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>FwTimeBaseStoreType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Alias type definition</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The type used to serialize a time base value</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Underlying type must be an integer type</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>FwTimeContextStoreType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Alias type definition</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The type used to serialize a time context value</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Underlying type must be an integer type</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Fw.DpState</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Enum type definition</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The data product state</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Fw.DpCfg.ProcType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Enum type definition</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">A bit mask for selecting the type of processing
+to perform on a container before writing it to disk.</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Fw.DpCfg.CONTAINER_USER_DATA_SIZE</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Constant definition</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The size in bytes of the user-configurable
+data in the container packet header</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Constant must be an integer type</p></td>
+</tr>
 </tbody>
 </table>
-<div class="paragraph">
-<p>Alias Types:</p>
-</div>
-<div class="ulist">
-<ul>
-<li>
-<p><code>FwChanIdType</code></p>
-</li>
-<li>
-<p><code>FwEventIdType</code></p>
-</li>
-<li>
-<p><code>FwOpcodeType</code></p>
-</li>
-<li>
-<p><code>FwPacketDescriptorType</code></p>
-</li>
-<li>
-<p><code>FwTlmPacketizeIdType</code></p>
-</li>
-<li>
-<p><code>FwDpIdType</code></p>
-</li>
-<li>
-<p><code>FwDpPriorityType</code></p>
-</li>
-<li>
-<p><code>FwSizeStoreType</code></p>
-</li>
-<li>
-<p><code>FwTimeBaseStoreType</code></p>
-</li>
-<li>
-<p><code>FwTimeContextStoreType</code></p>
-</li>
-</ul>
-</div>
-<div class="paragraph">
-<p>Enumerations:</p>
-</div>
-<div class="ulist">
-<ul>
-<li>
-<p><code>Fw.DpState</code></p>
-</li>
-<li>
-<p><code>Fw.DpCfg.ProcType</code></p>
-</li>
-</ul>
-</div>
-<div class="paragraph">
-<p>Constants:</p>
-</div>
-<div class="ulist">
-<ul>
-<li>
-<p><code>Fw.DpCfg.CONTAINER_USER_DATA_SIZE</code></p>
-</li>
-</ul>
-</div>
-<div class="paragraph">
-<p>The alias types and constants required by the dictionary must all be integer types.</p>
-</div>
 <div class="paragraph">
 <p>Typically you specify these types as part of F Prime configuration,
 in the file <code>config/FpConfig.fpp</code>.
@@ -15747,7 +15752,7 @@ serialized according to its
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2025-06-11 11:15:12 -0700
+Last updated 2025-06-11 13:32:02 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-users-guide.html
+++ b/docs/fpp-users-guide.html
@@ -2809,7 +2809,8 @@ array A = [3] T</code></pre>
 </div>
 </div>
 <div class="paragraph">
-<p>An alias type definition may refer to any type, including another
+<p><strong>Rules for alias type definitions:</strong>
+An alias type definition may refer to any type, including another
 alias type, except that it may not refer to itself, either directly or through
 another alias.
 For example, here is an alias type definition specifying that the type
@@ -2842,7 +2843,22 @@ type T = S</code></pre>
 </div>
 </div>
 <div class="paragraph">
-<p>Alias type definitions are useful for specifying configurations.
+<p><strong>Underlying types:</strong>
+Because an alias type definition may not refer to itself, every
+chain of aliases ends in a type that is not an alias.
+This type is called the <strong>underlying type</strong> of all the aliases
+in the chain.
+For example:</p>
+</div>
+<div class="listingblock fpp">
+<div class="content">
+<pre class="prettyprint highlight"><code>type S = T   # Underlying type of S is U32
+type T = U32 # Underlying type of T is U32</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>Configuration:</strong>
+Alias type definitions are useful for specifying configurations.
 Part of a model can use a type <code>T</code>, without
 defining <code>T</code>; elsewhere, configuration code can define
 <code>T</code> to be the alias of another type.
@@ -14714,10 +14730,35 @@ are generated for them.</p>
 </div>
 <div class="paragraph">
 <p><strong>F Prime configuration:</strong>
-There are various types and constants required by the F Prime GDS, so they
-are included in the dictionary. When you run <code>fpp-to-dict</code> on an FPP model,
-the model must define the following alias types, enumerations, and constants:</p>
+When you run <code>fpp-to-dict</code> on an FPP model,
+the model must contain the definitions shown in Table <a href="#dict-defs">Definitions Required by the GDS</a>.
+These definitions are required by the F Prime GDS.</p>
 </div>
+<table id="dict-defs" class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 5. Definitions Required by the GDS</caption>
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Kind</th>
+<th class="tableblock halign-left valign-top">Purpose</th>
+<th class="tableblock halign-left valign-top">Notes</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>FwChanIdType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Alias type definition</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The type of a telemetry channel identifier</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Underlying type must be an integer type</p></td>
+</tr>
+</tbody>
+</table>
 <div class="paragraph">
 <p>Alias Types:</p>
 </div>
@@ -15706,7 +15747,7 @@ serialized according to its
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2025-06-11 09:17:55 -0700
+Last updated 2025-06-11 11:15:12 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-users-guide.html
+++ b/docs/fpp-users-guide.html
@@ -14782,20 +14782,6 @@ the model must define the following alias types, enumerations, and constants:</p
 <p>The alias types and constants required by the dictionary must all be integer types.</p>
 </div>
 <div class="paragraph">
-<p>Type information for constant dictionary entries is determined by
-checking the sign of a constant and will always default to the maximum integer size (64 bits):</p>
-</div>
-<div class="ulist">
-<ul>
-<li>
-<p>If the constant is positive, the type of the constant is U64.</p>
-</li>
-<li>
-<p>If the constant is negative, the type of the constant is I64.</p>
-</li>
-</ul>
-</div>
-<div class="paragraph">
 <p>Typically you specify these types as part of F Prime configuration,
 in the file <code>config/FpConfig.fpp</code>.
 See the
@@ -15720,7 +15706,7 @@ serialized according to its
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2025-06-10 16:27:26 -0700
+Last updated 2025-06-11 09:17:55 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-users-guide.html
+++ b/docs/fpp-users-guide.html
@@ -14714,8 +14714,12 @@ are generated for them.</p>
 </div>
 <div class="paragraph">
 <p><strong>F Prime configuration:</strong>
-When you run <code>fpp-to-dict</code> on an FPP model, the model must define the following
-types:</p>
+There are various types and constants required by the F Prime GDS, so they
+are included in the dictionary. When you run <code>fpp-to-dict</code> on an FPP model,
+the model must define the following alias types, enumerations, and constants:</p>
+</div>
+<div class="paragraph">
+<p>Alias Types:</p>
 </div>
 <div class="ulist">
 <ul>
@@ -14734,13 +14738,65 @@ types:</p>
 <li>
 <p><code>FwTlmPacketizeIdType</code></p>
 </li>
+<li>
+<p><code>FwDpIdType</code></p>
+</li>
+<li>
+<p><code>FwDpPriorityType</code></p>
+</li>
+<li>
+<p><code>FwSizeStoreType</code></p>
+</li>
+<li>
+<p><code>FwTimeBaseStoreType</code></p>
+</li>
+<li>
+<p><code>FwTimeContextStoreType</code></p>
+</li>
 </ul>
 </div>
 <div class="paragraph">
-<p>These types are required by the F Prime GDS, so they are included in the
-dictionary.
-Each of these types must be an alias of an integer type.
-Typically you specify these types as part of F Prime configuration,
+<p>Enumerations:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><code>Fw.DpState</code></p>
+</li>
+<li>
+<p><code>Fw.DpCfg.ProcType</code></p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Constants:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><code>Fw.DpCfg.CONTAINER_USER_DATA_SIZE</code></p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>The alias types and constants required by the dictionary must all be integer types.</p>
+</div>
+<div class="paragraph">
+<p>Type information for constant dictionary entries is determined by
+checking the sign of a constant and will always default to the maximum integer size (64 bits):</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>If the constant is positive, the type of the constant is U64.</p>
+</li>
+<li>
+<p>If the constant is negative, the type of the constant is I64.</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Typically you specify these types as part of F Prime configuration,
 in the file <code>config/FpConfig.fpp</code>.
 See the
 <a href="https://fprime.jpl.nasa.gov/devel/docs/user-manual/framework/configuring-fprime/">F
@@ -15664,7 +15720,7 @@ serialized according to its
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2025-05-21 16:29:41 -0700
+Last updated 2025-06-10 16:27:26 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -140,7 +140,7 @@ p a>code:hover{color:rgba(0,0,0,.9)}
 #content::before{content:none}
 #header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
 #header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
-#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
+#header>h1:only-child{border-bottom:1px solid #dddddf;padding-bottom:8px}
 #header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
 #header .details span:first-child{margin-left:-.125em}
 #header .details span.email a{color:rgba(0,0,0,.85)}
@@ -162,6 +162,7 @@ p a>code:hover{color:rgba(0,0,0,.9)}
 #toctitle{color:#7a2518;font-size:1.2em}
 @media screen and (min-width:768px){#toctitle{font-size:1.375em}
 body.toc2{padding-left:15em;padding-right:0}
+body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
 #toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
 #toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
 #toc.toc2>ul{font-size:.9em;margin-bottom:0}
@@ -327,7 +328,7 @@ a.image{text-decoration:none;display:inline-block}
 a.image object{pointer-events:none}
 sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
 sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+sup.footnote a:active,sup.footnoteref a:active,#footnotes .footnote a:first-of-type:active{text-decoration:underline}
 #footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
 #footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
 #footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
@@ -463,7 +464,7 @@ generated code.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2025-02-18 09:43:03 -0800
+Last updated 2025-05-15 16:08:32 -0700
 </div>
 </div>
 </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.20">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>F Prime Prime (FPP)</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
@@ -464,7 +464,7 @@ generated code.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2025-05-15 16:08:32 -0700
+Last updated 2025-02-14 13:29:20 -0800
 </div>
 </div>
 </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -464,7 +464,7 @@ generated code.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2025-02-14 13:29:20 -0800
+Last updated 2025-05-15 16:08:32 -0700
 </div>
 </div>
 </body>

--- a/docs/users-guide/Analyzing-and-Translating-Models.adoc
+++ b/docs/users-guide/Analyzing-and-Translating-Models.adoc
@@ -1479,40 +1479,64 @@ These definitions are required by the F Prime GDS.
 |The type of a telemetry channel identifier
 |Underlying type must be an integer type
 
+|`FwEventIdType`
+|Alias type definition
+|The type of an event identifier
+|Underlying type must be an integer type
+
+|`FwOpcodeType`
+|Alias type definition
+|The type of a command opcode
+|Underlying type must be an integer type
+
+|`FwPacketDescriptorType`
+|Alias type definition
+|The type of a com packet descriptor
+|Underlying type must be an integer type
+
+|`FwDpIdType`
+|Alias type definition
+|The type of a data product identifier
+|Underlying type must be an integer type
+
+|`FwDpPriorityType`
+|Alias type definition
+|The type of a data product priority
+|Underlying type must be an integer type
+
+|`FwSizeStoreType`
+|Alias type definition
+|The type used to serialize a size value
+|Underlying type must be an integer type
+
+|`FwTimeBaseStoreType`
+|Alias type definition
+|The type used to serialize a time base value
+|Underlying type must be an integer type
+
+|`FwTimeContextStoreType`
+|Alias type definition
+|The type used to serialize a time context value
+|Underlying type must be an integer type
+
+|`Fw.DpState`
+|Enum type definition
+|The data product state
+|
+
+|`Fw.DpCfg.ProcType`
+|Enum type definition
+|A bit mask for selecting the type of processing 
+to perform on a container before writing it to disk.
+|
+
+|`Fw.DpCfg.CONTAINER_USER_DATA_SIZE`
+|Constant definition
+|The size in bytes of the user-configurable 
+data in the container packet header
+|Constant must be an integer type
+
 |===
-
-Alias Types:
-
-* `FwChanIdType`
-
-* `FwEventIdType`
-
-* `FwOpcodeType`
-
-* `FwPacketDescriptorType`
-
-* `FwTlmPacketizeIdType`
-
-* `FwDpIdType`
-
-* `FwDpPriorityType`
-
-* `FwSizeStoreType`
-
-* `FwTimeBaseStoreType`
-
-* `FwTimeContextStoreType`
-
-Enumerations:
-
-* `Fw.DpState`
-* `Fw.DpCfg.ProcType`
-
-Constants:
-
-* `Fw.DpCfg.CONTAINER_USER_DATA_SIZE`
-
-The alias types and constants required by the dictionary must all be integer types.
 
 Typically you specify these types as part of F Prime configuration,
 in the file `config/FpConfig.fpp`.

--- a/docs/users-guide/Analyzing-and-Translating-Models.adoc
+++ b/docs/users-guide/Analyzing-and-Translating-Models.adoc
@@ -1465,9 +1465,21 @@ That way the subtopologies are part of the model, but no dictionaries
 are generated for them.
 
 *F Prime configuration:*
-There are various types and constants required by the F Prime GDS, so they
-are included in the dictionary. When you run `fpp-to-dict` on an FPP model, 
-the model must define the following alias types, enumerations, and constants:
+When you run `fpp-to-dict` on an FPP model, 
+the model must contain the definitions shown in Table <<dict-defs>>.
+These definitions are required by the F Prime GDS.
+
+[[dict-defs]]
+.Definitions Required by the GDS
+|===
+|Name|Kind|Purpose|Notes
+
+|`FwChanIdType`
+|Alias type definition
+|The type of a telemetry channel identifier
+|Underlying type must be an integer type
+
+|===
 
 Alias Types:
 

--- a/docs/users-guide/Analyzing-and-Translating-Models.adoc
+++ b/docs/users-guide/Analyzing-and-Translating-Models.adoc
@@ -1502,14 +1502,6 @@ Constants:
 
 The alias types and constants required by the dictionary must all be integer types.
 
-Type information for constant dictionary entries is determined by 
-checking the sign of a constant and will always default to the maximum integer size (64 bits):
-
-* If the constant is positive, the type of the constant is U64.
-
-* If the constant is negative, the type of the constant is I64.
-
-
 Typically you specify these types as part of F Prime configuration,
 in the file `config/FpConfig.fpp`.
 See the

--- a/docs/users-guide/Analyzing-and-Translating-Models.adoc
+++ b/docs/users-guide/Analyzing-and-Translating-Models.adoc
@@ -1465,8 +1465,11 @@ That way the subtopologies are part of the model, but no dictionaries
 are generated for them.
 
 *F Prime configuration:*
-When you run `fpp-to-dict` on an FPP model, the model must define the following 
-types:
+There are various types and constants required by the F Prime GDS, so they
+are included in the dictionary. When you run `fpp-to-dict` on an FPP model, 
+the model must define the following alias types, enumerations, and constants:
+
+Alias Types:
 
 * `FwChanIdType`
 
@@ -1478,9 +1481,35 @@ types:
 
 * `FwTlmPacketizeIdType`
 
-These types are required by the F Prime GDS, so they are included in the 
-dictionary.
-Each of these types must be an alias of an integer type.
+* `FwDpIdType`
+
+* `FwDpPriorityType`
+
+* `FwSizeStoreType`
+
+* `FwTimeBaseStoreType`
+
+* `FwTimeContextStoreType`
+
+Enumerations:
+
+* `Fw.DpState`
+* `Fw.DpCfg.ProcType`
+
+Constants:
+
+* `Fw.DpCfg.CONTAINER_USER_DATA_SIZE`
+
+The alias types and constants required by the dictionary must all be integer types.
+
+Type information for constant dictionary entries is determined by 
+checking the sign of a constant and will always default to the maximum integer size (64 bits):
+
+* If the constant is positive, the type of the constant is U64.
+
+* If the constant is negative, the type of the constant is I64.
+
+
 Typically you specify these types as part of F Prime configuration,
 in the file `config/FpConfig.fpp`.
 See the

--- a/docs/users-guide/Defining-Types.adoc
+++ b/docs/users-guide/Defining-Types.adoc
@@ -665,6 +665,7 @@ type T = U32
 array A = [3] T
 ----
 
+*Rules for alias type definitions:*
 An alias type definition may refer to any type, including another
 alias type, except that it may not refer to itself, either directly or through
 another alias.
@@ -695,6 +696,20 @@ type S = T
 type T = S
 --------
 
+*Underlying types:*
+Because an alias type definition may not refer to itself, every
+chain of aliases ends in a type that is not an alias.
+This type is called the *underlying type* of all the aliases
+in the chain.
+For example:
+
+[source.fpp]
+----
+type S = T   # Underlying type of S is U32
+type T = U32 # Underlying type of T is U32
+----
+
+*Configuration:*
 Alias type definitions are useful for specifying configurations.
 Part of a model can use a type `T`, without
 defining `T`; elsewhere, configuration code can define


### PR DESCRIPTION
Require that the following types are defined and output them to the dictionary:

**Aliases**
- FwDpIdType
- FwDpPriorityType
- FwSizeStoreType
- FwTimeBaseStoreType
- FwTimeContextStoreType

**Enums**
- Fw.DpState
- Fw.DpCfg.ProcType

**Constants**
- Fw.DpCfg.CONTAINER_USER_DATA_SIZE


Closes https://github.com/nasa/fpp/issues/719.

Spec updates are done in https://github.com/nasa/fprime/pull/3692.