### PR TITLE
Fix interface locs

### DIFF
--- a/compiler/lib/src/main/scala/syntax/Parser.scala
+++ b/compiler/lib/src/main/scala/syntax/Parser.scala
@@ -665,6 +665,7 @@ object Parser extends Parsers {
         state ~! machine ^^ (_ => Ast.SpecLoc.StateMachine) |
         topology ^^ (_ => Ast.SpecLoc.Topology) |
         typeToken ^^ (_ => Ast.SpecLoc.Type) |
+        interface ^^ (_ => Ast.SpecLoc.Interface) |
         failure("location kind expected")
     }
 

--- a/compiler/tools/fpp-depend/test/def_interface.fpp
+++ b/compiler/tools/fpp-depend/test/def_interface.fpp
@@ -1,0 +1,7 @@
+locate port P1 at "P1.fpp"
+locate port P2 at "P2.fpp"
+
+interface I {
+    async input port p1: P1
+    output port p2: P2
+}

--- a/compiler/tools/fpp-depend/test/def_interface.ref.txt
+++ b/compiler/tools/fpp-depend/test/def_interface.ref.txt
@@ -1,0 +1,2 @@
+[ local path prefix ]/compiler/tools/fpp-depend/test/P1.fpp
+[ local path prefix ]/compiler/tools/fpp-depend/test/P2.fpp

--- a/compiler/tools/fpp-depend/test/spec_import_interface.fpp
+++ b/compiler/tools/fpp-depend/test/spec_import_interface.fpp
@@ -4,9 +4,11 @@ locate constant a at "a.fpp"
 locate constant b at "b.fpp"
 locate constant c at "c.fpp"
 locate constant d at "d.fpp"
-
+locate interface K at "k.fpp"
 
 interface J {
+  import K
+
   async input port p: [a] P priority b
 }
 

--- a/compiler/tools/fpp-depend/test/spec_import_interface.ref.txt
+++ b/compiler/tools/fpp-depend/test/spec_import_interface.ref.txt
@@ -4,3 +4,4 @@
 [ local path prefix ]/compiler/tools/fpp-depend/test/b.fpp
 [ local path prefix ]/compiler/tools/fpp-depend/test/c.fpp
 [ local path prefix ]/compiler/tools/fpp-depend/test/d.fpp
+[ local path prefix ]/compiler/tools/fpp-depend/test/k.fpp

--- a/compiler/tools/fpp-depend/test/tests.sh
+++ b/compiler/tools/fpp-depend/test/tests.sh
@@ -4,6 +4,7 @@ def_array
 def_component_instance
 def_constant
 def_enum
+def_interface
 def_port
 def_state_machine
 def_struct


### PR DESCRIPTION
I found this issue which working on https://github.com/nasa/fpp/issues/702. The generated locs file could not be parsed back into the model since I didn't update the parser. This was the only FPP change required to get FppTest passing