### PR TITLE
Cast Fw types in C++ codegen

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCommands.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCommands.scala
@@ -67,7 +67,7 @@ case class ComponentCommands (
           sortedCmds.map((_, cmd) =>
             lines(
               s"""|this->${portVariableName(cmdRegPort.get)}[0].invoke(
-                  |  this->getIdBase() + ${commandConstantName(cmd)}
+                  |  static_cast<FwOpcodeType>(this->getIdBase()) + ${commandConstantName(cmd)}
                   |);
                   |"""
             )

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentEvents.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentEvents.scala
@@ -268,7 +268,7 @@ case class ComponentEvents (
               |
               |FwEventIdType _id = static_cast<FwEventIdType>(0);
               |
-              |_id = this->getIdBase() + ${eventIdConstantName(event.getName)};
+              |_id = static_cast<FwEventIdType>(this->getIdBase()) + ${eventIdConstantName(event.getName)};
               |"""
         ),
         writeLogBody(id, event),

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentTelemetry.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentTelemetry.scala
@@ -127,7 +127,7 @@ case class ComponentTelemetry (
                   |
                   |FwChanIdType _id;
                   |
-                  |_id = this->getIdBase() + ${channelIdConstantName(channel.getName)};
+                  |_id = static_cast<FwChanIdType>(this->getIdBase()) + ${channelIdConstantName(channel.getName)};
                   |
                   |this->${portVariableName(tlmPort.get)}[0].invoke(
                   |  _id,

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentHistory.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentHistory.scala
@@ -406,7 +406,7 @@ case class ComponentHistory(
           wrapInScope(
             "struct TextLogEntry {",
             lines(
-              """|U32 id;
+              """|FwEventIdType id;
                  |Fw::Time timeTag;
                  |Fw::LogSeverity severity;
                  |Fw::TextLogString text;

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentTesterBaseWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentTesterBaseWriter.scala
@@ -769,8 +769,8 @@ case class ComponentTesterBaseWriter(
             lines(
               s"""|// Call output command port
                   |FwOpcodeType _opcode;
-                  |const U32 idBase = this->getIdBase();
-                  |_opcode = $className::${commandConstantName(cmd)} + idBase;
+                  |const FwBaseIdType idBase = this->getIdBase();
+                  |_opcode = $className::${commandConstantName(cmd)} + static_cast<FwOpcodeType>(idBase);
                   |"""
             ),
             cmdPortInvocation
@@ -818,8 +818,8 @@ case class ComponentTesterBaseWriter(
           CppDoc.Type("void"),
           List.concat(
             lines(
-              s"""|const U32 idBase = this->getIdBase();
-                  |FwOpcodeType _opcode = opCode + idBase;
+              s"""|const FwBaseIdType idBase = this->getIdBase();
+                  |FwOpcodeType _opcode = opCode + static_cast<FwOpcodeType>(idBase);
                   |
                   |"""
             ),
@@ -1005,7 +1005,7 @@ case class ComponentTesterBaseWriter(
         lines(
           """|args.resetDeser();
              |
-             |const U32 idBase = this->getIdBase();
+             |const FwBaseIdType idBase = this->getIdBase();
              |FW_ASSERT(
              |  id >= idBase,
              |  static_cast<FwAssertArgType>(id),
@@ -1157,7 +1157,7 @@ case class ComponentTesterBaseWriter(
             lines(
               """|val.resetDeser();
                  |
-                 |const U32 idBase = this->getIdBase();
+                 |const FwBaseIdType idBase = this->getIdBase();
                  |FW_ASSERT(
                  |  id >= idBase,
                  |  static_cast<FwAssertArgType>(id),
@@ -1279,8 +1279,8 @@ case class ComponentTesterBaseWriter(
                     |  args.serialize(this->$paramVar) == Fw::FW_SERIALIZE_OK
                     |);
                     |
-                    |const U32 idBase = this->getIdBase();
-                    |FwOpcodeType _prmOpcode =  $className::$constantName + idBase;
+                    |const FwBaseIdType idBase = this->getIdBase();
+                    |FwOpcodeType _prmOpcode =  $className::$constantName + static_cast<FwOpcodeType>(idBase);
                     |
                     |if (not this->$portVar[0].isConnected()) {
                     |  printf("Test Command Output port not connected!\\n");
@@ -1313,8 +1313,8 @@ case class ComponentTesterBaseWriter(
               val varName = testerPortVariableName(cmdRecvPort.get)
               lines(
               s"""|Fw::CmdArgBuffer args;
-                  |const U32 idBase = this->getIdBase();
-                  |FwOpcodeType _prmOpcode = $className::$constantName + idBase;
+                  |const FwBaseIdType idBase = this->getIdBase();
+                  |FwOpcodeType _prmOpcode = $className::$constantName + static_cast<FwOpcodeType>(idBase);
                   |
                   |if (not this->$varName[0].isConnected()) {
                   |  printf("Test Command Output port not connected!\\n");
@@ -1347,7 +1347,7 @@ case class ComponentTesterBaseWriter(
           s"""|Fw::ParamValid _ret = Fw::ParamValid::VALID;
               |$value.resetSer();
               |
-              |const U32 idBase = _testerBase->getIdBase();
+              |const FwBaseIdType idBase = _testerBase->getIdBase();
               |FW_ASSERT(
               |  $id >= idBase,
               |  static_cast<FwAssertArgType>($id),
@@ -1401,7 +1401,7 @@ case class ComponentTesterBaseWriter(
       guardedList (hasParameters) (lines("Fw::SerializeStatus _status;")),
       lines(
         s"""|
-            |const U32 idBase = _testerBase->getIdBase();
+            |const FwBaseIdType idBase = _testerBase->getIdBase();
             |FW_ASSERT(
             |  $id >= idBase,
             |  static_cast<FwAssertArgType>($id),

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentTesterBaseWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentTesterBaseWriter.scala
@@ -769,7 +769,7 @@ case class ComponentTesterBaseWriter(
             lines(
               s"""|// Call output command port
                   |FwOpcodeType _opcode;
-                  |const FwBaseIdType idBase = this->getIdBase();
+                  |const FwIdType idBase = this->getIdBase();
                   |_opcode = $className::${commandConstantName(cmd)} + static_cast<FwOpcodeType>(idBase);
                   |"""
             ),
@@ -818,7 +818,7 @@ case class ComponentTesterBaseWriter(
           CppDoc.Type("void"),
           List.concat(
             lines(
-              s"""|const FwBaseIdType idBase = this->getIdBase();
+              s"""|const FwIdType idBase = this->getIdBase();
                   |FwOpcodeType _opcode = opCode + static_cast<FwOpcodeType>(idBase);
                   |
                   |"""
@@ -1005,7 +1005,7 @@ case class ComponentTesterBaseWriter(
         lines(
           """|args.resetDeser();
              |
-             |const FwBaseIdType idBase = this->getIdBase();
+             |const FwIdType idBase = this->getIdBase();
              |FW_ASSERT(
              |  id >= idBase,
              |  static_cast<FwAssertArgType>(id),
@@ -1157,7 +1157,7 @@ case class ComponentTesterBaseWriter(
             lines(
               """|val.resetDeser();
                  |
-                 |const FwBaseIdType idBase = this->getIdBase();
+                 |const FwIdType idBase = this->getIdBase();
                  |FW_ASSERT(
                  |  id >= idBase,
                  |  static_cast<FwAssertArgType>(id),
@@ -1279,7 +1279,7 @@ case class ComponentTesterBaseWriter(
                     |  args.serialize(this->$paramVar) == Fw::FW_SERIALIZE_OK
                     |);
                     |
-                    |const FwBaseIdType idBase = this->getIdBase();
+                    |const FwIdType idBase = this->getIdBase();
                     |FwOpcodeType _prmOpcode =  $className::$constantName + static_cast<FwOpcodeType>(idBase);
                     |
                     |if (not this->$portVar[0].isConnected()) {
@@ -1313,7 +1313,7 @@ case class ComponentTesterBaseWriter(
               val varName = testerPortVariableName(cmdRecvPort.get)
               lines(
               s"""|Fw::CmdArgBuffer args;
-                  |const FwBaseIdType idBase = this->getIdBase();
+                  |const FwIdType idBase = this->getIdBase();
                   |FwOpcodeType _prmOpcode = $className::$constantName + static_cast<FwOpcodeType>(idBase);
                   |
                   |if (not this->$varName[0].isConnected()) {
@@ -1347,7 +1347,7 @@ case class ComponentTesterBaseWriter(
           s"""|Fw::ParamValid _ret = Fw::ParamValid::VALID;
               |$value.resetSer();
               |
-              |const FwBaseIdType idBase = _testerBase->getIdBase();
+              |const FwIdType idBase = _testerBase->getIdBase();
               |FW_ASSERT(
               |  $id >= idBase,
               |  static_cast<FwAssertArgType>($id),
@@ -1401,7 +1401,7 @@ case class ComponentTesterBaseWriter(
       guardedList (hasParameters) (lines("Fw::SerializeStatus _status;")),
       lines(
         s"""|
-            |const FwBaseIdType idBase = _testerBase->getIdBase();
+            |const FwIdType idBase = _testerBase->getIdBase();
             |FW_ASSERT(
             |  $id >= idBase,
             |  static_cast<FwAssertArgType>($id),

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveCommandsComponentAc.ref.cpp
@@ -1518,71 +1518,71 @@ void ActiveCommandsComponentBase ::
   FW_ASSERT(this->m_cmdRegOut_OutputPort[0].isConnected());
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_PRIMITIVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_PRIMITIVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_STRING
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_STRING
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_ENUM
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_ENUM
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_ARRAY
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_ARRAY
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_STRUCT
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_STRUCT
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_PRIMITIVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_PRIMITIVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_STRING
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_STRING
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_ENUM
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_ENUM
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_ARRAY
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_ARRAY
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_STRUCT
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_STRUCT
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_ASYNC
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_ASYNC
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_PRIORITY
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_PRIORITY
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_PARAMS_PRIORITY
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_DROP
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_DROP
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_DROP
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_PARAMS_PRIORITY_DROP
   );
 }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.cpp
@@ -3202,7 +3202,7 @@ void ActiveEventsComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTACTIVITYHIGH;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTACTIVITYHIGH;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -3279,7 +3279,7 @@ void ActiveEventsComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTACTIVITYLOWTHROTTLED;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTACTIVITYLOWTHROTTLED;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -3398,7 +3398,7 @@ void ActiveEventsComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTCOMMAND;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTCOMMAND;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -3477,7 +3477,7 @@ void ActiveEventsComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTDIAGNOSTIC;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTDIAGNOSTIC;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -3570,7 +3570,7 @@ void ActiveEventsComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTFATALTHROTTLED;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTFATALTHROTTLED;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -3668,7 +3668,7 @@ void ActiveEventsComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTWARNINGHIGH;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTWARNINGHIGH;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -3761,7 +3761,7 @@ void ActiveEventsComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLED;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTWARNINGLOWTHROTTLED;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveExternalParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveExternalParamsComponentAc.ref.cpp
@@ -1513,51 +1513,51 @@ void ActiveExternalParamsComponentBase ::
   FW_ASSERT(this->m_cmdRegOut_OutputPort[0].isConnected());
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMI32EXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMI32EXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMI32EXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMI32EXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMF64EXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64EXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMF64EXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64EXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRINGEXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRINGEXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMENUMEXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUMEXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMENUMEXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUMEXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMARRAYEXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAYEXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMARRAYEXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAYEXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCTEXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCTEXT_SAVE
   );
 }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveOverflowComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveOverflowComponentAc.ref.cpp
@@ -753,11 +753,11 @@ void ActiveOverflowComponentBase ::
   FW_ASSERT(this->m_cmdRegOut_OutputPort[0].isConnected());
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_HOOK
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_HOOK
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_HOOK
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_PARAMS_PRIORITY_HOOK
   );
 }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.cpp
@@ -1513,51 +1513,51 @@ void ActiveParamsComponentBase ::
   FW_ASSERT(this->m_cmdRegOut_OutputPort[0].isConnected());
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMU32_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMU32_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMU32_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMU32_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMF64_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMF64_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRING_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRING_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRING_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRING_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMENUM_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUM_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMENUM_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUM_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMARRAY_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAY_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMARRAY_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAY_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRUCT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRUCT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCT_SAVE
   );
 }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
@@ -1812,167 +1812,167 @@ void ActiveSerialComponentBase ::
   FW_ASSERT(this->m_cmdRegOut_OutputPort[0].isConnected());
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_PRIMITIVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_PRIMITIVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_STRING
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_STRING
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_ENUM
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_ENUM
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_ARRAY
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_ARRAY
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_STRUCT
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_STRUCT
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_PRIMITIVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_PRIMITIVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_STRING
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_STRING
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_ENUM
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_ENUM
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_ARRAY
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_ARRAY
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_STRUCT
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_STRUCT
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_ASYNC
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_ASYNC
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_PRIORITY
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_PRIORITY
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_PARAMS_PRIORITY
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_DROP
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_DROP
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_DROP
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_PARAMS_PRIORITY_DROP
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMU32_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMU32_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMU32_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMU32_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMF64_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMF64_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRING_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRING_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRING_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRING_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMENUM_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUM_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMENUM_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUM_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMARRAY_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAY_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMARRAY_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAY_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRUCT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRUCT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMI32EXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMI32EXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMI32EXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMI32EXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMF64EXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64EXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMF64EXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64EXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRINGEXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRINGEXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMENUMEXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUMEXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMENUMEXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUMEXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMARRAYEXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAYEXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMARRAYEXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAYEXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCTEXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCTEXT_SAVE
   );
 }
 
@@ -5690,7 +5690,7 @@ void ActiveSerialComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTACTIVITYHIGH;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTACTIVITYHIGH;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -5767,7 +5767,7 @@ void ActiveSerialComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTACTIVITYLOWTHROTTLED;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTACTIVITYLOWTHROTTLED;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -5886,7 +5886,7 @@ void ActiveSerialComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTCOMMAND;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTCOMMAND;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -5965,7 +5965,7 @@ void ActiveSerialComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTDIAGNOSTIC;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTDIAGNOSTIC;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -6058,7 +6058,7 @@ void ActiveSerialComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTFATALTHROTTLED;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTFATALTHROTTLED;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -6156,7 +6156,7 @@ void ActiveSerialComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTWARNINGHIGH;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTWARNINGHIGH;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -6249,7 +6249,7 @@ void ActiveSerialComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLED;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTWARNINGLOWTHROTTLED;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -6355,7 +6355,7 @@ void ActiveSerialComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELU32FORMAT;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELU32FORMAT;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -6388,7 +6388,7 @@ void ActiveSerialComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELF32FORMAT;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELF32FORMAT;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -6421,7 +6421,7 @@ void ActiveSerialComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELSTRINGFORMAT;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELSTRINGFORMAT;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -6454,7 +6454,7 @@ void ActiveSerialComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELENUM;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELENUM;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -6487,7 +6487,7 @@ void ActiveSerialComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELARRAYFREQ;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELARRAYFREQ;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -6520,7 +6520,7 @@ void ActiveSerialComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELSTRUCTFREQ;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELSTRUCTFREQ;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -6553,7 +6553,7 @@ void ActiveSerialComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELU32LIMITS;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELU32LIMITS;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -6586,7 +6586,7 @@ void ActiveSerialComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELF32LIMITS;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELF32LIMITS;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -6619,7 +6619,7 @@ void ActiveSerialComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELF64;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELF64;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -6667,7 +6667,7 @@ void ActiveSerialComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELU32ONCHANGE;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELU32ONCHANGE;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -6715,7 +6715,7 @@ void ActiveSerialComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELENUMONCHANGE;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELENUMONCHANGE;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.cpp
@@ -3217,7 +3217,7 @@ void ActiveTelemetryComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELU32FORMAT;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELU32FORMAT;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -3250,7 +3250,7 @@ void ActiveTelemetryComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELF32FORMAT;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELF32FORMAT;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -3283,7 +3283,7 @@ void ActiveTelemetryComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELSTRINGFORMAT;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELSTRINGFORMAT;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -3316,7 +3316,7 @@ void ActiveTelemetryComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELENUM;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELENUM;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -3349,7 +3349,7 @@ void ActiveTelemetryComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELARRAYFREQ;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELARRAYFREQ;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -3382,7 +3382,7 @@ void ActiveTelemetryComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELSTRUCTFREQ;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELSTRUCTFREQ;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -3415,7 +3415,7 @@ void ActiveTelemetryComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELU32LIMITS;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELU32LIMITS;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -3448,7 +3448,7 @@ void ActiveTelemetryComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELF32LIMITS;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELF32LIMITS;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -3481,7 +3481,7 @@ void ActiveTelemetryComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELF64;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELF64;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -3529,7 +3529,7 @@ void ActiveTelemetryComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELU32ONCHANGE;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELU32ONCHANGE;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -3577,7 +3577,7 @@ void ActiveTelemetryComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELENUMONCHANGE;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELENUMONCHANGE;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
@@ -1901,167 +1901,167 @@ namespace M {
     FW_ASSERT(this->m_cmdRegOut_OutputPort[0].isConnected());
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_CMD_SYNC
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_CMD_SYNC_PRIMITIVE
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_PRIMITIVE
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_CMD_SYNC_STRING
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_STRING
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_CMD_SYNC_ENUM
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_ENUM
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_CMD_SYNC_ARRAY
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_ARRAY
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_CMD_SYNC_STRUCT
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_STRUCT
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_CMD_GUARDED
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_CMD_GUARDED_PRIMITIVE
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_PRIMITIVE
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_CMD_GUARDED_STRING
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_STRING
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_CMD_GUARDED_ENUM
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_ENUM
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_CMD_GUARDED_ARRAY
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_ARRAY
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_CMD_GUARDED_STRUCT
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_STRUCT
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_CMD_ASYNC
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_ASYNC
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_CMD_PRIORITY
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_PRIORITY
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_PARAMS_PRIORITY
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_CMD_DROP
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_DROP
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_DROP
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_PARAMS_PRIORITY_DROP
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_PARAMU32_SET
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMU32_SET
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_PARAMU32_SAVE
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMU32_SAVE
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_PARAMF64_SET
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64_SET
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_PARAMF64_SAVE
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64_SAVE
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_PARAMSTRING_SET
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRING_SET
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_PARAMSTRING_SAVE
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRING_SAVE
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_PARAMENUM_SET
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUM_SET
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_PARAMENUM_SAVE
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUM_SAVE
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_PARAMARRAY_SET
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAY_SET
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_PARAMARRAY_SAVE
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAY_SAVE
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_PARAMSTRUCT_SET
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCT_SET
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_PARAMSTRUCT_SAVE
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCT_SAVE
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_PARAMI32EXT_SET
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMI32EXT_SET
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_PARAMI32EXT_SAVE
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMI32EXT_SAVE
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_PARAMF64EXT_SET
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64EXT_SET
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_PARAMF64EXT_SAVE
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64EXT_SAVE
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_PARAMSTRINGEXT_SET
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRINGEXT_SET
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_PARAMSTRINGEXT_SAVE
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRINGEXT_SAVE
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_PARAMENUMEXT_SET
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUMEXT_SET
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_PARAMENUMEXT_SAVE
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUMEXT_SAVE
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_PARAMARRAYEXT_SET
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAYEXT_SET
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_PARAMARRAYEXT_SAVE
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAYEXT_SAVE
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SET
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCTEXT_SET
     );
 
     this->m_cmdRegOut_OutputPort[0].invoke(
-      this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SAVE
+      static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCTEXT_SAVE
     );
   }
 
@@ -5563,7 +5563,7 @@ namespace M {
 
     FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-    _id = this->getIdBase() + EVENTID_EVENTACTIVITYHIGH;
+    _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTACTIVITYHIGH;
 
     // Emit the event on the log port
     if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -5640,7 +5640,7 @@ namespace M {
 
     FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-    _id = this->getIdBase() + EVENTID_EVENTACTIVITYLOWTHROTTLED;
+    _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTACTIVITYLOWTHROTTLED;
 
     // Emit the event on the log port
     if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -5759,7 +5759,7 @@ namespace M {
 
     FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-    _id = this->getIdBase() + EVENTID_EVENTCOMMAND;
+    _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTCOMMAND;
 
     // Emit the event on the log port
     if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -5838,7 +5838,7 @@ namespace M {
 
     FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-    _id = this->getIdBase() + EVENTID_EVENTDIAGNOSTIC;
+    _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTDIAGNOSTIC;
 
     // Emit the event on the log port
     if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -5931,7 +5931,7 @@ namespace M {
 
     FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-    _id = this->getIdBase() + EVENTID_EVENTFATALTHROTTLED;
+    _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTFATALTHROTTLED;
 
     // Emit the event on the log port
     if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -6029,7 +6029,7 @@ namespace M {
 
     FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-    _id = this->getIdBase() + EVENTID_EVENTWARNINGHIGH;
+    _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTWARNINGHIGH;
 
     // Emit the event on the log port
     if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -6122,7 +6122,7 @@ namespace M {
 
     FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-    _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLED;
+    _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTWARNINGLOWTHROTTLED;
 
     // Emit the event on the log port
     if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -6228,7 +6228,7 @@ namespace M {
 
       FwChanIdType _id;
 
-      _id = this->getIdBase() + CHANNELID_CHANNELU32FORMAT;
+      _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELU32FORMAT;
 
       this->m_tlmOut_OutputPort[0].invoke(
         _id,
@@ -6261,7 +6261,7 @@ namespace M {
 
       FwChanIdType _id;
 
-      _id = this->getIdBase() + CHANNELID_CHANNELF32FORMAT;
+      _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELF32FORMAT;
 
       this->m_tlmOut_OutputPort[0].invoke(
         _id,
@@ -6294,7 +6294,7 @@ namespace M {
 
       FwChanIdType _id;
 
-      _id = this->getIdBase() + CHANNELID_CHANNELSTRINGFORMAT;
+      _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELSTRINGFORMAT;
 
       this->m_tlmOut_OutputPort[0].invoke(
         _id,
@@ -6327,7 +6327,7 @@ namespace M {
 
       FwChanIdType _id;
 
-      _id = this->getIdBase() + CHANNELID_CHANNELENUM;
+      _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELENUM;
 
       this->m_tlmOut_OutputPort[0].invoke(
         _id,
@@ -6360,7 +6360,7 @@ namespace M {
 
       FwChanIdType _id;
 
-      _id = this->getIdBase() + CHANNELID_CHANNELARRAYFREQ;
+      _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELARRAYFREQ;
 
       this->m_tlmOut_OutputPort[0].invoke(
         _id,
@@ -6393,7 +6393,7 @@ namespace M {
 
       FwChanIdType _id;
 
-      _id = this->getIdBase() + CHANNELID_CHANNELSTRUCTFREQ;
+      _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELSTRUCTFREQ;
 
       this->m_tlmOut_OutputPort[0].invoke(
         _id,
@@ -6426,7 +6426,7 @@ namespace M {
 
       FwChanIdType _id;
 
-      _id = this->getIdBase() + CHANNELID_CHANNELU32LIMITS;
+      _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELU32LIMITS;
 
       this->m_tlmOut_OutputPort[0].invoke(
         _id,
@@ -6459,7 +6459,7 @@ namespace M {
 
       FwChanIdType _id;
 
-      _id = this->getIdBase() + CHANNELID_CHANNELF32LIMITS;
+      _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELF32LIMITS;
 
       this->m_tlmOut_OutputPort[0].invoke(
         _id,
@@ -6492,7 +6492,7 @@ namespace M {
 
       FwChanIdType _id;
 
-      _id = this->getIdBase() + CHANNELID_CHANNELF64;
+      _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELF64;
 
       this->m_tlmOut_OutputPort[0].invoke(
         _id,
@@ -6540,7 +6540,7 @@ namespace M {
 
       FwChanIdType _id;
 
-      _id = this->getIdBase() + CHANNELID_CHANNELU32ONCHANGE;
+      _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELU32ONCHANGE;
 
       this->m_tlmOut_OutputPort[0].invoke(
         _id,
@@ -6588,7 +6588,7 @@ namespace M {
 
       FwChanIdType _id;
 
-      _id = this->getIdBase() + CHANNELID_CHANNELENUMONCHANGE;
+      _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELENUMONCHANGE;
 
       this->m_tlmOut_OutputPort[0].invoke(
         _id,

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveCommandsComponentAc.ref.cpp
@@ -1232,51 +1232,51 @@ void PassiveCommandsComponentBase ::
   FW_ASSERT(this->m_cmdRegOut_OutputPort[0].isConnected());
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_PRIMITIVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_PRIMITIVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_STRING
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_STRING
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_ENUM
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_ENUM
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_ARRAY
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_ARRAY
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_STRUCT
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_STRUCT
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_PRIMITIVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_PRIMITIVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_STRING
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_STRING
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_ENUM
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_ENUM
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_ARRAY
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_ARRAY
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_STRUCT
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_STRUCT
   );
 }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveEventsComponentAc.ref.cpp
@@ -2216,7 +2216,7 @@ void PassiveEventsComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTACTIVITYHIGH;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTACTIVITYHIGH;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -2293,7 +2293,7 @@ void PassiveEventsComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTACTIVITYLOWTHROTTLED;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTACTIVITYLOWTHROTTLED;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -2412,7 +2412,7 @@ void PassiveEventsComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTCOMMAND;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTCOMMAND;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -2491,7 +2491,7 @@ void PassiveEventsComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTDIAGNOSTIC;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTDIAGNOSTIC;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -2584,7 +2584,7 @@ void PassiveEventsComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTFATALTHROTTLED;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTFATALTHROTTLED;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -2682,7 +2682,7 @@ void PassiveEventsComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTWARNINGHIGH;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTWARNINGHIGH;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -2775,7 +2775,7 @@ void PassiveEventsComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLED;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTWARNINGLOWTHROTTLED;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveExternalParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveExternalParamsComponentAc.ref.cpp
@@ -1232,51 +1232,51 @@ void PassiveExternalParamsComponentBase ::
   FW_ASSERT(this->m_cmdRegOut_OutputPort[0].isConnected());
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMI32EXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMI32EXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMI32EXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMI32EXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMF64EXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64EXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMF64EXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64EXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRINGEXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRINGEXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMENUMEXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUMEXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMENUMEXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUMEXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMARRAYEXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAYEXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMARRAYEXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAYEXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCTEXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCTEXT_SAVE
   );
 }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveParamsComponentAc.ref.cpp
@@ -1232,51 +1232,51 @@ void PassiveParamsComponentBase ::
   FW_ASSERT(this->m_cmdRegOut_OutputPort[0].isConnected());
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMU32_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMU32_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMU32_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMU32_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMF64_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMF64_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRING_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRING_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRING_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRING_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMENUM_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUM_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMENUM_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUM_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMARRAY_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAY_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMARRAY_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAY_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRUCT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRUCT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCT_SAVE
   );
 }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
@@ -1347,147 +1347,147 @@ void PassiveSerialComponentBase ::
   FW_ASSERT(this->m_cmdRegOut_OutputPort[0].isConnected());
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_PRIMITIVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_PRIMITIVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_STRING
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_STRING
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_ENUM
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_ENUM
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_ARRAY
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_ARRAY
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_STRUCT
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_STRUCT
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_PRIMITIVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_PRIMITIVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_STRING
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_STRING
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_ENUM
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_ENUM
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_ARRAY
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_ARRAY
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_STRUCT
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_STRUCT
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMU32_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMU32_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMU32_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMU32_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMF64_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMF64_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRING_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRING_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRING_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRING_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMENUM_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUM_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMENUM_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUM_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMARRAY_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAY_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMARRAY_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAY_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRUCT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRUCT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMI32EXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMI32EXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMI32EXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMI32EXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMF64EXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64EXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMF64EXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64EXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRINGEXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRINGEXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMENUMEXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUMEXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMENUMEXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUMEXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMARRAYEXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAYEXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMARRAYEXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAYEXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCTEXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCTEXT_SAVE
   );
 }
 
@@ -3598,7 +3598,7 @@ void PassiveSerialComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTACTIVITYHIGH;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTACTIVITYHIGH;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -3675,7 +3675,7 @@ void PassiveSerialComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTACTIVITYLOWTHROTTLED;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTACTIVITYLOWTHROTTLED;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -3794,7 +3794,7 @@ void PassiveSerialComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTCOMMAND;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTCOMMAND;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -3873,7 +3873,7 @@ void PassiveSerialComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTDIAGNOSTIC;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTDIAGNOSTIC;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -3966,7 +3966,7 @@ void PassiveSerialComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTFATALTHROTTLED;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTFATALTHROTTLED;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -4064,7 +4064,7 @@ void PassiveSerialComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTWARNINGHIGH;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTWARNINGHIGH;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -4157,7 +4157,7 @@ void PassiveSerialComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLED;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTWARNINGLOWTHROTTLED;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -4263,7 +4263,7 @@ void PassiveSerialComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELU32FORMAT;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELU32FORMAT;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -4296,7 +4296,7 @@ void PassiveSerialComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELF32FORMAT;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELF32FORMAT;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -4329,7 +4329,7 @@ void PassiveSerialComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELSTRINGFORMAT;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELSTRINGFORMAT;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -4362,7 +4362,7 @@ void PassiveSerialComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELENUM;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELENUM;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -4395,7 +4395,7 @@ void PassiveSerialComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELARRAYFREQ;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELARRAYFREQ;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -4428,7 +4428,7 @@ void PassiveSerialComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELSTRUCTFREQ;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELSTRUCTFREQ;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -4461,7 +4461,7 @@ void PassiveSerialComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELU32LIMITS;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELU32LIMITS;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -4494,7 +4494,7 @@ void PassiveSerialComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELF32LIMITS;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELF32LIMITS;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -4527,7 +4527,7 @@ void PassiveSerialComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELF64;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELF64;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -4575,7 +4575,7 @@ void PassiveSerialComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELU32ONCHANGE;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELU32ONCHANGE;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -4623,7 +4623,7 @@ void PassiveSerialComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELENUMONCHANGE;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELENUMONCHANGE;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTelemetryComponentAc.ref.cpp
@@ -2231,7 +2231,7 @@ void PassiveTelemetryComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELU32FORMAT;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELU32FORMAT;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -2264,7 +2264,7 @@ void PassiveTelemetryComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELF32FORMAT;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELF32FORMAT;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -2297,7 +2297,7 @@ void PassiveTelemetryComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELSTRINGFORMAT;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELSTRINGFORMAT;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -2330,7 +2330,7 @@ void PassiveTelemetryComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELENUM;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELENUM;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -2363,7 +2363,7 @@ void PassiveTelemetryComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELARRAYFREQ;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELARRAYFREQ;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -2396,7 +2396,7 @@ void PassiveTelemetryComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELSTRUCTFREQ;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELSTRUCTFREQ;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -2429,7 +2429,7 @@ void PassiveTelemetryComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELU32LIMITS;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELU32LIMITS;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -2462,7 +2462,7 @@ void PassiveTelemetryComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELF32LIMITS;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELF32LIMITS;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -2495,7 +2495,7 @@ void PassiveTelemetryComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELF64;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELF64;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -2543,7 +2543,7 @@ void PassiveTelemetryComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELU32ONCHANGE;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELU32ONCHANGE;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -2591,7 +2591,7 @@ void PassiveTelemetryComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELENUMONCHANGE;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELENUMONCHANGE;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
@@ -1582,147 +1582,147 @@ void PassiveTestComponentBase ::
   FW_ASSERT(this->m_cmdRegOut_OutputPort[0].isConnected());
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_PRIMITIVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_PRIMITIVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_STRING
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_STRING
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_ENUM
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_ENUM
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_ARRAY
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_ARRAY
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_STRUCT
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_STRUCT
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_PRIMITIVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_PRIMITIVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_STRING
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_STRING
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_ENUM
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_ENUM
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_ARRAY
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_ARRAY
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_STRUCT
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_STRUCT
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMU32_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMU32_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMU32_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMU32_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMF64_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMF64_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRING_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRING_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRING_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRING_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMENUM_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUM_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMENUM_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUM_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMARRAY_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAY_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMARRAY_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAY_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRUCT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRUCT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMI32EXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMI32EXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMI32EXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMI32EXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMF64EXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64EXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMF64EXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64EXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRINGEXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRINGEXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMENUMEXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUMEXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMENUMEXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUMEXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMARRAYEXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAYEXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMARRAYEXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAYEXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCTEXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCTEXT_SAVE
   );
 }
 
@@ -3835,7 +3835,7 @@ void PassiveTestComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTACTIVITYHIGH;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTACTIVITYHIGH;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -3912,7 +3912,7 @@ void PassiveTestComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTACTIVITYLOWTHROTTLED;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTACTIVITYLOWTHROTTLED;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -4031,7 +4031,7 @@ void PassiveTestComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTCOMMAND;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTCOMMAND;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -4110,7 +4110,7 @@ void PassiveTestComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTDIAGNOSTIC;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTDIAGNOSTIC;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -4203,7 +4203,7 @@ void PassiveTestComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTFATALTHROTTLED;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTFATALTHROTTLED;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -4301,7 +4301,7 @@ void PassiveTestComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTWARNINGHIGH;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTWARNINGHIGH;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -4394,7 +4394,7 @@ void PassiveTestComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLED;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTWARNINGLOWTHROTTLED;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -4500,7 +4500,7 @@ void PassiveTestComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELU32FORMAT;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELU32FORMAT;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -4533,7 +4533,7 @@ void PassiveTestComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELF32FORMAT;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELF32FORMAT;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -4566,7 +4566,7 @@ void PassiveTestComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELSTRINGFORMAT;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELSTRINGFORMAT;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -4599,7 +4599,7 @@ void PassiveTestComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELENUM;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELENUM;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -4632,7 +4632,7 @@ void PassiveTestComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELARRAYFREQ;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELARRAYFREQ;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -4665,7 +4665,7 @@ void PassiveTestComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELSTRUCTFREQ;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELSTRUCTFREQ;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -4698,7 +4698,7 @@ void PassiveTestComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELU32LIMITS;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELU32LIMITS;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -4731,7 +4731,7 @@ void PassiveTestComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELF32LIMITS;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELF32LIMITS;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -4764,7 +4764,7 @@ void PassiveTestComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELF64;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELF64;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -4812,7 +4812,7 @@ void PassiveTestComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELU32ONCHANGE;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELU32ONCHANGE;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -4860,7 +4860,7 @@ void PassiveTestComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELENUMONCHANGE;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELENUMONCHANGE;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedCommandsComponentAc.ref.cpp
@@ -1518,71 +1518,71 @@ void QueuedCommandsComponentBase ::
   FW_ASSERT(this->m_cmdRegOut_OutputPort[0].isConnected());
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_PRIMITIVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_PRIMITIVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_STRING
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_STRING
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_ENUM
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_ENUM
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_ARRAY
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_ARRAY
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_STRUCT
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_STRUCT
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_PRIMITIVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_PRIMITIVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_STRING
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_STRING
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_ENUM
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_ENUM
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_ARRAY
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_ARRAY
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_STRUCT
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_STRUCT
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_ASYNC
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_ASYNC
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_PRIORITY
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_PRIORITY
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_PARAMS_PRIORITY
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_DROP
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_DROP
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_DROP
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_PARAMS_PRIORITY_DROP
   );
 }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.cpp
@@ -3202,7 +3202,7 @@ void QueuedEventsComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTACTIVITYHIGH;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTACTIVITYHIGH;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -3279,7 +3279,7 @@ void QueuedEventsComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTACTIVITYLOWTHROTTLED;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTACTIVITYLOWTHROTTLED;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -3398,7 +3398,7 @@ void QueuedEventsComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTCOMMAND;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTCOMMAND;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -3477,7 +3477,7 @@ void QueuedEventsComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTDIAGNOSTIC;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTDIAGNOSTIC;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -3570,7 +3570,7 @@ void QueuedEventsComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTFATALTHROTTLED;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTFATALTHROTTLED;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -3668,7 +3668,7 @@ void QueuedEventsComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTWARNINGHIGH;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTWARNINGHIGH;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -3761,7 +3761,7 @@ void QueuedEventsComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLED;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTWARNINGLOWTHROTTLED;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedExternalParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedExternalParamsComponentAc.ref.cpp
@@ -1513,51 +1513,51 @@ void QueuedExternalParamsComponentBase ::
   FW_ASSERT(this->m_cmdRegOut_OutputPort[0].isConnected());
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMI32EXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMI32EXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMI32EXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMI32EXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMF64EXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64EXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMF64EXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64EXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRINGEXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRINGEXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMENUMEXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUMEXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMENUMEXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUMEXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMARRAYEXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAYEXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMARRAYEXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAYEXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCTEXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCTEXT_SAVE
   );
 }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedOverflowComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedOverflowComponentAc.ref.cpp
@@ -753,11 +753,11 @@ void QueuedOverflowComponentBase ::
   FW_ASSERT(this->m_cmdRegOut_OutputPort[0].isConnected());
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_HOOK
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_HOOK
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_HOOK
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_PARAMS_PRIORITY_HOOK
   );
 }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.cpp
@@ -1513,51 +1513,51 @@ void QueuedParamsComponentBase ::
   FW_ASSERT(this->m_cmdRegOut_OutputPort[0].isConnected());
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMU32_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMU32_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMU32_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMU32_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMF64_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMF64_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRING_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRING_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRING_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRING_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMENUM_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUM_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMENUM_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUM_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMARRAY_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAY_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMARRAY_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAY_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRUCT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRUCT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCT_SAVE
   );
 }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
@@ -1812,167 +1812,167 @@ void QueuedSerialComponentBase ::
   FW_ASSERT(this->m_cmdRegOut_OutputPort[0].isConnected());
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_PRIMITIVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_PRIMITIVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_STRING
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_STRING
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_ENUM
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_ENUM
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_ARRAY
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_ARRAY
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_STRUCT
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_STRUCT
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_PRIMITIVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_PRIMITIVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_STRING
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_STRING
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_ENUM
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_ENUM
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_ARRAY
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_ARRAY
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_STRUCT
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_STRUCT
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_ASYNC
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_ASYNC
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_PRIORITY
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_PRIORITY
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_PARAMS_PRIORITY
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_DROP
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_DROP
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_DROP
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_PARAMS_PRIORITY_DROP
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMU32_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMU32_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMU32_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMU32_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMF64_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMF64_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRING_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRING_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRING_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRING_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMENUM_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUM_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMENUM_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUM_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMARRAY_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAY_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMARRAY_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAY_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRUCT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRUCT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMI32EXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMI32EXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMI32EXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMI32EXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMF64EXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64EXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMF64EXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64EXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRINGEXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRINGEXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMENUMEXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUMEXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMENUMEXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUMEXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMARRAYEXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAYEXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMARRAYEXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAYEXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCTEXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCTEXT_SAVE
   );
 }
 
@@ -5690,7 +5690,7 @@ void QueuedSerialComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTACTIVITYHIGH;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTACTIVITYHIGH;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -5767,7 +5767,7 @@ void QueuedSerialComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTACTIVITYLOWTHROTTLED;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTACTIVITYLOWTHROTTLED;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -5886,7 +5886,7 @@ void QueuedSerialComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTCOMMAND;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTCOMMAND;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -5965,7 +5965,7 @@ void QueuedSerialComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTDIAGNOSTIC;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTDIAGNOSTIC;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -6058,7 +6058,7 @@ void QueuedSerialComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTFATALTHROTTLED;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTFATALTHROTTLED;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -6156,7 +6156,7 @@ void QueuedSerialComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTWARNINGHIGH;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTWARNINGHIGH;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -6249,7 +6249,7 @@ void QueuedSerialComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLED;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTWARNINGLOWTHROTTLED;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -6355,7 +6355,7 @@ void QueuedSerialComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELU32FORMAT;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELU32FORMAT;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -6388,7 +6388,7 @@ void QueuedSerialComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELF32FORMAT;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELF32FORMAT;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -6421,7 +6421,7 @@ void QueuedSerialComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELSTRINGFORMAT;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELSTRINGFORMAT;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -6454,7 +6454,7 @@ void QueuedSerialComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELENUM;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELENUM;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -6487,7 +6487,7 @@ void QueuedSerialComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELARRAYFREQ;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELARRAYFREQ;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -6520,7 +6520,7 @@ void QueuedSerialComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELSTRUCTFREQ;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELSTRUCTFREQ;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -6553,7 +6553,7 @@ void QueuedSerialComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELU32LIMITS;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELU32LIMITS;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -6586,7 +6586,7 @@ void QueuedSerialComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELF32LIMITS;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELF32LIMITS;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -6619,7 +6619,7 @@ void QueuedSerialComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELF64;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELF64;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -6667,7 +6667,7 @@ void QueuedSerialComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELU32ONCHANGE;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELU32ONCHANGE;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -6715,7 +6715,7 @@ void QueuedSerialComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELENUMONCHANGE;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELENUMONCHANGE;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.cpp
@@ -3217,7 +3217,7 @@ void QueuedTelemetryComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELU32FORMAT;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELU32FORMAT;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -3250,7 +3250,7 @@ void QueuedTelemetryComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELF32FORMAT;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELF32FORMAT;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -3283,7 +3283,7 @@ void QueuedTelemetryComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELSTRINGFORMAT;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELSTRINGFORMAT;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -3316,7 +3316,7 @@ void QueuedTelemetryComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELENUM;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELENUM;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -3349,7 +3349,7 @@ void QueuedTelemetryComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELARRAYFREQ;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELARRAYFREQ;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -3382,7 +3382,7 @@ void QueuedTelemetryComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELSTRUCTFREQ;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELSTRUCTFREQ;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -3415,7 +3415,7 @@ void QueuedTelemetryComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELU32LIMITS;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELU32LIMITS;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -3448,7 +3448,7 @@ void QueuedTelemetryComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELF32LIMITS;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELF32LIMITS;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -3481,7 +3481,7 @@ void QueuedTelemetryComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELF64;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELF64;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -3529,7 +3529,7 @@ void QueuedTelemetryComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELU32ONCHANGE;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELU32ONCHANGE;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -3577,7 +3577,7 @@ void QueuedTelemetryComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELENUMONCHANGE;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELENUMONCHANGE;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
@@ -1899,167 +1899,167 @@ void QueuedTestComponentBase ::
   FW_ASSERT(this->m_cmdRegOut_OutputPort[0].isConnected());
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_PRIMITIVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_PRIMITIVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_STRING
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_STRING
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_ENUM
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_ENUM
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_ARRAY
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_ARRAY
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_SYNC_STRUCT
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_SYNC_STRUCT
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_PRIMITIVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_PRIMITIVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_STRING
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_STRING
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_ENUM
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_ENUM
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_ARRAY
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_ARRAY
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_GUARDED_STRUCT
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_GUARDED_STRUCT
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_ASYNC
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_ASYNC
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_PRIORITY
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_PRIORITY
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_PARAMS_PRIORITY
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_DROP
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_DROP
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_CMD_PARAMS_PRIORITY_DROP
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_CMD_PARAMS_PRIORITY_DROP
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMU32_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMU32_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMU32_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMU32_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMF64_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMF64_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRING_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRING_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRING_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRING_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMENUM_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUM_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMENUM_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUM_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMARRAY_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAY_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMARRAY_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAY_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRUCT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRUCT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMI32EXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMI32EXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMI32EXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMI32EXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMF64EXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64EXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMF64EXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMF64EXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRINGEXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRINGEXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRINGEXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMENUMEXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUMEXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMENUMEXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMENUMEXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMARRAYEXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAYEXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMARRAYEXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMARRAYEXT_SAVE
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SET
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCTEXT_SET
   );
 
   this->m_cmdRegOut_OutputPort[0].invoke(
-    this->getIdBase() + OPCODE_PARAMSTRUCTEXT_SAVE
+    static_cast<FwOpcodeType>(this->getIdBase()) + OPCODE_PARAMSTRUCTEXT_SAVE
   );
 }
 
@@ -5561,7 +5561,7 @@ void QueuedTestComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTACTIVITYHIGH;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTACTIVITYHIGH;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -5638,7 +5638,7 @@ void QueuedTestComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTACTIVITYLOWTHROTTLED;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTACTIVITYLOWTHROTTLED;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -5757,7 +5757,7 @@ void QueuedTestComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTCOMMAND;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTCOMMAND;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -5836,7 +5836,7 @@ void QueuedTestComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTDIAGNOSTIC;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTDIAGNOSTIC;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -5929,7 +5929,7 @@ void QueuedTestComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTFATALTHROTTLED;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTFATALTHROTTLED;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -6027,7 +6027,7 @@ void QueuedTestComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTWARNINGHIGH;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTWARNINGHIGH;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -6120,7 +6120,7 @@ void QueuedTestComponentBase ::
 
   FwEventIdType _id = static_cast<FwEventIdType>(0);
 
-  _id = this->getIdBase() + EVENTID_EVENTWARNINGLOWTHROTTLED;
+  _id = static_cast<FwEventIdType>(this->getIdBase()) + EVENTID_EVENTWARNINGLOWTHROTTLED;
 
   // Emit the event on the log port
   if (this->m_eventOut_OutputPort[0].isConnected()) {
@@ -6226,7 +6226,7 @@ void QueuedTestComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELU32FORMAT;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELU32FORMAT;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -6259,7 +6259,7 @@ void QueuedTestComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELF32FORMAT;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELF32FORMAT;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -6292,7 +6292,7 @@ void QueuedTestComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELSTRINGFORMAT;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELSTRINGFORMAT;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -6325,7 +6325,7 @@ void QueuedTestComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELENUM;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELENUM;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -6358,7 +6358,7 @@ void QueuedTestComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELARRAYFREQ;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELARRAYFREQ;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -6391,7 +6391,7 @@ void QueuedTestComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELSTRUCTFREQ;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELSTRUCTFREQ;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -6424,7 +6424,7 @@ void QueuedTestComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELU32LIMITS;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELU32LIMITS;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -6457,7 +6457,7 @@ void QueuedTestComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELF32LIMITS;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELF32LIMITS;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -6490,7 +6490,7 @@ void QueuedTestComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELF64;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELF64;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -6538,7 +6538,7 @@ void QueuedTestComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELU32ONCHANGE;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELU32ONCHANGE;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,
@@ -6586,7 +6586,7 @@ void QueuedTestComponentBase ::
 
     FwChanIdType _id;
 
-    _id = this->getIdBase() + CHANNELID_CHANNELENUMONCHANGE;
+    _id = static_cast<FwChanIdType>(this->getIdBase()) + CHANNELID_CHANNELENUMONCHANGE;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsTesterBase.ref.cpp
@@ -2343,8 +2343,8 @@ void ActiveCommandsTesterBase ::
       Fw::CmdArgBuffer& buf
   )
 {
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _opcode = opCode + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _opcode = opCode + static_cast<FwOpcodeType>(idBase);
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
       _opcode,
@@ -2367,8 +2367,8 @@ void ActiveCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = ActiveCommandsComponentBase::OPCODE_CMD_SYNC + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = ActiveCommandsComponentBase::OPCODE_CMD_SYNC + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2415,8 +2415,8 @@ void ActiveCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = ActiveCommandsComponentBase::OPCODE_CMD_SYNC_PRIMITIVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = ActiveCommandsComponentBase::OPCODE_CMD_SYNC_PRIMITIVE + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2456,8 +2456,8 @@ void ActiveCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = ActiveCommandsComponentBase::OPCODE_CMD_SYNC_STRING + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = ActiveCommandsComponentBase::OPCODE_CMD_SYNC_STRING + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2490,8 +2490,8 @@ void ActiveCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = ActiveCommandsComponentBase::OPCODE_CMD_SYNC_ENUM + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = ActiveCommandsComponentBase::OPCODE_CMD_SYNC_ENUM + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2524,8 +2524,8 @@ void ActiveCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = ActiveCommandsComponentBase::OPCODE_CMD_SYNC_ARRAY + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = ActiveCommandsComponentBase::OPCODE_CMD_SYNC_ARRAY + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2558,8 +2558,8 @@ void ActiveCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = ActiveCommandsComponentBase::OPCODE_CMD_SYNC_STRUCT + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = ActiveCommandsComponentBase::OPCODE_CMD_SYNC_STRUCT + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2583,8 +2583,8 @@ void ActiveCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = ActiveCommandsComponentBase::OPCODE_CMD_GUARDED + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = ActiveCommandsComponentBase::OPCODE_CMD_GUARDED + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2631,8 +2631,8 @@ void ActiveCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = ActiveCommandsComponentBase::OPCODE_CMD_GUARDED_PRIMITIVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = ActiveCommandsComponentBase::OPCODE_CMD_GUARDED_PRIMITIVE + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2672,8 +2672,8 @@ void ActiveCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = ActiveCommandsComponentBase::OPCODE_CMD_GUARDED_STRING + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = ActiveCommandsComponentBase::OPCODE_CMD_GUARDED_STRING + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2706,8 +2706,8 @@ void ActiveCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = ActiveCommandsComponentBase::OPCODE_CMD_GUARDED_ENUM + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = ActiveCommandsComponentBase::OPCODE_CMD_GUARDED_ENUM + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2740,8 +2740,8 @@ void ActiveCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = ActiveCommandsComponentBase::OPCODE_CMD_GUARDED_ARRAY + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = ActiveCommandsComponentBase::OPCODE_CMD_GUARDED_ARRAY + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2774,8 +2774,8 @@ void ActiveCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = ActiveCommandsComponentBase::OPCODE_CMD_GUARDED_STRUCT + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = ActiveCommandsComponentBase::OPCODE_CMD_GUARDED_STRUCT + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2799,8 +2799,8 @@ void ActiveCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = ActiveCommandsComponentBase::OPCODE_CMD_ASYNC + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = ActiveCommandsComponentBase::OPCODE_CMD_ASYNC + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2824,8 +2824,8 @@ void ActiveCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = ActiveCommandsComponentBase::OPCODE_CMD_PRIORITY + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = ActiveCommandsComponentBase::OPCODE_CMD_PRIORITY + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2858,8 +2858,8 @@ void ActiveCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = ActiveCommandsComponentBase::OPCODE_CMD_PARAMS_PRIORITY + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = ActiveCommandsComponentBase::OPCODE_CMD_PARAMS_PRIORITY + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2883,8 +2883,8 @@ void ActiveCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = ActiveCommandsComponentBase::OPCODE_CMD_DROP + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = ActiveCommandsComponentBase::OPCODE_CMD_DROP + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2917,8 +2917,8 @@ void ActiveCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = ActiveCommandsComponentBase::OPCODE_CMD_PARAMS_PRIORITY_DROP + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = ActiveCommandsComponentBase::OPCODE_CMD_PARAMS_PRIORITY_DROP + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsTesterBase.ref.cpp
@@ -2332,7 +2332,7 @@ void ActiveEventsTesterBase ::
 {
   args.resetDeser();
 
-  const U32 idBase = this->getIdBase();
+  const FwIdType idBase = this->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsTesterBase.ref.hpp
@@ -216,7 +216,7 @@ class ActiveEventsTesterBase :
 
     //! A history entry for text log events
     struct TextLogEntry {
-      U32 id;
+      FwEventIdType id;
       Fw::Time timeTag;
       Fw::LogSeverity severity;
       Fw::TextLogString text;

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveExternalParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveExternalParamsTesterBase.ref.cpp
@@ -2486,8 +2486,8 @@ void ActiveExternalParamsTesterBase ::
       Fw::CmdArgBuffer& buf
   )
 {
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _opcode = opCode + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _opcode = opCode + static_cast<FwOpcodeType>(idBase);
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
       _opcode,
@@ -2526,8 +2526,8 @@ void ActiveExternalParamsTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamI32Ext) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  ActiveExternalParamsComponentBase::OPCODE_PARAMI32EXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  ActiveExternalParamsComponentBase::OPCODE_PARAMI32EXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2548,8 +2548,8 @@ void ActiveExternalParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = ActiveExternalParamsComponentBase::OPCODE_PARAMI32EXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = ActiveExternalParamsComponentBase::OPCODE_PARAMI32EXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2585,8 +2585,8 @@ void ActiveExternalParamsTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamF64Ext) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  ActiveExternalParamsComponentBase::OPCODE_PARAMF64EXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  ActiveExternalParamsComponentBase::OPCODE_PARAMF64EXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2607,8 +2607,8 @@ void ActiveExternalParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = ActiveExternalParamsComponentBase::OPCODE_PARAMF64EXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = ActiveExternalParamsComponentBase::OPCODE_PARAMF64EXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2644,8 +2644,8 @@ void ActiveExternalParamsTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamStringExt) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  ActiveExternalParamsComponentBase::OPCODE_PARAMSTRINGEXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  ActiveExternalParamsComponentBase::OPCODE_PARAMSTRINGEXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2666,8 +2666,8 @@ void ActiveExternalParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = ActiveExternalParamsComponentBase::OPCODE_PARAMSTRINGEXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = ActiveExternalParamsComponentBase::OPCODE_PARAMSTRINGEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2703,8 +2703,8 @@ void ActiveExternalParamsTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamEnumExt) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  ActiveExternalParamsComponentBase::OPCODE_PARAMENUMEXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  ActiveExternalParamsComponentBase::OPCODE_PARAMENUMEXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2725,8 +2725,8 @@ void ActiveExternalParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = ActiveExternalParamsComponentBase::OPCODE_PARAMENUMEXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = ActiveExternalParamsComponentBase::OPCODE_PARAMENUMEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2762,8 +2762,8 @@ void ActiveExternalParamsTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamArrayExt) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  ActiveExternalParamsComponentBase::OPCODE_PARAMARRAYEXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  ActiveExternalParamsComponentBase::OPCODE_PARAMARRAYEXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2784,8 +2784,8 @@ void ActiveExternalParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = ActiveExternalParamsComponentBase::OPCODE_PARAMARRAYEXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = ActiveExternalParamsComponentBase::OPCODE_PARAMARRAYEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2821,8 +2821,8 @@ void ActiveExternalParamsTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamStructExt) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  ActiveExternalParamsComponentBase::OPCODE_PARAMSTRUCTEXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  ActiveExternalParamsComponentBase::OPCODE_PARAMSTRUCTEXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2843,8 +2843,8 @@ void ActiveExternalParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = ActiveExternalParamsComponentBase::OPCODE_PARAMSTRUCTEXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = ActiveExternalParamsComponentBase::OPCODE_PARAMSTRUCTEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -3097,7 +3097,7 @@ Fw::ParamValid ActiveExternalParamsTesterBase ::
   Fw::ParamValid _ret = Fw::ParamValid::VALID;
   val.resetSer();
 
-  const U32 idBase = _testerBase->getIdBase();
+  const FwIdType idBase = _testerBase->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),
@@ -3184,7 +3184,7 @@ void ActiveExternalParamsTesterBase ::
   ActiveExternalParamsTesterBase* _testerBase = static_cast<ActiveExternalParamsTesterBase*>(callComp);
   Fw::SerializeStatus _status;
 
-  const U32 idBase = _testerBase->getIdBase();
+  const FwIdType idBase = _testerBase->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsTesterBase.ref.cpp
@@ -2397,8 +2397,8 @@ void ActiveParamsTesterBase ::
       Fw::CmdArgBuffer& buf
   )
 {
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _opcode = opCode + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _opcode = opCode + static_cast<FwOpcodeType>(idBase);
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
       _opcode,
@@ -2437,8 +2437,8 @@ void ActiveParamsTesterBase ::
     args.serialize(this->m_param_ParamU32) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  ActiveParamsComponentBase::OPCODE_PARAMU32_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  ActiveParamsComponentBase::OPCODE_PARAMU32_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2459,8 +2459,8 @@ void ActiveParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = ActiveParamsComponentBase::OPCODE_PARAMU32_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = ActiveParamsComponentBase::OPCODE_PARAMU32_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2496,8 +2496,8 @@ void ActiveParamsTesterBase ::
     args.serialize(this->m_param_ParamF64) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  ActiveParamsComponentBase::OPCODE_PARAMF64_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  ActiveParamsComponentBase::OPCODE_PARAMF64_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2518,8 +2518,8 @@ void ActiveParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = ActiveParamsComponentBase::OPCODE_PARAMF64_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = ActiveParamsComponentBase::OPCODE_PARAMF64_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2555,8 +2555,8 @@ void ActiveParamsTesterBase ::
     args.serialize(this->m_param_ParamString) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  ActiveParamsComponentBase::OPCODE_PARAMSTRING_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  ActiveParamsComponentBase::OPCODE_PARAMSTRING_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2577,8 +2577,8 @@ void ActiveParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = ActiveParamsComponentBase::OPCODE_PARAMSTRING_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = ActiveParamsComponentBase::OPCODE_PARAMSTRING_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2614,8 +2614,8 @@ void ActiveParamsTesterBase ::
     args.serialize(this->m_param_ParamEnum) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  ActiveParamsComponentBase::OPCODE_PARAMENUM_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  ActiveParamsComponentBase::OPCODE_PARAMENUM_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2636,8 +2636,8 @@ void ActiveParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = ActiveParamsComponentBase::OPCODE_PARAMENUM_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = ActiveParamsComponentBase::OPCODE_PARAMENUM_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2673,8 +2673,8 @@ void ActiveParamsTesterBase ::
     args.serialize(this->m_param_ParamArray) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  ActiveParamsComponentBase::OPCODE_PARAMARRAY_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  ActiveParamsComponentBase::OPCODE_PARAMARRAY_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2695,8 +2695,8 @@ void ActiveParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = ActiveParamsComponentBase::OPCODE_PARAMARRAY_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = ActiveParamsComponentBase::OPCODE_PARAMARRAY_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2732,8 +2732,8 @@ void ActiveParamsTesterBase ::
     args.serialize(this->m_param_ParamStruct) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  ActiveParamsComponentBase::OPCODE_PARAMSTRUCT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  ActiveParamsComponentBase::OPCODE_PARAMSTRUCT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2754,8 +2754,8 @@ void ActiveParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = ActiveParamsComponentBase::OPCODE_PARAMSTRUCT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = ActiveParamsComponentBase::OPCODE_PARAMSTRUCT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -3008,7 +3008,7 @@ Fw::ParamValid ActiveParamsTesterBase ::
   Fw::ParamValid _ret = Fw::ParamValid::VALID;
   val.resetSer();
 
-  const U32 idBase = _testerBase->getIdBase();
+  const FwIdType idBase = _testerBase->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),
@@ -3095,7 +3095,7 @@ void ActiveParamsTesterBase ::
   ActiveParamsTesterBase* _testerBase = static_cast<ActiveParamsTesterBase*>(callComp);
   Fw::SerializeStatus _status;
 
-  const U32 idBase = _testerBase->getIdBase();
+  const FwIdType idBase = _testerBase->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.cpp
@@ -3080,8 +3080,8 @@ void ActiveSerialTesterBase ::
       Fw::CmdArgBuffer& buf
   )
 {
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _opcode = opCode + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _opcode = opCode + static_cast<FwOpcodeType>(idBase);
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
       _opcode,
@@ -3104,8 +3104,8 @@ void ActiveSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = ActiveSerialComponentBase::OPCODE_CMD_SYNC + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = ActiveSerialComponentBase::OPCODE_CMD_SYNC + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3152,8 +3152,8 @@ void ActiveSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = ActiveSerialComponentBase::OPCODE_CMD_SYNC_PRIMITIVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = ActiveSerialComponentBase::OPCODE_CMD_SYNC_PRIMITIVE + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3193,8 +3193,8 @@ void ActiveSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = ActiveSerialComponentBase::OPCODE_CMD_SYNC_STRING + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = ActiveSerialComponentBase::OPCODE_CMD_SYNC_STRING + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3227,8 +3227,8 @@ void ActiveSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = ActiveSerialComponentBase::OPCODE_CMD_SYNC_ENUM + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = ActiveSerialComponentBase::OPCODE_CMD_SYNC_ENUM + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3261,8 +3261,8 @@ void ActiveSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = ActiveSerialComponentBase::OPCODE_CMD_SYNC_ARRAY + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = ActiveSerialComponentBase::OPCODE_CMD_SYNC_ARRAY + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3295,8 +3295,8 @@ void ActiveSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = ActiveSerialComponentBase::OPCODE_CMD_SYNC_STRUCT + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = ActiveSerialComponentBase::OPCODE_CMD_SYNC_STRUCT + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3320,8 +3320,8 @@ void ActiveSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = ActiveSerialComponentBase::OPCODE_CMD_GUARDED + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = ActiveSerialComponentBase::OPCODE_CMD_GUARDED + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3368,8 +3368,8 @@ void ActiveSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = ActiveSerialComponentBase::OPCODE_CMD_GUARDED_PRIMITIVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = ActiveSerialComponentBase::OPCODE_CMD_GUARDED_PRIMITIVE + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3409,8 +3409,8 @@ void ActiveSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = ActiveSerialComponentBase::OPCODE_CMD_GUARDED_STRING + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = ActiveSerialComponentBase::OPCODE_CMD_GUARDED_STRING + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3443,8 +3443,8 @@ void ActiveSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = ActiveSerialComponentBase::OPCODE_CMD_GUARDED_ENUM + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = ActiveSerialComponentBase::OPCODE_CMD_GUARDED_ENUM + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3477,8 +3477,8 @@ void ActiveSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = ActiveSerialComponentBase::OPCODE_CMD_GUARDED_ARRAY + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = ActiveSerialComponentBase::OPCODE_CMD_GUARDED_ARRAY + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3511,8 +3511,8 @@ void ActiveSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = ActiveSerialComponentBase::OPCODE_CMD_GUARDED_STRUCT + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = ActiveSerialComponentBase::OPCODE_CMD_GUARDED_STRUCT + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3536,8 +3536,8 @@ void ActiveSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = ActiveSerialComponentBase::OPCODE_CMD_ASYNC + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = ActiveSerialComponentBase::OPCODE_CMD_ASYNC + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3561,8 +3561,8 @@ void ActiveSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = ActiveSerialComponentBase::OPCODE_CMD_PRIORITY + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = ActiveSerialComponentBase::OPCODE_CMD_PRIORITY + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3595,8 +3595,8 @@ void ActiveSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = ActiveSerialComponentBase::OPCODE_CMD_PARAMS_PRIORITY + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = ActiveSerialComponentBase::OPCODE_CMD_PARAMS_PRIORITY + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3620,8 +3620,8 @@ void ActiveSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = ActiveSerialComponentBase::OPCODE_CMD_DROP + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = ActiveSerialComponentBase::OPCODE_CMD_DROP + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3654,8 +3654,8 @@ void ActiveSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = ActiveSerialComponentBase::OPCODE_CMD_PARAMS_PRIORITY_DROP + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = ActiveSerialComponentBase::OPCODE_CMD_PARAMS_PRIORITY_DROP + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3683,7 +3683,7 @@ void ActiveSerialTesterBase ::
 {
   args.resetDeser();
 
-  const U32 idBase = this->getIdBase();
+  const FwIdType idBase = this->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),
@@ -4148,7 +4148,7 @@ void ActiveSerialTesterBase ::
 {
   val.resetDeser();
 
-  const U32 idBase = this->getIdBase();
+  const FwIdType idBase = this->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),
@@ -4453,8 +4453,8 @@ void ActiveSerialTesterBase ::
     args.serialize(this->m_param_ParamU32) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  ActiveSerialComponentBase::OPCODE_PARAMU32_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  ActiveSerialComponentBase::OPCODE_PARAMU32_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4475,8 +4475,8 @@ void ActiveSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = ActiveSerialComponentBase::OPCODE_PARAMU32_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = ActiveSerialComponentBase::OPCODE_PARAMU32_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4512,8 +4512,8 @@ void ActiveSerialTesterBase ::
     args.serialize(this->m_param_ParamF64) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  ActiveSerialComponentBase::OPCODE_PARAMF64_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  ActiveSerialComponentBase::OPCODE_PARAMF64_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4534,8 +4534,8 @@ void ActiveSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = ActiveSerialComponentBase::OPCODE_PARAMF64_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = ActiveSerialComponentBase::OPCODE_PARAMF64_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4571,8 +4571,8 @@ void ActiveSerialTesterBase ::
     args.serialize(this->m_param_ParamString) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  ActiveSerialComponentBase::OPCODE_PARAMSTRING_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  ActiveSerialComponentBase::OPCODE_PARAMSTRING_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4593,8 +4593,8 @@ void ActiveSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = ActiveSerialComponentBase::OPCODE_PARAMSTRING_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = ActiveSerialComponentBase::OPCODE_PARAMSTRING_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4630,8 +4630,8 @@ void ActiveSerialTesterBase ::
     args.serialize(this->m_param_ParamEnum) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  ActiveSerialComponentBase::OPCODE_PARAMENUM_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  ActiveSerialComponentBase::OPCODE_PARAMENUM_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4652,8 +4652,8 @@ void ActiveSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = ActiveSerialComponentBase::OPCODE_PARAMENUM_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = ActiveSerialComponentBase::OPCODE_PARAMENUM_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4689,8 +4689,8 @@ void ActiveSerialTesterBase ::
     args.serialize(this->m_param_ParamArray) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  ActiveSerialComponentBase::OPCODE_PARAMARRAY_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  ActiveSerialComponentBase::OPCODE_PARAMARRAY_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4711,8 +4711,8 @@ void ActiveSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = ActiveSerialComponentBase::OPCODE_PARAMARRAY_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = ActiveSerialComponentBase::OPCODE_PARAMARRAY_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4748,8 +4748,8 @@ void ActiveSerialTesterBase ::
     args.serialize(this->m_param_ParamStruct) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  ActiveSerialComponentBase::OPCODE_PARAMSTRUCT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  ActiveSerialComponentBase::OPCODE_PARAMSTRUCT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4770,8 +4770,8 @@ void ActiveSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = ActiveSerialComponentBase::OPCODE_PARAMSTRUCT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = ActiveSerialComponentBase::OPCODE_PARAMSTRUCT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4807,8 +4807,8 @@ void ActiveSerialTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamI32Ext) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  ActiveSerialComponentBase::OPCODE_PARAMI32EXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  ActiveSerialComponentBase::OPCODE_PARAMI32EXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4829,8 +4829,8 @@ void ActiveSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = ActiveSerialComponentBase::OPCODE_PARAMI32EXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = ActiveSerialComponentBase::OPCODE_PARAMI32EXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4866,8 +4866,8 @@ void ActiveSerialTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamF64Ext) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  ActiveSerialComponentBase::OPCODE_PARAMF64EXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  ActiveSerialComponentBase::OPCODE_PARAMF64EXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4888,8 +4888,8 @@ void ActiveSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = ActiveSerialComponentBase::OPCODE_PARAMF64EXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = ActiveSerialComponentBase::OPCODE_PARAMF64EXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4925,8 +4925,8 @@ void ActiveSerialTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamStringExt) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  ActiveSerialComponentBase::OPCODE_PARAMSTRINGEXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  ActiveSerialComponentBase::OPCODE_PARAMSTRINGEXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4947,8 +4947,8 @@ void ActiveSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = ActiveSerialComponentBase::OPCODE_PARAMSTRINGEXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = ActiveSerialComponentBase::OPCODE_PARAMSTRINGEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4984,8 +4984,8 @@ void ActiveSerialTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamEnumExt) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  ActiveSerialComponentBase::OPCODE_PARAMENUMEXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  ActiveSerialComponentBase::OPCODE_PARAMENUMEXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -5006,8 +5006,8 @@ void ActiveSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = ActiveSerialComponentBase::OPCODE_PARAMENUMEXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = ActiveSerialComponentBase::OPCODE_PARAMENUMEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -5043,8 +5043,8 @@ void ActiveSerialTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamArrayExt) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  ActiveSerialComponentBase::OPCODE_PARAMARRAYEXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  ActiveSerialComponentBase::OPCODE_PARAMARRAYEXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -5065,8 +5065,8 @@ void ActiveSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = ActiveSerialComponentBase::OPCODE_PARAMARRAYEXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = ActiveSerialComponentBase::OPCODE_PARAMARRAYEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -5102,8 +5102,8 @@ void ActiveSerialTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamStructExt) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  ActiveSerialComponentBase::OPCODE_PARAMSTRUCTEXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  ActiveSerialComponentBase::OPCODE_PARAMSTRUCTEXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -5124,8 +5124,8 @@ void ActiveSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = ActiveSerialComponentBase::OPCODE_PARAMSTRUCTEXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = ActiveSerialComponentBase::OPCODE_PARAMSTRUCTEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -5489,7 +5489,7 @@ Fw::ParamValid ActiveSerialTesterBase ::
   Fw::ParamValid _ret = Fw::ParamValid::VALID;
   val.resetSer();
 
-  const U32 idBase = _testerBase->getIdBase();
+  const FwIdType idBase = _testerBase->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),
@@ -5636,7 +5636,7 @@ void ActiveSerialTesterBase ::
   ActiveSerialTesterBase* _testerBase = static_cast<ActiveSerialTesterBase*>(callComp);
   Fw::SerializeStatus _status;
 
-  const U32 idBase = _testerBase->getIdBase();
+  const FwIdType idBase = _testerBase->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.hpp
@@ -224,7 +224,7 @@ class ActiveSerialTesterBase :
 
     //! A history entry for text log events
     struct TextLogEntry {
-      U32 id;
+      FwEventIdType id;
       Fw::Time timeTag;
       Fw::LogSeverity severity;
       Fw::TextLogString text;

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryTesterBase.ref.cpp
@@ -2311,7 +2311,7 @@ void ActiveTelemetryTesterBase ::
 {
   val.resetDeser();
 
-  const U32 idBase = this->getIdBase();
+  const FwIdType idBase = this->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.cpp
@@ -2754,8 +2754,8 @@ namespace M {
         Fw::CmdArgBuffer& buf
     )
   {
-    const U32 idBase = this->getIdBase();
-    FwOpcodeType _opcode = opCode + idBase;
+    const FwIdType idBase = this->getIdBase();
+    FwOpcodeType _opcode = opCode + static_cast<FwOpcodeType>(idBase);
     if (this->m_to_cmdIn[0].isConnected()) {
       this->m_to_cmdIn[0].invoke(
         _opcode,
@@ -2778,8 +2778,8 @@ namespace M {
 
     // Call output command port
     FwOpcodeType _opcode;
-    const U32 idBase = this->getIdBase();
-    _opcode = ActiveTestComponentBase::OPCODE_CMD_SYNC + idBase;
+    const FwIdType idBase = this->getIdBase();
+    _opcode = ActiveTestComponentBase::OPCODE_CMD_SYNC + static_cast<FwOpcodeType>(idBase);
 
     if (this->m_to_cmdIn[0].isConnected()) {
       this->m_to_cmdIn[0].invoke(
@@ -2826,8 +2826,8 @@ namespace M {
 
     // Call output command port
     FwOpcodeType _opcode;
-    const U32 idBase = this->getIdBase();
-    _opcode = ActiveTestComponentBase::OPCODE_CMD_SYNC_PRIMITIVE + idBase;
+    const FwIdType idBase = this->getIdBase();
+    _opcode = ActiveTestComponentBase::OPCODE_CMD_SYNC_PRIMITIVE + static_cast<FwOpcodeType>(idBase);
 
     if (this->m_to_cmdIn[0].isConnected()) {
       this->m_to_cmdIn[0].invoke(
@@ -2867,8 +2867,8 @@ namespace M {
 
     // Call output command port
     FwOpcodeType _opcode;
-    const U32 idBase = this->getIdBase();
-    _opcode = ActiveTestComponentBase::OPCODE_CMD_SYNC_STRING + idBase;
+    const FwIdType idBase = this->getIdBase();
+    _opcode = ActiveTestComponentBase::OPCODE_CMD_SYNC_STRING + static_cast<FwOpcodeType>(idBase);
 
     if (this->m_to_cmdIn[0].isConnected()) {
       this->m_to_cmdIn[0].invoke(
@@ -2901,8 +2901,8 @@ namespace M {
 
     // Call output command port
     FwOpcodeType _opcode;
-    const U32 idBase = this->getIdBase();
-    _opcode = ActiveTestComponentBase::OPCODE_CMD_SYNC_ENUM + idBase;
+    const FwIdType idBase = this->getIdBase();
+    _opcode = ActiveTestComponentBase::OPCODE_CMD_SYNC_ENUM + static_cast<FwOpcodeType>(idBase);
 
     if (this->m_to_cmdIn[0].isConnected()) {
       this->m_to_cmdIn[0].invoke(
@@ -2935,8 +2935,8 @@ namespace M {
 
     // Call output command port
     FwOpcodeType _opcode;
-    const U32 idBase = this->getIdBase();
-    _opcode = ActiveTestComponentBase::OPCODE_CMD_SYNC_ARRAY + idBase;
+    const FwIdType idBase = this->getIdBase();
+    _opcode = ActiveTestComponentBase::OPCODE_CMD_SYNC_ARRAY + static_cast<FwOpcodeType>(idBase);
 
     if (this->m_to_cmdIn[0].isConnected()) {
       this->m_to_cmdIn[0].invoke(
@@ -2969,8 +2969,8 @@ namespace M {
 
     // Call output command port
     FwOpcodeType _opcode;
-    const U32 idBase = this->getIdBase();
-    _opcode = ActiveTestComponentBase::OPCODE_CMD_SYNC_STRUCT + idBase;
+    const FwIdType idBase = this->getIdBase();
+    _opcode = ActiveTestComponentBase::OPCODE_CMD_SYNC_STRUCT + static_cast<FwOpcodeType>(idBase);
 
     if (this->m_to_cmdIn[0].isConnected()) {
       this->m_to_cmdIn[0].invoke(
@@ -2994,8 +2994,8 @@ namespace M {
 
     // Call output command port
     FwOpcodeType _opcode;
-    const U32 idBase = this->getIdBase();
-    _opcode = ActiveTestComponentBase::OPCODE_CMD_GUARDED + idBase;
+    const FwIdType idBase = this->getIdBase();
+    _opcode = ActiveTestComponentBase::OPCODE_CMD_GUARDED + static_cast<FwOpcodeType>(idBase);
 
     if (this->m_to_cmdIn[0].isConnected()) {
       this->m_to_cmdIn[0].invoke(
@@ -3042,8 +3042,8 @@ namespace M {
 
     // Call output command port
     FwOpcodeType _opcode;
-    const U32 idBase = this->getIdBase();
-    _opcode = ActiveTestComponentBase::OPCODE_CMD_GUARDED_PRIMITIVE + idBase;
+    const FwIdType idBase = this->getIdBase();
+    _opcode = ActiveTestComponentBase::OPCODE_CMD_GUARDED_PRIMITIVE + static_cast<FwOpcodeType>(idBase);
 
     if (this->m_to_cmdIn[0].isConnected()) {
       this->m_to_cmdIn[0].invoke(
@@ -3083,8 +3083,8 @@ namespace M {
 
     // Call output command port
     FwOpcodeType _opcode;
-    const U32 idBase = this->getIdBase();
-    _opcode = ActiveTestComponentBase::OPCODE_CMD_GUARDED_STRING + idBase;
+    const FwIdType idBase = this->getIdBase();
+    _opcode = ActiveTestComponentBase::OPCODE_CMD_GUARDED_STRING + static_cast<FwOpcodeType>(idBase);
 
     if (this->m_to_cmdIn[0].isConnected()) {
       this->m_to_cmdIn[0].invoke(
@@ -3117,8 +3117,8 @@ namespace M {
 
     // Call output command port
     FwOpcodeType _opcode;
-    const U32 idBase = this->getIdBase();
-    _opcode = ActiveTestComponentBase::OPCODE_CMD_GUARDED_ENUM + idBase;
+    const FwIdType idBase = this->getIdBase();
+    _opcode = ActiveTestComponentBase::OPCODE_CMD_GUARDED_ENUM + static_cast<FwOpcodeType>(idBase);
 
     if (this->m_to_cmdIn[0].isConnected()) {
       this->m_to_cmdIn[0].invoke(
@@ -3151,8 +3151,8 @@ namespace M {
 
     // Call output command port
     FwOpcodeType _opcode;
-    const U32 idBase = this->getIdBase();
-    _opcode = ActiveTestComponentBase::OPCODE_CMD_GUARDED_ARRAY + idBase;
+    const FwIdType idBase = this->getIdBase();
+    _opcode = ActiveTestComponentBase::OPCODE_CMD_GUARDED_ARRAY + static_cast<FwOpcodeType>(idBase);
 
     if (this->m_to_cmdIn[0].isConnected()) {
       this->m_to_cmdIn[0].invoke(
@@ -3185,8 +3185,8 @@ namespace M {
 
     // Call output command port
     FwOpcodeType _opcode;
-    const U32 idBase = this->getIdBase();
-    _opcode = ActiveTestComponentBase::OPCODE_CMD_GUARDED_STRUCT + idBase;
+    const FwIdType idBase = this->getIdBase();
+    _opcode = ActiveTestComponentBase::OPCODE_CMD_GUARDED_STRUCT + static_cast<FwOpcodeType>(idBase);
 
     if (this->m_to_cmdIn[0].isConnected()) {
       this->m_to_cmdIn[0].invoke(
@@ -3210,8 +3210,8 @@ namespace M {
 
     // Call output command port
     FwOpcodeType _opcode;
-    const U32 idBase = this->getIdBase();
-    _opcode = ActiveTestComponentBase::OPCODE_CMD_ASYNC + idBase;
+    const FwIdType idBase = this->getIdBase();
+    _opcode = ActiveTestComponentBase::OPCODE_CMD_ASYNC + static_cast<FwOpcodeType>(idBase);
 
     if (this->m_to_cmdIn[0].isConnected()) {
       this->m_to_cmdIn[0].invoke(
@@ -3235,8 +3235,8 @@ namespace M {
 
     // Call output command port
     FwOpcodeType _opcode;
-    const U32 idBase = this->getIdBase();
-    _opcode = ActiveTestComponentBase::OPCODE_CMD_PRIORITY + idBase;
+    const FwIdType idBase = this->getIdBase();
+    _opcode = ActiveTestComponentBase::OPCODE_CMD_PRIORITY + static_cast<FwOpcodeType>(idBase);
 
     if (this->m_to_cmdIn[0].isConnected()) {
       this->m_to_cmdIn[0].invoke(
@@ -3269,8 +3269,8 @@ namespace M {
 
     // Call output command port
     FwOpcodeType _opcode;
-    const U32 idBase = this->getIdBase();
-    _opcode = ActiveTestComponentBase::OPCODE_CMD_PARAMS_PRIORITY + idBase;
+    const FwIdType idBase = this->getIdBase();
+    _opcode = ActiveTestComponentBase::OPCODE_CMD_PARAMS_PRIORITY + static_cast<FwOpcodeType>(idBase);
 
     if (this->m_to_cmdIn[0].isConnected()) {
       this->m_to_cmdIn[0].invoke(
@@ -3294,8 +3294,8 @@ namespace M {
 
     // Call output command port
     FwOpcodeType _opcode;
-    const U32 idBase = this->getIdBase();
-    _opcode = ActiveTestComponentBase::OPCODE_CMD_DROP + idBase;
+    const FwIdType idBase = this->getIdBase();
+    _opcode = ActiveTestComponentBase::OPCODE_CMD_DROP + static_cast<FwOpcodeType>(idBase);
 
     if (this->m_to_cmdIn[0].isConnected()) {
       this->m_to_cmdIn[0].invoke(
@@ -3328,8 +3328,8 @@ namespace M {
 
     // Call output command port
     FwOpcodeType _opcode;
-    const U32 idBase = this->getIdBase();
-    _opcode = ActiveTestComponentBase::OPCODE_CMD_PARAMS_PRIORITY_DROP + idBase;
+    const FwIdType idBase = this->getIdBase();
+    _opcode = ActiveTestComponentBase::OPCODE_CMD_PARAMS_PRIORITY_DROP + static_cast<FwOpcodeType>(idBase);
 
     if (this->m_to_cmdIn[0].isConnected()) {
       this->m_to_cmdIn[0].invoke(
@@ -3357,7 +3357,7 @@ namespace M {
   {
     args.resetDeser();
 
-    const U32 idBase = this->getIdBase();
+    const FwIdType idBase = this->getIdBase();
     FW_ASSERT(
       id >= idBase,
       static_cast<FwAssertArgType>(id),
@@ -3822,7 +3822,7 @@ namespace M {
   {
     val.resetDeser();
 
-    const U32 idBase = this->getIdBase();
+    const FwIdType idBase = this->getIdBase();
     FW_ASSERT(
       id >= idBase,
       static_cast<FwAssertArgType>(id),
@@ -4127,8 +4127,8 @@ namespace M {
       args.serialize(this->m_param_ParamU32) == Fw::FW_SERIALIZE_OK
     );
 
-    const U32 idBase = this->getIdBase();
-    FwOpcodeType _prmOpcode =  ActiveTestComponentBase::OPCODE_PARAMU32_SET + idBase;
+    const FwIdType idBase = this->getIdBase();
+    FwOpcodeType _prmOpcode =  ActiveTestComponentBase::OPCODE_PARAMU32_SET + static_cast<FwOpcodeType>(idBase);
 
     if (not this->m_to_cmdIn[0].isConnected()) {
       printf("Test Command Output port not connected!\n");
@@ -4149,8 +4149,8 @@ namespace M {
     )
   {
     Fw::CmdArgBuffer args;
-    const U32 idBase = this->getIdBase();
-    FwOpcodeType _prmOpcode = ActiveTestComponentBase::OPCODE_PARAMU32_SAVE + idBase;
+    const FwIdType idBase = this->getIdBase();
+    FwOpcodeType _prmOpcode = ActiveTestComponentBase::OPCODE_PARAMU32_SAVE + static_cast<FwOpcodeType>(idBase);
 
     if (not this->m_to_cmdIn[0].isConnected()) {
       printf("Test Command Output port not connected!\n");
@@ -4186,8 +4186,8 @@ namespace M {
       args.serialize(this->m_param_ParamF64) == Fw::FW_SERIALIZE_OK
     );
 
-    const U32 idBase = this->getIdBase();
-    FwOpcodeType _prmOpcode =  ActiveTestComponentBase::OPCODE_PARAMF64_SET + idBase;
+    const FwIdType idBase = this->getIdBase();
+    FwOpcodeType _prmOpcode =  ActiveTestComponentBase::OPCODE_PARAMF64_SET + static_cast<FwOpcodeType>(idBase);
 
     if (not this->m_to_cmdIn[0].isConnected()) {
       printf("Test Command Output port not connected!\n");
@@ -4208,8 +4208,8 @@ namespace M {
     )
   {
     Fw::CmdArgBuffer args;
-    const U32 idBase = this->getIdBase();
-    FwOpcodeType _prmOpcode = ActiveTestComponentBase::OPCODE_PARAMF64_SAVE + idBase;
+    const FwIdType idBase = this->getIdBase();
+    FwOpcodeType _prmOpcode = ActiveTestComponentBase::OPCODE_PARAMF64_SAVE + static_cast<FwOpcodeType>(idBase);
 
     if (not this->m_to_cmdIn[0].isConnected()) {
       printf("Test Command Output port not connected!\n");
@@ -4245,8 +4245,8 @@ namespace M {
       args.serialize(this->m_param_ParamString) == Fw::FW_SERIALIZE_OK
     );
 
-    const U32 idBase = this->getIdBase();
-    FwOpcodeType _prmOpcode =  ActiveTestComponentBase::OPCODE_PARAMSTRING_SET + idBase;
+    const FwIdType idBase = this->getIdBase();
+    FwOpcodeType _prmOpcode =  ActiveTestComponentBase::OPCODE_PARAMSTRING_SET + static_cast<FwOpcodeType>(idBase);
 
     if (not this->m_to_cmdIn[0].isConnected()) {
       printf("Test Command Output port not connected!\n");
@@ -4267,8 +4267,8 @@ namespace M {
     )
   {
     Fw::CmdArgBuffer args;
-    const U32 idBase = this->getIdBase();
-    FwOpcodeType _prmOpcode = ActiveTestComponentBase::OPCODE_PARAMSTRING_SAVE + idBase;
+    const FwIdType idBase = this->getIdBase();
+    FwOpcodeType _prmOpcode = ActiveTestComponentBase::OPCODE_PARAMSTRING_SAVE + static_cast<FwOpcodeType>(idBase);
 
     if (not this->m_to_cmdIn[0].isConnected()) {
       printf("Test Command Output port not connected!\n");
@@ -4304,8 +4304,8 @@ namespace M {
       args.serialize(this->m_param_ParamEnum) == Fw::FW_SERIALIZE_OK
     );
 
-    const U32 idBase = this->getIdBase();
-    FwOpcodeType _prmOpcode =  ActiveTestComponentBase::OPCODE_PARAMENUM_SET + idBase;
+    const FwIdType idBase = this->getIdBase();
+    FwOpcodeType _prmOpcode =  ActiveTestComponentBase::OPCODE_PARAMENUM_SET + static_cast<FwOpcodeType>(idBase);
 
     if (not this->m_to_cmdIn[0].isConnected()) {
       printf("Test Command Output port not connected!\n");
@@ -4326,8 +4326,8 @@ namespace M {
     )
   {
     Fw::CmdArgBuffer args;
-    const U32 idBase = this->getIdBase();
-    FwOpcodeType _prmOpcode = ActiveTestComponentBase::OPCODE_PARAMENUM_SAVE + idBase;
+    const FwIdType idBase = this->getIdBase();
+    FwOpcodeType _prmOpcode = ActiveTestComponentBase::OPCODE_PARAMENUM_SAVE + static_cast<FwOpcodeType>(idBase);
 
     if (not this->m_to_cmdIn[0].isConnected()) {
       printf("Test Command Output port not connected!\n");
@@ -4363,8 +4363,8 @@ namespace M {
       args.serialize(this->m_param_ParamArray) == Fw::FW_SERIALIZE_OK
     );
 
-    const U32 idBase = this->getIdBase();
-    FwOpcodeType _prmOpcode =  ActiveTestComponentBase::OPCODE_PARAMARRAY_SET + idBase;
+    const FwIdType idBase = this->getIdBase();
+    FwOpcodeType _prmOpcode =  ActiveTestComponentBase::OPCODE_PARAMARRAY_SET + static_cast<FwOpcodeType>(idBase);
 
     if (not this->m_to_cmdIn[0].isConnected()) {
       printf("Test Command Output port not connected!\n");
@@ -4385,8 +4385,8 @@ namespace M {
     )
   {
     Fw::CmdArgBuffer args;
-    const U32 idBase = this->getIdBase();
-    FwOpcodeType _prmOpcode = ActiveTestComponentBase::OPCODE_PARAMARRAY_SAVE + idBase;
+    const FwIdType idBase = this->getIdBase();
+    FwOpcodeType _prmOpcode = ActiveTestComponentBase::OPCODE_PARAMARRAY_SAVE + static_cast<FwOpcodeType>(idBase);
 
     if (not this->m_to_cmdIn[0].isConnected()) {
       printf("Test Command Output port not connected!\n");
@@ -4422,8 +4422,8 @@ namespace M {
       args.serialize(this->m_param_ParamStruct) == Fw::FW_SERIALIZE_OK
     );
 
-    const U32 idBase = this->getIdBase();
-    FwOpcodeType _prmOpcode =  ActiveTestComponentBase::OPCODE_PARAMSTRUCT_SET + idBase;
+    const FwIdType idBase = this->getIdBase();
+    FwOpcodeType _prmOpcode =  ActiveTestComponentBase::OPCODE_PARAMSTRUCT_SET + static_cast<FwOpcodeType>(idBase);
 
     if (not this->m_to_cmdIn[0].isConnected()) {
       printf("Test Command Output port not connected!\n");
@@ -4444,8 +4444,8 @@ namespace M {
     )
   {
     Fw::CmdArgBuffer args;
-    const U32 idBase = this->getIdBase();
-    FwOpcodeType _prmOpcode = ActiveTestComponentBase::OPCODE_PARAMSTRUCT_SAVE + idBase;
+    const FwIdType idBase = this->getIdBase();
+    FwOpcodeType _prmOpcode = ActiveTestComponentBase::OPCODE_PARAMSTRUCT_SAVE + static_cast<FwOpcodeType>(idBase);
 
     if (not this->m_to_cmdIn[0].isConnected()) {
       printf("Test Command Output port not connected!\n");
@@ -4481,8 +4481,8 @@ namespace M {
       args.serialize(this->paramTesterDelegate.m_param_ParamI32Ext) == Fw::FW_SERIALIZE_OK
     );
 
-    const U32 idBase = this->getIdBase();
-    FwOpcodeType _prmOpcode =  ActiveTestComponentBase::OPCODE_PARAMI32EXT_SET + idBase;
+    const FwIdType idBase = this->getIdBase();
+    FwOpcodeType _prmOpcode =  ActiveTestComponentBase::OPCODE_PARAMI32EXT_SET + static_cast<FwOpcodeType>(idBase);
 
     if (not this->m_to_cmdIn[0].isConnected()) {
       printf("Test Command Output port not connected!\n");
@@ -4503,8 +4503,8 @@ namespace M {
     )
   {
     Fw::CmdArgBuffer args;
-    const U32 idBase = this->getIdBase();
-    FwOpcodeType _prmOpcode = ActiveTestComponentBase::OPCODE_PARAMI32EXT_SAVE + idBase;
+    const FwIdType idBase = this->getIdBase();
+    FwOpcodeType _prmOpcode = ActiveTestComponentBase::OPCODE_PARAMI32EXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
     if (not this->m_to_cmdIn[0].isConnected()) {
       printf("Test Command Output port not connected!\n");
@@ -4540,8 +4540,8 @@ namespace M {
       args.serialize(this->paramTesterDelegate.m_param_ParamF64Ext) == Fw::FW_SERIALIZE_OK
     );
 
-    const U32 idBase = this->getIdBase();
-    FwOpcodeType _prmOpcode =  ActiveTestComponentBase::OPCODE_PARAMF64EXT_SET + idBase;
+    const FwIdType idBase = this->getIdBase();
+    FwOpcodeType _prmOpcode =  ActiveTestComponentBase::OPCODE_PARAMF64EXT_SET + static_cast<FwOpcodeType>(idBase);
 
     if (not this->m_to_cmdIn[0].isConnected()) {
       printf("Test Command Output port not connected!\n");
@@ -4562,8 +4562,8 @@ namespace M {
     )
   {
     Fw::CmdArgBuffer args;
-    const U32 idBase = this->getIdBase();
-    FwOpcodeType _prmOpcode = ActiveTestComponentBase::OPCODE_PARAMF64EXT_SAVE + idBase;
+    const FwIdType idBase = this->getIdBase();
+    FwOpcodeType _prmOpcode = ActiveTestComponentBase::OPCODE_PARAMF64EXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
     if (not this->m_to_cmdIn[0].isConnected()) {
       printf("Test Command Output port not connected!\n");
@@ -4599,8 +4599,8 @@ namespace M {
       args.serialize(this->paramTesterDelegate.m_param_ParamStringExt) == Fw::FW_SERIALIZE_OK
     );
 
-    const U32 idBase = this->getIdBase();
-    FwOpcodeType _prmOpcode =  ActiveTestComponentBase::OPCODE_PARAMSTRINGEXT_SET + idBase;
+    const FwIdType idBase = this->getIdBase();
+    FwOpcodeType _prmOpcode =  ActiveTestComponentBase::OPCODE_PARAMSTRINGEXT_SET + static_cast<FwOpcodeType>(idBase);
 
     if (not this->m_to_cmdIn[0].isConnected()) {
       printf("Test Command Output port not connected!\n");
@@ -4621,8 +4621,8 @@ namespace M {
     )
   {
     Fw::CmdArgBuffer args;
-    const U32 idBase = this->getIdBase();
-    FwOpcodeType _prmOpcode = ActiveTestComponentBase::OPCODE_PARAMSTRINGEXT_SAVE + idBase;
+    const FwIdType idBase = this->getIdBase();
+    FwOpcodeType _prmOpcode = ActiveTestComponentBase::OPCODE_PARAMSTRINGEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
     if (not this->m_to_cmdIn[0].isConnected()) {
       printf("Test Command Output port not connected!\n");
@@ -4658,8 +4658,8 @@ namespace M {
       args.serialize(this->paramTesterDelegate.m_param_ParamEnumExt) == Fw::FW_SERIALIZE_OK
     );
 
-    const U32 idBase = this->getIdBase();
-    FwOpcodeType _prmOpcode =  ActiveTestComponentBase::OPCODE_PARAMENUMEXT_SET + idBase;
+    const FwIdType idBase = this->getIdBase();
+    FwOpcodeType _prmOpcode =  ActiveTestComponentBase::OPCODE_PARAMENUMEXT_SET + static_cast<FwOpcodeType>(idBase);
 
     if (not this->m_to_cmdIn[0].isConnected()) {
       printf("Test Command Output port not connected!\n");
@@ -4680,8 +4680,8 @@ namespace M {
     )
   {
     Fw::CmdArgBuffer args;
-    const U32 idBase = this->getIdBase();
-    FwOpcodeType _prmOpcode = ActiveTestComponentBase::OPCODE_PARAMENUMEXT_SAVE + idBase;
+    const FwIdType idBase = this->getIdBase();
+    FwOpcodeType _prmOpcode = ActiveTestComponentBase::OPCODE_PARAMENUMEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
     if (not this->m_to_cmdIn[0].isConnected()) {
       printf("Test Command Output port not connected!\n");
@@ -4717,8 +4717,8 @@ namespace M {
       args.serialize(this->paramTesterDelegate.m_param_ParamArrayExt) == Fw::FW_SERIALIZE_OK
     );
 
-    const U32 idBase = this->getIdBase();
-    FwOpcodeType _prmOpcode =  ActiveTestComponentBase::OPCODE_PARAMARRAYEXT_SET + idBase;
+    const FwIdType idBase = this->getIdBase();
+    FwOpcodeType _prmOpcode =  ActiveTestComponentBase::OPCODE_PARAMARRAYEXT_SET + static_cast<FwOpcodeType>(idBase);
 
     if (not this->m_to_cmdIn[0].isConnected()) {
       printf("Test Command Output port not connected!\n");
@@ -4739,8 +4739,8 @@ namespace M {
     )
   {
     Fw::CmdArgBuffer args;
-    const U32 idBase = this->getIdBase();
-    FwOpcodeType _prmOpcode = ActiveTestComponentBase::OPCODE_PARAMARRAYEXT_SAVE + idBase;
+    const FwIdType idBase = this->getIdBase();
+    FwOpcodeType _prmOpcode = ActiveTestComponentBase::OPCODE_PARAMARRAYEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
     if (not this->m_to_cmdIn[0].isConnected()) {
       printf("Test Command Output port not connected!\n");
@@ -4776,8 +4776,8 @@ namespace M {
       args.serialize(this->paramTesterDelegate.m_param_ParamStructExt) == Fw::FW_SERIALIZE_OK
     );
 
-    const U32 idBase = this->getIdBase();
-    FwOpcodeType _prmOpcode =  ActiveTestComponentBase::OPCODE_PARAMSTRUCTEXT_SET + idBase;
+    const FwIdType idBase = this->getIdBase();
+    FwOpcodeType _prmOpcode =  ActiveTestComponentBase::OPCODE_PARAMSTRUCTEXT_SET + static_cast<FwOpcodeType>(idBase);
 
     if (not this->m_to_cmdIn[0].isConnected()) {
       printf("Test Command Output port not connected!\n");
@@ -4798,8 +4798,8 @@ namespace M {
     )
   {
     Fw::CmdArgBuffer args;
-    const U32 idBase = this->getIdBase();
-    FwOpcodeType _prmOpcode = ActiveTestComponentBase::OPCODE_PARAMSTRUCTEXT_SAVE + idBase;
+    const FwIdType idBase = this->getIdBase();
+    FwOpcodeType _prmOpcode = ActiveTestComponentBase::OPCODE_PARAMSTRUCTEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
     if (not this->m_to_cmdIn[0].isConnected()) {
       printf("Test Command Output port not connected!\n");
@@ -5219,7 +5219,7 @@ namespace M {
     Fw::ParamValid _ret = Fw::ParamValid::VALID;
     val.resetSer();
 
-    const U32 idBase = _testerBase->getIdBase();
+    const FwIdType idBase = _testerBase->getIdBase();
     FW_ASSERT(
       id >= idBase,
       static_cast<FwAssertArgType>(id),
@@ -5366,7 +5366,7 @@ namespace M {
     ActiveTestTesterBase* _testerBase = static_cast<ActiveTestTesterBase*>(callComp);
     Fw::SerializeStatus _status;
 
-    const U32 idBase = _testerBase->getIdBase();
+    const FwIdType idBase = _testerBase->getIdBase();
     FW_ASSERT(
       id >= idBase,
       static_cast<FwAssertArgType>(id),

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.hpp
@@ -227,7 +227,7 @@ namespace M {
 
       //! A history entry for text log events
       struct TextLogEntry {
-        U32 id;
+        FwEventIdType id;
         Fw::Time timeTag;
         Fw::LogSeverity severity;
         Fw::TextLogString text;

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsTesterBase.ref.cpp
@@ -1892,8 +1892,8 @@ void PassiveCommandsTesterBase ::
       Fw::CmdArgBuffer& buf
   )
 {
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _opcode = opCode + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _opcode = opCode + static_cast<FwOpcodeType>(idBase);
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
       _opcode,
@@ -1916,8 +1916,8 @@ void PassiveCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveCommandsComponentBase::OPCODE_CMD_SYNC + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveCommandsComponentBase::OPCODE_CMD_SYNC + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -1964,8 +1964,8 @@ void PassiveCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveCommandsComponentBase::OPCODE_CMD_SYNC_PRIMITIVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveCommandsComponentBase::OPCODE_CMD_SYNC_PRIMITIVE + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2005,8 +2005,8 @@ void PassiveCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveCommandsComponentBase::OPCODE_CMD_SYNC_STRING + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveCommandsComponentBase::OPCODE_CMD_SYNC_STRING + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2039,8 +2039,8 @@ void PassiveCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveCommandsComponentBase::OPCODE_CMD_SYNC_ENUM + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveCommandsComponentBase::OPCODE_CMD_SYNC_ENUM + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2073,8 +2073,8 @@ void PassiveCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveCommandsComponentBase::OPCODE_CMD_SYNC_ARRAY + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveCommandsComponentBase::OPCODE_CMD_SYNC_ARRAY + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2107,8 +2107,8 @@ void PassiveCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveCommandsComponentBase::OPCODE_CMD_SYNC_STRUCT + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveCommandsComponentBase::OPCODE_CMD_SYNC_STRUCT + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2132,8 +2132,8 @@ void PassiveCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveCommandsComponentBase::OPCODE_CMD_GUARDED + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveCommandsComponentBase::OPCODE_CMD_GUARDED + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2180,8 +2180,8 @@ void PassiveCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveCommandsComponentBase::OPCODE_CMD_GUARDED_PRIMITIVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveCommandsComponentBase::OPCODE_CMD_GUARDED_PRIMITIVE + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2221,8 +2221,8 @@ void PassiveCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveCommandsComponentBase::OPCODE_CMD_GUARDED_STRING + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveCommandsComponentBase::OPCODE_CMD_GUARDED_STRING + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2255,8 +2255,8 @@ void PassiveCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveCommandsComponentBase::OPCODE_CMD_GUARDED_ENUM + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveCommandsComponentBase::OPCODE_CMD_GUARDED_ENUM + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2289,8 +2289,8 @@ void PassiveCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveCommandsComponentBase::OPCODE_CMD_GUARDED_ARRAY + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveCommandsComponentBase::OPCODE_CMD_GUARDED_ARRAY + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2323,8 +2323,8 @@ void PassiveCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveCommandsComponentBase::OPCODE_CMD_GUARDED_STRUCT + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveCommandsComponentBase::OPCODE_CMD_GUARDED_STRUCT + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsTesterBase.ref.cpp
@@ -1881,7 +1881,7 @@ void PassiveEventsTesterBase ::
 {
   args.resetDeser();
 
-  const U32 idBase = this->getIdBase();
+  const FwIdType idBase = this->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsTesterBase.ref.hpp
@@ -216,7 +216,7 @@ class PassiveEventsTesterBase :
 
     //! A history entry for text log events
     struct TextLogEntry {
-      U32 id;
+      FwEventIdType id;
       Fw::Time timeTag;
       Fw::LogSeverity severity;
       Fw::TextLogString text;

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveExternalParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveExternalParamsTesterBase.ref.cpp
@@ -2035,8 +2035,8 @@ void PassiveExternalParamsTesterBase ::
       Fw::CmdArgBuffer& buf
   )
 {
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _opcode = opCode + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _opcode = opCode + static_cast<FwOpcodeType>(idBase);
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
       _opcode,
@@ -2075,8 +2075,8 @@ void PassiveExternalParamsTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamI32Ext) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveExternalParamsComponentBase::OPCODE_PARAMI32EXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveExternalParamsComponentBase::OPCODE_PARAMI32EXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2097,8 +2097,8 @@ void PassiveExternalParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveExternalParamsComponentBase::OPCODE_PARAMI32EXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveExternalParamsComponentBase::OPCODE_PARAMI32EXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2134,8 +2134,8 @@ void PassiveExternalParamsTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamF64Ext) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveExternalParamsComponentBase::OPCODE_PARAMF64EXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveExternalParamsComponentBase::OPCODE_PARAMF64EXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2156,8 +2156,8 @@ void PassiveExternalParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveExternalParamsComponentBase::OPCODE_PARAMF64EXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveExternalParamsComponentBase::OPCODE_PARAMF64EXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2193,8 +2193,8 @@ void PassiveExternalParamsTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamStringExt) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveExternalParamsComponentBase::OPCODE_PARAMSTRINGEXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveExternalParamsComponentBase::OPCODE_PARAMSTRINGEXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2215,8 +2215,8 @@ void PassiveExternalParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveExternalParamsComponentBase::OPCODE_PARAMSTRINGEXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveExternalParamsComponentBase::OPCODE_PARAMSTRINGEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2252,8 +2252,8 @@ void PassiveExternalParamsTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamEnumExt) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveExternalParamsComponentBase::OPCODE_PARAMENUMEXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveExternalParamsComponentBase::OPCODE_PARAMENUMEXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2274,8 +2274,8 @@ void PassiveExternalParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveExternalParamsComponentBase::OPCODE_PARAMENUMEXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveExternalParamsComponentBase::OPCODE_PARAMENUMEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2311,8 +2311,8 @@ void PassiveExternalParamsTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamArrayExt) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveExternalParamsComponentBase::OPCODE_PARAMARRAYEXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveExternalParamsComponentBase::OPCODE_PARAMARRAYEXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2333,8 +2333,8 @@ void PassiveExternalParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveExternalParamsComponentBase::OPCODE_PARAMARRAYEXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveExternalParamsComponentBase::OPCODE_PARAMARRAYEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2370,8 +2370,8 @@ void PassiveExternalParamsTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamStructExt) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveExternalParamsComponentBase::OPCODE_PARAMSTRUCTEXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveExternalParamsComponentBase::OPCODE_PARAMSTRUCTEXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2392,8 +2392,8 @@ void PassiveExternalParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveExternalParamsComponentBase::OPCODE_PARAMSTRUCTEXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveExternalParamsComponentBase::OPCODE_PARAMSTRUCTEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2620,7 +2620,7 @@ Fw::ParamValid PassiveExternalParamsTesterBase ::
   Fw::ParamValid _ret = Fw::ParamValid::VALID;
   val.resetSer();
 
-  const U32 idBase = _testerBase->getIdBase();
+  const FwIdType idBase = _testerBase->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),
@@ -2707,7 +2707,7 @@ void PassiveExternalParamsTesterBase ::
   PassiveExternalParamsTesterBase* _testerBase = static_cast<PassiveExternalParamsTesterBase*>(callComp);
   Fw::SerializeStatus _status;
 
-  const U32 idBase = _testerBase->getIdBase();
+  const FwIdType idBase = _testerBase->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsTesterBase.ref.cpp
@@ -1946,8 +1946,8 @@ void PassiveParamsTesterBase ::
       Fw::CmdArgBuffer& buf
   )
 {
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _opcode = opCode + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _opcode = opCode + static_cast<FwOpcodeType>(idBase);
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
       _opcode,
@@ -1986,8 +1986,8 @@ void PassiveParamsTesterBase ::
     args.serialize(this->m_param_ParamU32) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveParamsComponentBase::OPCODE_PARAMU32_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveParamsComponentBase::OPCODE_PARAMU32_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2008,8 +2008,8 @@ void PassiveParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveParamsComponentBase::OPCODE_PARAMU32_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveParamsComponentBase::OPCODE_PARAMU32_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2045,8 +2045,8 @@ void PassiveParamsTesterBase ::
     args.serialize(this->m_param_ParamF64) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveParamsComponentBase::OPCODE_PARAMF64_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveParamsComponentBase::OPCODE_PARAMF64_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2067,8 +2067,8 @@ void PassiveParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveParamsComponentBase::OPCODE_PARAMF64_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveParamsComponentBase::OPCODE_PARAMF64_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2104,8 +2104,8 @@ void PassiveParamsTesterBase ::
     args.serialize(this->m_param_ParamString) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveParamsComponentBase::OPCODE_PARAMSTRING_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveParamsComponentBase::OPCODE_PARAMSTRING_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2126,8 +2126,8 @@ void PassiveParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveParamsComponentBase::OPCODE_PARAMSTRING_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveParamsComponentBase::OPCODE_PARAMSTRING_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2163,8 +2163,8 @@ void PassiveParamsTesterBase ::
     args.serialize(this->m_param_ParamEnum) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveParamsComponentBase::OPCODE_PARAMENUM_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveParamsComponentBase::OPCODE_PARAMENUM_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2185,8 +2185,8 @@ void PassiveParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveParamsComponentBase::OPCODE_PARAMENUM_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveParamsComponentBase::OPCODE_PARAMENUM_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2222,8 +2222,8 @@ void PassiveParamsTesterBase ::
     args.serialize(this->m_param_ParamArray) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveParamsComponentBase::OPCODE_PARAMARRAY_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveParamsComponentBase::OPCODE_PARAMARRAY_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2244,8 +2244,8 @@ void PassiveParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveParamsComponentBase::OPCODE_PARAMARRAY_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveParamsComponentBase::OPCODE_PARAMARRAY_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2281,8 +2281,8 @@ void PassiveParamsTesterBase ::
     args.serialize(this->m_param_ParamStruct) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveParamsComponentBase::OPCODE_PARAMSTRUCT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveParamsComponentBase::OPCODE_PARAMSTRUCT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2303,8 +2303,8 @@ void PassiveParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveParamsComponentBase::OPCODE_PARAMSTRUCT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveParamsComponentBase::OPCODE_PARAMSTRUCT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2531,7 +2531,7 @@ Fw::ParamValid PassiveParamsTesterBase ::
   Fw::ParamValid _ret = Fw::ParamValid::VALID;
   val.resetSer();
 
-  const U32 idBase = _testerBase->getIdBase();
+  const FwIdType idBase = _testerBase->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),
@@ -2618,7 +2618,7 @@ void PassiveParamsTesterBase ::
   PassiveParamsTesterBase* _testerBase = static_cast<PassiveParamsTesterBase*>(callComp);
   Fw::SerializeStatus _status;
 
-  const U32 idBase = _testerBase->getIdBase();
+  const FwIdType idBase = _testerBase->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.cpp
@@ -2365,8 +2365,8 @@ void PassiveSerialTesterBase ::
       Fw::CmdArgBuffer& buf
   )
 {
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _opcode = opCode + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _opcode = opCode + static_cast<FwOpcodeType>(idBase);
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
       _opcode,
@@ -2389,8 +2389,8 @@ void PassiveSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveSerialComponentBase::OPCODE_CMD_SYNC + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveSerialComponentBase::OPCODE_CMD_SYNC + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2437,8 +2437,8 @@ void PassiveSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveSerialComponentBase::OPCODE_CMD_SYNC_PRIMITIVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveSerialComponentBase::OPCODE_CMD_SYNC_PRIMITIVE + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2478,8 +2478,8 @@ void PassiveSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveSerialComponentBase::OPCODE_CMD_SYNC_STRING + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveSerialComponentBase::OPCODE_CMD_SYNC_STRING + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2512,8 +2512,8 @@ void PassiveSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveSerialComponentBase::OPCODE_CMD_SYNC_ENUM + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveSerialComponentBase::OPCODE_CMD_SYNC_ENUM + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2546,8 +2546,8 @@ void PassiveSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveSerialComponentBase::OPCODE_CMD_SYNC_ARRAY + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveSerialComponentBase::OPCODE_CMD_SYNC_ARRAY + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2580,8 +2580,8 @@ void PassiveSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveSerialComponentBase::OPCODE_CMD_SYNC_STRUCT + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveSerialComponentBase::OPCODE_CMD_SYNC_STRUCT + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2605,8 +2605,8 @@ void PassiveSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveSerialComponentBase::OPCODE_CMD_GUARDED + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveSerialComponentBase::OPCODE_CMD_GUARDED + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2653,8 +2653,8 @@ void PassiveSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveSerialComponentBase::OPCODE_CMD_GUARDED_PRIMITIVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveSerialComponentBase::OPCODE_CMD_GUARDED_PRIMITIVE + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2694,8 +2694,8 @@ void PassiveSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveSerialComponentBase::OPCODE_CMD_GUARDED_STRING + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveSerialComponentBase::OPCODE_CMD_GUARDED_STRING + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2728,8 +2728,8 @@ void PassiveSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveSerialComponentBase::OPCODE_CMD_GUARDED_ENUM + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveSerialComponentBase::OPCODE_CMD_GUARDED_ENUM + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2762,8 +2762,8 @@ void PassiveSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveSerialComponentBase::OPCODE_CMD_GUARDED_ARRAY + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveSerialComponentBase::OPCODE_CMD_GUARDED_ARRAY + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2796,8 +2796,8 @@ void PassiveSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveSerialComponentBase::OPCODE_CMD_GUARDED_STRUCT + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveSerialComponentBase::OPCODE_CMD_GUARDED_STRUCT + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2825,7 +2825,7 @@ void PassiveSerialTesterBase ::
 {
   args.resetDeser();
 
-  const U32 idBase = this->getIdBase();
+  const FwIdType idBase = this->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),
@@ -3290,7 +3290,7 @@ void PassiveSerialTesterBase ::
 {
   val.resetDeser();
 
-  const U32 idBase = this->getIdBase();
+  const FwIdType idBase = this->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),
@@ -3595,8 +3595,8 @@ void PassiveSerialTesterBase ::
     args.serialize(this->m_param_ParamU32) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveSerialComponentBase::OPCODE_PARAMU32_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveSerialComponentBase::OPCODE_PARAMU32_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -3617,8 +3617,8 @@ void PassiveSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveSerialComponentBase::OPCODE_PARAMU32_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveSerialComponentBase::OPCODE_PARAMU32_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -3654,8 +3654,8 @@ void PassiveSerialTesterBase ::
     args.serialize(this->m_param_ParamF64) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveSerialComponentBase::OPCODE_PARAMF64_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveSerialComponentBase::OPCODE_PARAMF64_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -3676,8 +3676,8 @@ void PassiveSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveSerialComponentBase::OPCODE_PARAMF64_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveSerialComponentBase::OPCODE_PARAMF64_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -3713,8 +3713,8 @@ void PassiveSerialTesterBase ::
     args.serialize(this->m_param_ParamString) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveSerialComponentBase::OPCODE_PARAMSTRING_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveSerialComponentBase::OPCODE_PARAMSTRING_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -3735,8 +3735,8 @@ void PassiveSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveSerialComponentBase::OPCODE_PARAMSTRING_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveSerialComponentBase::OPCODE_PARAMSTRING_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -3772,8 +3772,8 @@ void PassiveSerialTesterBase ::
     args.serialize(this->m_param_ParamEnum) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveSerialComponentBase::OPCODE_PARAMENUM_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveSerialComponentBase::OPCODE_PARAMENUM_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -3794,8 +3794,8 @@ void PassiveSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveSerialComponentBase::OPCODE_PARAMENUM_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveSerialComponentBase::OPCODE_PARAMENUM_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -3831,8 +3831,8 @@ void PassiveSerialTesterBase ::
     args.serialize(this->m_param_ParamArray) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveSerialComponentBase::OPCODE_PARAMARRAY_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveSerialComponentBase::OPCODE_PARAMARRAY_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -3853,8 +3853,8 @@ void PassiveSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveSerialComponentBase::OPCODE_PARAMARRAY_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveSerialComponentBase::OPCODE_PARAMARRAY_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -3890,8 +3890,8 @@ void PassiveSerialTesterBase ::
     args.serialize(this->m_param_ParamStruct) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveSerialComponentBase::OPCODE_PARAMSTRUCT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveSerialComponentBase::OPCODE_PARAMSTRUCT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -3912,8 +3912,8 @@ void PassiveSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveSerialComponentBase::OPCODE_PARAMSTRUCT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveSerialComponentBase::OPCODE_PARAMSTRUCT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -3949,8 +3949,8 @@ void PassiveSerialTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamI32Ext) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveSerialComponentBase::OPCODE_PARAMI32EXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveSerialComponentBase::OPCODE_PARAMI32EXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -3971,8 +3971,8 @@ void PassiveSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveSerialComponentBase::OPCODE_PARAMI32EXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveSerialComponentBase::OPCODE_PARAMI32EXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4008,8 +4008,8 @@ void PassiveSerialTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamF64Ext) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveSerialComponentBase::OPCODE_PARAMF64EXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveSerialComponentBase::OPCODE_PARAMF64EXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4030,8 +4030,8 @@ void PassiveSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveSerialComponentBase::OPCODE_PARAMF64EXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveSerialComponentBase::OPCODE_PARAMF64EXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4067,8 +4067,8 @@ void PassiveSerialTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamStringExt) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveSerialComponentBase::OPCODE_PARAMSTRINGEXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveSerialComponentBase::OPCODE_PARAMSTRINGEXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4089,8 +4089,8 @@ void PassiveSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveSerialComponentBase::OPCODE_PARAMSTRINGEXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveSerialComponentBase::OPCODE_PARAMSTRINGEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4126,8 +4126,8 @@ void PassiveSerialTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamEnumExt) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveSerialComponentBase::OPCODE_PARAMENUMEXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveSerialComponentBase::OPCODE_PARAMENUMEXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4148,8 +4148,8 @@ void PassiveSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveSerialComponentBase::OPCODE_PARAMENUMEXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveSerialComponentBase::OPCODE_PARAMENUMEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4185,8 +4185,8 @@ void PassiveSerialTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamArrayExt) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveSerialComponentBase::OPCODE_PARAMARRAYEXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveSerialComponentBase::OPCODE_PARAMARRAYEXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4207,8 +4207,8 @@ void PassiveSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveSerialComponentBase::OPCODE_PARAMARRAYEXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveSerialComponentBase::OPCODE_PARAMARRAYEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4244,8 +4244,8 @@ void PassiveSerialTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamStructExt) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveSerialComponentBase::OPCODE_PARAMSTRUCTEXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveSerialComponentBase::OPCODE_PARAMSTRUCTEXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4266,8 +4266,8 @@ void PassiveSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveSerialComponentBase::OPCODE_PARAMSTRUCTEXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveSerialComponentBase::OPCODE_PARAMSTRUCTEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4605,7 +4605,7 @@ Fw::ParamValid PassiveSerialTesterBase ::
   Fw::ParamValid _ret = Fw::ParamValid::VALID;
   val.resetSer();
 
-  const U32 idBase = _testerBase->getIdBase();
+  const FwIdType idBase = _testerBase->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),
@@ -4752,7 +4752,7 @@ void PassiveSerialTesterBase ::
   PassiveSerialTesterBase* _testerBase = static_cast<PassiveSerialTesterBase*>(callComp);
   Fw::SerializeStatus _status;
 
-  const U32 idBase = _testerBase->getIdBase();
+  const FwIdType idBase = _testerBase->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.hpp
@@ -224,7 +224,7 @@ class PassiveSerialTesterBase :
 
     //! A history entry for text log events
     struct TextLogEntry {
-      U32 id;
+      FwEventIdType id;
       Fw::Time timeTag;
       Fw::LogSeverity severity;
       Fw::TextLogString text;

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryTesterBase.ref.cpp
@@ -1860,7 +1860,7 @@ void PassiveTelemetryTesterBase ::
 {
   val.resetDeser();
 
-  const U32 idBase = this->getIdBase();
+  const FwIdType idBase = this->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.cpp
@@ -2301,8 +2301,8 @@ void PassiveTestTesterBase ::
       Fw::CmdArgBuffer& buf
   )
 {
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _opcode = opCode + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _opcode = opCode + static_cast<FwOpcodeType>(idBase);
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
       _opcode,
@@ -2325,8 +2325,8 @@ void PassiveTestTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveTestComponentBase::OPCODE_CMD_SYNC + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveTestComponentBase::OPCODE_CMD_SYNC + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2373,8 +2373,8 @@ void PassiveTestTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveTestComponentBase::OPCODE_CMD_SYNC_PRIMITIVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveTestComponentBase::OPCODE_CMD_SYNC_PRIMITIVE + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2414,8 +2414,8 @@ void PassiveTestTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveTestComponentBase::OPCODE_CMD_SYNC_STRING + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveTestComponentBase::OPCODE_CMD_SYNC_STRING + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2448,8 +2448,8 @@ void PassiveTestTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveTestComponentBase::OPCODE_CMD_SYNC_ENUM + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveTestComponentBase::OPCODE_CMD_SYNC_ENUM + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2482,8 +2482,8 @@ void PassiveTestTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveTestComponentBase::OPCODE_CMD_SYNC_ARRAY + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveTestComponentBase::OPCODE_CMD_SYNC_ARRAY + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2516,8 +2516,8 @@ void PassiveTestTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveTestComponentBase::OPCODE_CMD_SYNC_STRUCT + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveTestComponentBase::OPCODE_CMD_SYNC_STRUCT + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2541,8 +2541,8 @@ void PassiveTestTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveTestComponentBase::OPCODE_CMD_GUARDED + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveTestComponentBase::OPCODE_CMD_GUARDED + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2589,8 +2589,8 @@ void PassiveTestTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveTestComponentBase::OPCODE_CMD_GUARDED_PRIMITIVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveTestComponentBase::OPCODE_CMD_GUARDED_PRIMITIVE + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2630,8 +2630,8 @@ void PassiveTestTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveTestComponentBase::OPCODE_CMD_GUARDED_STRING + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveTestComponentBase::OPCODE_CMD_GUARDED_STRING + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2664,8 +2664,8 @@ void PassiveTestTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveTestComponentBase::OPCODE_CMD_GUARDED_ENUM + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveTestComponentBase::OPCODE_CMD_GUARDED_ENUM + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2698,8 +2698,8 @@ void PassiveTestTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveTestComponentBase::OPCODE_CMD_GUARDED_ARRAY + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveTestComponentBase::OPCODE_CMD_GUARDED_ARRAY + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2732,8 +2732,8 @@ void PassiveTestTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = PassiveTestComponentBase::OPCODE_CMD_GUARDED_STRUCT + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = PassiveTestComponentBase::OPCODE_CMD_GUARDED_STRUCT + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2761,7 +2761,7 @@ void PassiveTestTesterBase ::
 {
   args.resetDeser();
 
-  const U32 idBase = this->getIdBase();
+  const FwIdType idBase = this->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),
@@ -3226,7 +3226,7 @@ void PassiveTestTesterBase ::
 {
   val.resetDeser();
 
-  const U32 idBase = this->getIdBase();
+  const FwIdType idBase = this->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),
@@ -3531,8 +3531,8 @@ void PassiveTestTesterBase ::
     args.serialize(this->m_param_ParamU32) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveTestComponentBase::OPCODE_PARAMU32_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveTestComponentBase::OPCODE_PARAMU32_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -3553,8 +3553,8 @@ void PassiveTestTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveTestComponentBase::OPCODE_PARAMU32_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveTestComponentBase::OPCODE_PARAMU32_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -3590,8 +3590,8 @@ void PassiveTestTesterBase ::
     args.serialize(this->m_param_ParamF64) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveTestComponentBase::OPCODE_PARAMF64_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveTestComponentBase::OPCODE_PARAMF64_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -3612,8 +3612,8 @@ void PassiveTestTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveTestComponentBase::OPCODE_PARAMF64_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveTestComponentBase::OPCODE_PARAMF64_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -3649,8 +3649,8 @@ void PassiveTestTesterBase ::
     args.serialize(this->m_param_ParamString) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveTestComponentBase::OPCODE_PARAMSTRING_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveTestComponentBase::OPCODE_PARAMSTRING_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -3671,8 +3671,8 @@ void PassiveTestTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveTestComponentBase::OPCODE_PARAMSTRING_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveTestComponentBase::OPCODE_PARAMSTRING_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -3708,8 +3708,8 @@ void PassiveTestTesterBase ::
     args.serialize(this->m_param_ParamEnum) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveTestComponentBase::OPCODE_PARAMENUM_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveTestComponentBase::OPCODE_PARAMENUM_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -3730,8 +3730,8 @@ void PassiveTestTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveTestComponentBase::OPCODE_PARAMENUM_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveTestComponentBase::OPCODE_PARAMENUM_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -3767,8 +3767,8 @@ void PassiveTestTesterBase ::
     args.serialize(this->m_param_ParamArray) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveTestComponentBase::OPCODE_PARAMARRAY_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveTestComponentBase::OPCODE_PARAMARRAY_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -3789,8 +3789,8 @@ void PassiveTestTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveTestComponentBase::OPCODE_PARAMARRAY_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveTestComponentBase::OPCODE_PARAMARRAY_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -3826,8 +3826,8 @@ void PassiveTestTesterBase ::
     args.serialize(this->m_param_ParamStruct) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveTestComponentBase::OPCODE_PARAMSTRUCT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveTestComponentBase::OPCODE_PARAMSTRUCT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -3848,8 +3848,8 @@ void PassiveTestTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveTestComponentBase::OPCODE_PARAMSTRUCT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveTestComponentBase::OPCODE_PARAMSTRUCT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -3885,8 +3885,8 @@ void PassiveTestTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamI32Ext) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveTestComponentBase::OPCODE_PARAMI32EXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveTestComponentBase::OPCODE_PARAMI32EXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -3907,8 +3907,8 @@ void PassiveTestTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveTestComponentBase::OPCODE_PARAMI32EXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveTestComponentBase::OPCODE_PARAMI32EXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -3944,8 +3944,8 @@ void PassiveTestTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamF64Ext) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveTestComponentBase::OPCODE_PARAMF64EXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveTestComponentBase::OPCODE_PARAMF64EXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -3966,8 +3966,8 @@ void PassiveTestTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveTestComponentBase::OPCODE_PARAMF64EXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveTestComponentBase::OPCODE_PARAMF64EXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4003,8 +4003,8 @@ void PassiveTestTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamStringExt) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveTestComponentBase::OPCODE_PARAMSTRINGEXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveTestComponentBase::OPCODE_PARAMSTRINGEXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4025,8 +4025,8 @@ void PassiveTestTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveTestComponentBase::OPCODE_PARAMSTRINGEXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveTestComponentBase::OPCODE_PARAMSTRINGEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4062,8 +4062,8 @@ void PassiveTestTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamEnumExt) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveTestComponentBase::OPCODE_PARAMENUMEXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveTestComponentBase::OPCODE_PARAMENUMEXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4084,8 +4084,8 @@ void PassiveTestTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveTestComponentBase::OPCODE_PARAMENUMEXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveTestComponentBase::OPCODE_PARAMENUMEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4121,8 +4121,8 @@ void PassiveTestTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamArrayExt) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveTestComponentBase::OPCODE_PARAMARRAYEXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveTestComponentBase::OPCODE_PARAMARRAYEXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4143,8 +4143,8 @@ void PassiveTestTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveTestComponentBase::OPCODE_PARAMARRAYEXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveTestComponentBase::OPCODE_PARAMARRAYEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4180,8 +4180,8 @@ void PassiveTestTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamStructExt) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  PassiveTestComponentBase::OPCODE_PARAMSTRUCTEXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  PassiveTestComponentBase::OPCODE_PARAMSTRUCTEXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4202,8 +4202,8 @@ void PassiveTestTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = PassiveTestComponentBase::OPCODE_PARAMSTRUCTEXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = PassiveTestComponentBase::OPCODE_PARAMSTRUCTEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4597,7 +4597,7 @@ Fw::ParamValid PassiveTestTesterBase ::
   Fw::ParamValid _ret = Fw::ParamValid::VALID;
   val.resetSer();
 
-  const U32 idBase = _testerBase->getIdBase();
+  const FwIdType idBase = _testerBase->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),
@@ -4744,7 +4744,7 @@ void PassiveTestTesterBase ::
   PassiveTestTesterBase* _testerBase = static_cast<PassiveTestTesterBase*>(callComp);
   Fw::SerializeStatus _status;
 
-  const U32 idBase = _testerBase->getIdBase();
+  const FwIdType idBase = _testerBase->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.hpp
@@ -225,7 +225,7 @@ class PassiveTestTesterBase :
 
     //! A history entry for text log events
     struct TextLogEntry {
-      U32 id;
+      FwEventIdType id;
       Fw::Time timeTag;
       Fw::LogSeverity severity;
       Fw::TextLogString text;

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsTesterBase.ref.cpp
@@ -2343,8 +2343,8 @@ void QueuedCommandsTesterBase ::
       Fw::CmdArgBuffer& buf
   )
 {
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _opcode = opCode + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _opcode = opCode + static_cast<FwOpcodeType>(idBase);
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
       _opcode,
@@ -2367,8 +2367,8 @@ void QueuedCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedCommandsComponentBase::OPCODE_CMD_SYNC + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedCommandsComponentBase::OPCODE_CMD_SYNC + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2415,8 +2415,8 @@ void QueuedCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedCommandsComponentBase::OPCODE_CMD_SYNC_PRIMITIVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedCommandsComponentBase::OPCODE_CMD_SYNC_PRIMITIVE + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2456,8 +2456,8 @@ void QueuedCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedCommandsComponentBase::OPCODE_CMD_SYNC_STRING + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedCommandsComponentBase::OPCODE_CMD_SYNC_STRING + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2490,8 +2490,8 @@ void QueuedCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedCommandsComponentBase::OPCODE_CMD_SYNC_ENUM + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedCommandsComponentBase::OPCODE_CMD_SYNC_ENUM + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2524,8 +2524,8 @@ void QueuedCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedCommandsComponentBase::OPCODE_CMD_SYNC_ARRAY + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedCommandsComponentBase::OPCODE_CMD_SYNC_ARRAY + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2558,8 +2558,8 @@ void QueuedCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedCommandsComponentBase::OPCODE_CMD_SYNC_STRUCT + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedCommandsComponentBase::OPCODE_CMD_SYNC_STRUCT + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2583,8 +2583,8 @@ void QueuedCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedCommandsComponentBase::OPCODE_CMD_GUARDED + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedCommandsComponentBase::OPCODE_CMD_GUARDED + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2631,8 +2631,8 @@ void QueuedCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedCommandsComponentBase::OPCODE_CMD_GUARDED_PRIMITIVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedCommandsComponentBase::OPCODE_CMD_GUARDED_PRIMITIVE + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2672,8 +2672,8 @@ void QueuedCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedCommandsComponentBase::OPCODE_CMD_GUARDED_STRING + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedCommandsComponentBase::OPCODE_CMD_GUARDED_STRING + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2706,8 +2706,8 @@ void QueuedCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedCommandsComponentBase::OPCODE_CMD_GUARDED_ENUM + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedCommandsComponentBase::OPCODE_CMD_GUARDED_ENUM + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2740,8 +2740,8 @@ void QueuedCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedCommandsComponentBase::OPCODE_CMD_GUARDED_ARRAY + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedCommandsComponentBase::OPCODE_CMD_GUARDED_ARRAY + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2774,8 +2774,8 @@ void QueuedCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedCommandsComponentBase::OPCODE_CMD_GUARDED_STRUCT + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedCommandsComponentBase::OPCODE_CMD_GUARDED_STRUCT + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2799,8 +2799,8 @@ void QueuedCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedCommandsComponentBase::OPCODE_CMD_ASYNC + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedCommandsComponentBase::OPCODE_CMD_ASYNC + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2824,8 +2824,8 @@ void QueuedCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedCommandsComponentBase::OPCODE_CMD_PRIORITY + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedCommandsComponentBase::OPCODE_CMD_PRIORITY + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2858,8 +2858,8 @@ void QueuedCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedCommandsComponentBase::OPCODE_CMD_PARAMS_PRIORITY + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedCommandsComponentBase::OPCODE_CMD_PARAMS_PRIORITY + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2883,8 +2883,8 @@ void QueuedCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedCommandsComponentBase::OPCODE_CMD_DROP + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedCommandsComponentBase::OPCODE_CMD_DROP + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2917,8 +2917,8 @@ void QueuedCommandsTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedCommandsComponentBase::OPCODE_CMD_PARAMS_PRIORITY_DROP + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedCommandsComponentBase::OPCODE_CMD_PARAMS_PRIORITY_DROP + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsTesterBase.ref.cpp
@@ -2332,7 +2332,7 @@ void QueuedEventsTesterBase ::
 {
   args.resetDeser();
 
-  const U32 idBase = this->getIdBase();
+  const FwIdType idBase = this->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsTesterBase.ref.hpp
@@ -216,7 +216,7 @@ class QueuedEventsTesterBase :
 
     //! A history entry for text log events
     struct TextLogEntry {
-      U32 id;
+      FwEventIdType id;
       Fw::Time timeTag;
       Fw::LogSeverity severity;
       Fw::TextLogString text;

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedExternalParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedExternalParamsTesterBase.ref.cpp
@@ -2486,8 +2486,8 @@ void QueuedExternalParamsTesterBase ::
       Fw::CmdArgBuffer& buf
   )
 {
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _opcode = opCode + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _opcode = opCode + static_cast<FwOpcodeType>(idBase);
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
       _opcode,
@@ -2526,8 +2526,8 @@ void QueuedExternalParamsTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamI32Ext) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedExternalParamsComponentBase::OPCODE_PARAMI32EXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedExternalParamsComponentBase::OPCODE_PARAMI32EXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2548,8 +2548,8 @@ void QueuedExternalParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedExternalParamsComponentBase::OPCODE_PARAMI32EXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedExternalParamsComponentBase::OPCODE_PARAMI32EXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2585,8 +2585,8 @@ void QueuedExternalParamsTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamF64Ext) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedExternalParamsComponentBase::OPCODE_PARAMF64EXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedExternalParamsComponentBase::OPCODE_PARAMF64EXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2607,8 +2607,8 @@ void QueuedExternalParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedExternalParamsComponentBase::OPCODE_PARAMF64EXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedExternalParamsComponentBase::OPCODE_PARAMF64EXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2644,8 +2644,8 @@ void QueuedExternalParamsTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamStringExt) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedExternalParamsComponentBase::OPCODE_PARAMSTRINGEXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedExternalParamsComponentBase::OPCODE_PARAMSTRINGEXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2666,8 +2666,8 @@ void QueuedExternalParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedExternalParamsComponentBase::OPCODE_PARAMSTRINGEXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedExternalParamsComponentBase::OPCODE_PARAMSTRINGEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2703,8 +2703,8 @@ void QueuedExternalParamsTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamEnumExt) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedExternalParamsComponentBase::OPCODE_PARAMENUMEXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedExternalParamsComponentBase::OPCODE_PARAMENUMEXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2725,8 +2725,8 @@ void QueuedExternalParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedExternalParamsComponentBase::OPCODE_PARAMENUMEXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedExternalParamsComponentBase::OPCODE_PARAMENUMEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2762,8 +2762,8 @@ void QueuedExternalParamsTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamArrayExt) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedExternalParamsComponentBase::OPCODE_PARAMARRAYEXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedExternalParamsComponentBase::OPCODE_PARAMARRAYEXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2784,8 +2784,8 @@ void QueuedExternalParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedExternalParamsComponentBase::OPCODE_PARAMARRAYEXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedExternalParamsComponentBase::OPCODE_PARAMARRAYEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2821,8 +2821,8 @@ void QueuedExternalParamsTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamStructExt) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedExternalParamsComponentBase::OPCODE_PARAMSTRUCTEXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedExternalParamsComponentBase::OPCODE_PARAMSTRUCTEXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2843,8 +2843,8 @@ void QueuedExternalParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedExternalParamsComponentBase::OPCODE_PARAMSTRUCTEXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedExternalParamsComponentBase::OPCODE_PARAMSTRUCTEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -3071,7 +3071,7 @@ Fw::ParamValid QueuedExternalParamsTesterBase ::
   Fw::ParamValid _ret = Fw::ParamValid::VALID;
   val.resetSer();
 
-  const U32 idBase = _testerBase->getIdBase();
+  const FwIdType idBase = _testerBase->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),
@@ -3158,7 +3158,7 @@ void QueuedExternalParamsTesterBase ::
   QueuedExternalParamsTesterBase* _testerBase = static_cast<QueuedExternalParamsTesterBase*>(callComp);
   Fw::SerializeStatus _status;
 
-  const U32 idBase = _testerBase->getIdBase();
+  const FwIdType idBase = _testerBase->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsTesterBase.ref.cpp
@@ -2397,8 +2397,8 @@ void QueuedParamsTesterBase ::
       Fw::CmdArgBuffer& buf
   )
 {
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _opcode = opCode + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _opcode = opCode + static_cast<FwOpcodeType>(idBase);
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
       _opcode,
@@ -2437,8 +2437,8 @@ void QueuedParamsTesterBase ::
     args.serialize(this->m_param_ParamU32) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedParamsComponentBase::OPCODE_PARAMU32_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedParamsComponentBase::OPCODE_PARAMU32_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2459,8 +2459,8 @@ void QueuedParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedParamsComponentBase::OPCODE_PARAMU32_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedParamsComponentBase::OPCODE_PARAMU32_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2496,8 +2496,8 @@ void QueuedParamsTesterBase ::
     args.serialize(this->m_param_ParamF64) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedParamsComponentBase::OPCODE_PARAMF64_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedParamsComponentBase::OPCODE_PARAMF64_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2518,8 +2518,8 @@ void QueuedParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedParamsComponentBase::OPCODE_PARAMF64_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedParamsComponentBase::OPCODE_PARAMF64_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2555,8 +2555,8 @@ void QueuedParamsTesterBase ::
     args.serialize(this->m_param_ParamString) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedParamsComponentBase::OPCODE_PARAMSTRING_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedParamsComponentBase::OPCODE_PARAMSTRING_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2577,8 +2577,8 @@ void QueuedParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedParamsComponentBase::OPCODE_PARAMSTRING_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedParamsComponentBase::OPCODE_PARAMSTRING_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2614,8 +2614,8 @@ void QueuedParamsTesterBase ::
     args.serialize(this->m_param_ParamEnum) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedParamsComponentBase::OPCODE_PARAMENUM_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedParamsComponentBase::OPCODE_PARAMENUM_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2636,8 +2636,8 @@ void QueuedParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedParamsComponentBase::OPCODE_PARAMENUM_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedParamsComponentBase::OPCODE_PARAMENUM_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2673,8 +2673,8 @@ void QueuedParamsTesterBase ::
     args.serialize(this->m_param_ParamArray) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedParamsComponentBase::OPCODE_PARAMARRAY_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedParamsComponentBase::OPCODE_PARAMARRAY_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2695,8 +2695,8 @@ void QueuedParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedParamsComponentBase::OPCODE_PARAMARRAY_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedParamsComponentBase::OPCODE_PARAMARRAY_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2732,8 +2732,8 @@ void QueuedParamsTesterBase ::
     args.serialize(this->m_param_ParamStruct) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedParamsComponentBase::OPCODE_PARAMSTRUCT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedParamsComponentBase::OPCODE_PARAMSTRUCT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2754,8 +2754,8 @@ void QueuedParamsTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedParamsComponentBase::OPCODE_PARAMSTRUCT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedParamsComponentBase::OPCODE_PARAMSTRUCT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -2982,7 +2982,7 @@ Fw::ParamValid QueuedParamsTesterBase ::
   Fw::ParamValid _ret = Fw::ParamValid::VALID;
   val.resetSer();
 
-  const U32 idBase = _testerBase->getIdBase();
+  const FwIdType idBase = _testerBase->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),
@@ -3069,7 +3069,7 @@ void QueuedParamsTesterBase ::
   QueuedParamsTesterBase* _testerBase = static_cast<QueuedParamsTesterBase*>(callComp);
   Fw::SerializeStatus _status;
 
-  const U32 idBase = _testerBase->getIdBase();
+  const FwIdType idBase = _testerBase->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.cpp
@@ -3080,8 +3080,8 @@ void QueuedSerialTesterBase ::
       Fw::CmdArgBuffer& buf
   )
 {
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _opcode = opCode + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _opcode = opCode + static_cast<FwOpcodeType>(idBase);
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
       _opcode,
@@ -3104,8 +3104,8 @@ void QueuedSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedSerialComponentBase::OPCODE_CMD_SYNC + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedSerialComponentBase::OPCODE_CMD_SYNC + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3152,8 +3152,8 @@ void QueuedSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedSerialComponentBase::OPCODE_CMD_SYNC_PRIMITIVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedSerialComponentBase::OPCODE_CMD_SYNC_PRIMITIVE + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3193,8 +3193,8 @@ void QueuedSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedSerialComponentBase::OPCODE_CMD_SYNC_STRING + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedSerialComponentBase::OPCODE_CMD_SYNC_STRING + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3227,8 +3227,8 @@ void QueuedSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedSerialComponentBase::OPCODE_CMD_SYNC_ENUM + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedSerialComponentBase::OPCODE_CMD_SYNC_ENUM + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3261,8 +3261,8 @@ void QueuedSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedSerialComponentBase::OPCODE_CMD_SYNC_ARRAY + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedSerialComponentBase::OPCODE_CMD_SYNC_ARRAY + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3295,8 +3295,8 @@ void QueuedSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedSerialComponentBase::OPCODE_CMD_SYNC_STRUCT + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedSerialComponentBase::OPCODE_CMD_SYNC_STRUCT + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3320,8 +3320,8 @@ void QueuedSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedSerialComponentBase::OPCODE_CMD_GUARDED + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedSerialComponentBase::OPCODE_CMD_GUARDED + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3368,8 +3368,8 @@ void QueuedSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedSerialComponentBase::OPCODE_CMD_GUARDED_PRIMITIVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedSerialComponentBase::OPCODE_CMD_GUARDED_PRIMITIVE + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3409,8 +3409,8 @@ void QueuedSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedSerialComponentBase::OPCODE_CMD_GUARDED_STRING + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedSerialComponentBase::OPCODE_CMD_GUARDED_STRING + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3443,8 +3443,8 @@ void QueuedSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedSerialComponentBase::OPCODE_CMD_GUARDED_ENUM + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedSerialComponentBase::OPCODE_CMD_GUARDED_ENUM + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3477,8 +3477,8 @@ void QueuedSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedSerialComponentBase::OPCODE_CMD_GUARDED_ARRAY + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedSerialComponentBase::OPCODE_CMD_GUARDED_ARRAY + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3511,8 +3511,8 @@ void QueuedSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedSerialComponentBase::OPCODE_CMD_GUARDED_STRUCT + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedSerialComponentBase::OPCODE_CMD_GUARDED_STRUCT + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3536,8 +3536,8 @@ void QueuedSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedSerialComponentBase::OPCODE_CMD_ASYNC + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedSerialComponentBase::OPCODE_CMD_ASYNC + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3561,8 +3561,8 @@ void QueuedSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedSerialComponentBase::OPCODE_CMD_PRIORITY + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedSerialComponentBase::OPCODE_CMD_PRIORITY + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3595,8 +3595,8 @@ void QueuedSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedSerialComponentBase::OPCODE_CMD_PARAMS_PRIORITY + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedSerialComponentBase::OPCODE_CMD_PARAMS_PRIORITY + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3620,8 +3620,8 @@ void QueuedSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedSerialComponentBase::OPCODE_CMD_DROP + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedSerialComponentBase::OPCODE_CMD_DROP + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3654,8 +3654,8 @@ void QueuedSerialTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedSerialComponentBase::OPCODE_CMD_PARAMS_PRIORITY_DROP + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedSerialComponentBase::OPCODE_CMD_PARAMS_PRIORITY_DROP + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3683,7 +3683,7 @@ void QueuedSerialTesterBase ::
 {
   args.resetDeser();
 
-  const U32 idBase = this->getIdBase();
+  const FwIdType idBase = this->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),
@@ -4148,7 +4148,7 @@ void QueuedSerialTesterBase ::
 {
   val.resetDeser();
 
-  const U32 idBase = this->getIdBase();
+  const FwIdType idBase = this->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),
@@ -4453,8 +4453,8 @@ void QueuedSerialTesterBase ::
     args.serialize(this->m_param_ParamU32) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedSerialComponentBase::OPCODE_PARAMU32_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedSerialComponentBase::OPCODE_PARAMU32_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4475,8 +4475,8 @@ void QueuedSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedSerialComponentBase::OPCODE_PARAMU32_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedSerialComponentBase::OPCODE_PARAMU32_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4512,8 +4512,8 @@ void QueuedSerialTesterBase ::
     args.serialize(this->m_param_ParamF64) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedSerialComponentBase::OPCODE_PARAMF64_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedSerialComponentBase::OPCODE_PARAMF64_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4534,8 +4534,8 @@ void QueuedSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedSerialComponentBase::OPCODE_PARAMF64_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedSerialComponentBase::OPCODE_PARAMF64_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4571,8 +4571,8 @@ void QueuedSerialTesterBase ::
     args.serialize(this->m_param_ParamString) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedSerialComponentBase::OPCODE_PARAMSTRING_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedSerialComponentBase::OPCODE_PARAMSTRING_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4593,8 +4593,8 @@ void QueuedSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedSerialComponentBase::OPCODE_PARAMSTRING_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedSerialComponentBase::OPCODE_PARAMSTRING_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4630,8 +4630,8 @@ void QueuedSerialTesterBase ::
     args.serialize(this->m_param_ParamEnum) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedSerialComponentBase::OPCODE_PARAMENUM_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedSerialComponentBase::OPCODE_PARAMENUM_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4652,8 +4652,8 @@ void QueuedSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedSerialComponentBase::OPCODE_PARAMENUM_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedSerialComponentBase::OPCODE_PARAMENUM_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4689,8 +4689,8 @@ void QueuedSerialTesterBase ::
     args.serialize(this->m_param_ParamArray) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedSerialComponentBase::OPCODE_PARAMARRAY_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedSerialComponentBase::OPCODE_PARAMARRAY_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4711,8 +4711,8 @@ void QueuedSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedSerialComponentBase::OPCODE_PARAMARRAY_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedSerialComponentBase::OPCODE_PARAMARRAY_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4748,8 +4748,8 @@ void QueuedSerialTesterBase ::
     args.serialize(this->m_param_ParamStruct) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedSerialComponentBase::OPCODE_PARAMSTRUCT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedSerialComponentBase::OPCODE_PARAMSTRUCT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4770,8 +4770,8 @@ void QueuedSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedSerialComponentBase::OPCODE_PARAMSTRUCT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedSerialComponentBase::OPCODE_PARAMSTRUCT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4807,8 +4807,8 @@ void QueuedSerialTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamI32Ext) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedSerialComponentBase::OPCODE_PARAMI32EXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedSerialComponentBase::OPCODE_PARAMI32EXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4829,8 +4829,8 @@ void QueuedSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedSerialComponentBase::OPCODE_PARAMI32EXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedSerialComponentBase::OPCODE_PARAMI32EXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4866,8 +4866,8 @@ void QueuedSerialTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamF64Ext) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedSerialComponentBase::OPCODE_PARAMF64EXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedSerialComponentBase::OPCODE_PARAMF64EXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4888,8 +4888,8 @@ void QueuedSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedSerialComponentBase::OPCODE_PARAMF64EXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedSerialComponentBase::OPCODE_PARAMF64EXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4925,8 +4925,8 @@ void QueuedSerialTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamStringExt) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedSerialComponentBase::OPCODE_PARAMSTRINGEXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedSerialComponentBase::OPCODE_PARAMSTRINGEXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4947,8 +4947,8 @@ void QueuedSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedSerialComponentBase::OPCODE_PARAMSTRINGEXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedSerialComponentBase::OPCODE_PARAMSTRINGEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4984,8 +4984,8 @@ void QueuedSerialTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamEnumExt) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedSerialComponentBase::OPCODE_PARAMENUMEXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedSerialComponentBase::OPCODE_PARAMENUMEXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -5006,8 +5006,8 @@ void QueuedSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedSerialComponentBase::OPCODE_PARAMENUMEXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedSerialComponentBase::OPCODE_PARAMENUMEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -5043,8 +5043,8 @@ void QueuedSerialTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamArrayExt) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedSerialComponentBase::OPCODE_PARAMARRAYEXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedSerialComponentBase::OPCODE_PARAMARRAYEXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -5065,8 +5065,8 @@ void QueuedSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedSerialComponentBase::OPCODE_PARAMARRAYEXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedSerialComponentBase::OPCODE_PARAMARRAYEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -5102,8 +5102,8 @@ void QueuedSerialTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamStructExt) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedSerialComponentBase::OPCODE_PARAMSTRUCTEXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedSerialComponentBase::OPCODE_PARAMSTRUCTEXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -5124,8 +5124,8 @@ void QueuedSerialTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedSerialComponentBase::OPCODE_PARAMSTRUCTEXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedSerialComponentBase::OPCODE_PARAMSTRUCTEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -5463,7 +5463,7 @@ Fw::ParamValid QueuedSerialTesterBase ::
   Fw::ParamValid _ret = Fw::ParamValid::VALID;
   val.resetSer();
 
-  const U32 idBase = _testerBase->getIdBase();
+  const FwIdType idBase = _testerBase->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),
@@ -5610,7 +5610,7 @@ void QueuedSerialTesterBase ::
   QueuedSerialTesterBase* _testerBase = static_cast<QueuedSerialTesterBase*>(callComp);
   Fw::SerializeStatus _status;
 
-  const U32 idBase = _testerBase->getIdBase();
+  const FwIdType idBase = _testerBase->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.hpp
@@ -224,7 +224,7 @@ class QueuedSerialTesterBase :
 
     //! A history entry for text log events
     struct TextLogEntry {
-      U32 id;
+      FwEventIdType id;
       Fw::Time timeTag;
       Fw::LogSeverity severity;
       Fw::TextLogString text;

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryTesterBase.ref.cpp
@@ -2311,7 +2311,7 @@ void QueuedTelemetryTesterBase ::
 {
   val.resetDeser();
 
-  const U32 idBase = this->getIdBase();
+  const FwIdType idBase = this->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.cpp
@@ -2752,8 +2752,8 @@ void QueuedTestTesterBase ::
       Fw::CmdArgBuffer& buf
   )
 {
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _opcode = opCode + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _opcode = opCode + static_cast<FwOpcodeType>(idBase);
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
       _opcode,
@@ -2776,8 +2776,8 @@ void QueuedTestTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedTestComponentBase::OPCODE_CMD_SYNC + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedTestComponentBase::OPCODE_CMD_SYNC + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2824,8 +2824,8 @@ void QueuedTestTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedTestComponentBase::OPCODE_CMD_SYNC_PRIMITIVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedTestComponentBase::OPCODE_CMD_SYNC_PRIMITIVE + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2865,8 +2865,8 @@ void QueuedTestTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedTestComponentBase::OPCODE_CMD_SYNC_STRING + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedTestComponentBase::OPCODE_CMD_SYNC_STRING + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2899,8 +2899,8 @@ void QueuedTestTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedTestComponentBase::OPCODE_CMD_SYNC_ENUM + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedTestComponentBase::OPCODE_CMD_SYNC_ENUM + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2933,8 +2933,8 @@ void QueuedTestTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedTestComponentBase::OPCODE_CMD_SYNC_ARRAY + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedTestComponentBase::OPCODE_CMD_SYNC_ARRAY + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2967,8 +2967,8 @@ void QueuedTestTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedTestComponentBase::OPCODE_CMD_SYNC_STRUCT + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedTestComponentBase::OPCODE_CMD_SYNC_STRUCT + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -2992,8 +2992,8 @@ void QueuedTestTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedTestComponentBase::OPCODE_CMD_GUARDED + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedTestComponentBase::OPCODE_CMD_GUARDED + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3040,8 +3040,8 @@ void QueuedTestTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedTestComponentBase::OPCODE_CMD_GUARDED_PRIMITIVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedTestComponentBase::OPCODE_CMD_GUARDED_PRIMITIVE + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3081,8 +3081,8 @@ void QueuedTestTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedTestComponentBase::OPCODE_CMD_GUARDED_STRING + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedTestComponentBase::OPCODE_CMD_GUARDED_STRING + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3115,8 +3115,8 @@ void QueuedTestTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedTestComponentBase::OPCODE_CMD_GUARDED_ENUM + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedTestComponentBase::OPCODE_CMD_GUARDED_ENUM + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3149,8 +3149,8 @@ void QueuedTestTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedTestComponentBase::OPCODE_CMD_GUARDED_ARRAY + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedTestComponentBase::OPCODE_CMD_GUARDED_ARRAY + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3183,8 +3183,8 @@ void QueuedTestTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedTestComponentBase::OPCODE_CMD_GUARDED_STRUCT + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedTestComponentBase::OPCODE_CMD_GUARDED_STRUCT + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3208,8 +3208,8 @@ void QueuedTestTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedTestComponentBase::OPCODE_CMD_ASYNC + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedTestComponentBase::OPCODE_CMD_ASYNC + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3233,8 +3233,8 @@ void QueuedTestTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedTestComponentBase::OPCODE_CMD_PRIORITY + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedTestComponentBase::OPCODE_CMD_PRIORITY + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3267,8 +3267,8 @@ void QueuedTestTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedTestComponentBase::OPCODE_CMD_PARAMS_PRIORITY + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedTestComponentBase::OPCODE_CMD_PARAMS_PRIORITY + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3292,8 +3292,8 @@ void QueuedTestTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedTestComponentBase::OPCODE_CMD_DROP + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedTestComponentBase::OPCODE_CMD_DROP + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3326,8 +3326,8 @@ void QueuedTestTesterBase ::
 
   // Call output command port
   FwOpcodeType _opcode;
-  const U32 idBase = this->getIdBase();
-  _opcode = QueuedTestComponentBase::OPCODE_CMD_PARAMS_PRIORITY_DROP + idBase;
+  const FwIdType idBase = this->getIdBase();
+  _opcode = QueuedTestComponentBase::OPCODE_CMD_PARAMS_PRIORITY_DROP + static_cast<FwOpcodeType>(idBase);
 
   if (this->m_to_cmdIn[0].isConnected()) {
     this->m_to_cmdIn[0].invoke(
@@ -3355,7 +3355,7 @@ void QueuedTestTesterBase ::
 {
   args.resetDeser();
 
-  const U32 idBase = this->getIdBase();
+  const FwIdType idBase = this->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),
@@ -3820,7 +3820,7 @@ void QueuedTestTesterBase ::
 {
   val.resetDeser();
 
-  const U32 idBase = this->getIdBase();
+  const FwIdType idBase = this->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),
@@ -4125,8 +4125,8 @@ void QueuedTestTesterBase ::
     args.serialize(this->m_param_ParamU32) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedTestComponentBase::OPCODE_PARAMU32_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedTestComponentBase::OPCODE_PARAMU32_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4147,8 +4147,8 @@ void QueuedTestTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedTestComponentBase::OPCODE_PARAMU32_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedTestComponentBase::OPCODE_PARAMU32_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4184,8 +4184,8 @@ void QueuedTestTesterBase ::
     args.serialize(this->m_param_ParamF64) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedTestComponentBase::OPCODE_PARAMF64_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedTestComponentBase::OPCODE_PARAMF64_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4206,8 +4206,8 @@ void QueuedTestTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedTestComponentBase::OPCODE_PARAMF64_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedTestComponentBase::OPCODE_PARAMF64_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4243,8 +4243,8 @@ void QueuedTestTesterBase ::
     args.serialize(this->m_param_ParamString) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedTestComponentBase::OPCODE_PARAMSTRING_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedTestComponentBase::OPCODE_PARAMSTRING_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4265,8 +4265,8 @@ void QueuedTestTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedTestComponentBase::OPCODE_PARAMSTRING_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedTestComponentBase::OPCODE_PARAMSTRING_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4302,8 +4302,8 @@ void QueuedTestTesterBase ::
     args.serialize(this->m_param_ParamEnum) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedTestComponentBase::OPCODE_PARAMENUM_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedTestComponentBase::OPCODE_PARAMENUM_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4324,8 +4324,8 @@ void QueuedTestTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedTestComponentBase::OPCODE_PARAMENUM_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedTestComponentBase::OPCODE_PARAMENUM_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4361,8 +4361,8 @@ void QueuedTestTesterBase ::
     args.serialize(this->m_param_ParamArray) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedTestComponentBase::OPCODE_PARAMARRAY_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedTestComponentBase::OPCODE_PARAMARRAY_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4383,8 +4383,8 @@ void QueuedTestTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedTestComponentBase::OPCODE_PARAMARRAY_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedTestComponentBase::OPCODE_PARAMARRAY_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4420,8 +4420,8 @@ void QueuedTestTesterBase ::
     args.serialize(this->m_param_ParamStruct) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedTestComponentBase::OPCODE_PARAMSTRUCT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedTestComponentBase::OPCODE_PARAMSTRUCT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4442,8 +4442,8 @@ void QueuedTestTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedTestComponentBase::OPCODE_PARAMSTRUCT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedTestComponentBase::OPCODE_PARAMSTRUCT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4479,8 +4479,8 @@ void QueuedTestTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamI32Ext) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedTestComponentBase::OPCODE_PARAMI32EXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedTestComponentBase::OPCODE_PARAMI32EXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4501,8 +4501,8 @@ void QueuedTestTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedTestComponentBase::OPCODE_PARAMI32EXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedTestComponentBase::OPCODE_PARAMI32EXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4538,8 +4538,8 @@ void QueuedTestTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamF64Ext) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedTestComponentBase::OPCODE_PARAMF64EXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedTestComponentBase::OPCODE_PARAMF64EXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4560,8 +4560,8 @@ void QueuedTestTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedTestComponentBase::OPCODE_PARAMF64EXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedTestComponentBase::OPCODE_PARAMF64EXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4597,8 +4597,8 @@ void QueuedTestTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamStringExt) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedTestComponentBase::OPCODE_PARAMSTRINGEXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedTestComponentBase::OPCODE_PARAMSTRINGEXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4619,8 +4619,8 @@ void QueuedTestTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedTestComponentBase::OPCODE_PARAMSTRINGEXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedTestComponentBase::OPCODE_PARAMSTRINGEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4656,8 +4656,8 @@ void QueuedTestTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamEnumExt) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedTestComponentBase::OPCODE_PARAMENUMEXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedTestComponentBase::OPCODE_PARAMENUMEXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4678,8 +4678,8 @@ void QueuedTestTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedTestComponentBase::OPCODE_PARAMENUMEXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedTestComponentBase::OPCODE_PARAMENUMEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4715,8 +4715,8 @@ void QueuedTestTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamArrayExt) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedTestComponentBase::OPCODE_PARAMARRAYEXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedTestComponentBase::OPCODE_PARAMARRAYEXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4737,8 +4737,8 @@ void QueuedTestTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedTestComponentBase::OPCODE_PARAMARRAYEXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedTestComponentBase::OPCODE_PARAMARRAYEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4774,8 +4774,8 @@ void QueuedTestTesterBase ::
     args.serialize(this->paramTesterDelegate.m_param_ParamStructExt) == Fw::FW_SERIALIZE_OK
   );
 
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode =  QueuedTestComponentBase::OPCODE_PARAMSTRUCTEXT_SET + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode =  QueuedTestComponentBase::OPCODE_PARAMSTRUCTEXT_SET + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -4796,8 +4796,8 @@ void QueuedTestTesterBase ::
   )
 {
   Fw::CmdArgBuffer args;
-  const U32 idBase = this->getIdBase();
-  FwOpcodeType _prmOpcode = QueuedTestComponentBase::OPCODE_PARAMSTRUCTEXT_SAVE + idBase;
+  const FwIdType idBase = this->getIdBase();
+  FwOpcodeType _prmOpcode = QueuedTestComponentBase::OPCODE_PARAMSTRUCTEXT_SAVE + static_cast<FwOpcodeType>(idBase);
 
   if (not this->m_to_cmdIn[0].isConnected()) {
     printf("Test Command Output port not connected!\n");
@@ -5191,7 +5191,7 @@ Fw::ParamValid QueuedTestTesterBase ::
   Fw::ParamValid _ret = Fw::ParamValid::VALID;
   val.resetSer();
 
-  const U32 idBase = _testerBase->getIdBase();
+  const FwIdType idBase = _testerBase->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),
@@ -5338,7 +5338,7 @@ void QueuedTestTesterBase ::
   QueuedTestTesterBase* _testerBase = static_cast<QueuedTestTesterBase*>(callComp);
   Fw::SerializeStatus _status;
 
-  const U32 idBase = _testerBase->getIdBase();
+  const FwIdType idBase = _testerBase->getIdBase();
   FW_ASSERT(
     id >= idBase,
     static_cast<FwAssertArgType>(id),

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.hpp
@@ -225,7 +225,7 @@ class QueuedTestTesterBase :
 
     //! A history entry for text log events
     struct TextLogEntry {
-      U32 id;
+      FwEventIdType id;
       Fw::Time timeTag;
       Fw::LogSeverity severity;
       Fw::TextLogString text;


### PR DESCRIPTION
Related to https://github.com/nasa/fprime/pull/3714, in C++ codegen, cast opcodes, event IDs, channel IDs, etc. to their respective types (ie: FwOpcodeType, FwEventIdType, FwChanIdType, etc.). This helps avoid implicit type conversion warnings that occur when building.

Partially addresses https://github.com/nasa/fprime/issues/3529 (fprime updates are included in https://github.com/nasa/fprime/pull/3714).