### PR TITLE
Change struct getters/setters to include _

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/StructCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/StructCppWriter.scala
@@ -534,7 +534,7 @@ case class StructCppWriter(
   }
 
   private def getGetterFunctionMembers: List[CppDoc.Class.Member] = {
-    def getGetterName(n: String) = s"get$n"
+    def getGetterName(n: String) = s"get_$n"
 
     memberList.flatMap((n, tn) => (sizes.contains(n), typeMembers(n).getUnderlyingType) match {
       case (false, _: Type.Enum) => List(
@@ -599,7 +599,7 @@ case class StructCppWriter(
       memberList.map((n, tn) =>
         functionClassMember(
           Some(s"Set member $n"),
-          s"set$n",
+          s"set_$n",
           List(
             writeMemberAsParam((n, tn))
           ),

--- a/compiler/tools/fpp-to-cpp/test/alias/AbsSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/alias/AbsSerializableAc.ref.cpp
@@ -131,7 +131,7 @@ void Abs ::
 }
 
 void Abs ::
-  setA(const AbsType& A)
+  set_A(const AbsType& A)
 {
   this->m_A = A;
 }

--- a/compiler/tools/fpp-to-cpp/test/alias/AbsSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/alias/AbsSerializableAc.ref.hpp
@@ -107,13 +107,13 @@ class Abs :
     // ----------------------------------------------------------------------
 
     //! Get member A
-    AbsType& getA()
+    AbsType& get_A()
     {
       return this->m_A;
     }
 
     //! Get member A (const)
-    const AbsType& getA() const
+    const AbsType& get_A() const
     {
       return this->m_A;
     }
@@ -126,7 +126,7 @@ class Abs :
     void set(const AbsType& A);
 
     //! Set member A
-    void setA(const AbsType& A);
+    void set_A(const AbsType& A);
 
   protected:
 

--- a/compiler/tools/fpp-to-cpp/test/alias/BasicSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/alias/BasicSerializableAc.ref.cpp
@@ -199,25 +199,25 @@ void Basic ::
 }
 
 void Basic ::
-  setA(TU32 A)
+  set_A(TU32 A)
 {
   this->m_A = A;
 }
 
 void Basic ::
-  setB(TF32 B)
+  set_B(TF32 B)
 {
   this->m_B = B;
 }
 
 void Basic ::
-  setC(const Fw::StringBase& C)
+  set_C(const Fw::StringBase& C)
 {
   this->m_C = C;
 }
 
 void Basic ::
-  setD(const Fw::StringBase& D)
+  set_D(const Fw::StringBase& D)
 {
   this->m_D = D;
 }

--- a/compiler/tools/fpp-to-cpp/test/alias/BasicSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/alias/BasicSerializableAc.ref.hpp
@@ -118,37 +118,37 @@ class Basic :
     // ----------------------------------------------------------------------
 
     //! Get member A
-    TU32 getA() const
+    TU32 get_A() const
     {
       return this->m_A;
     }
 
     //! Get member B
-    TF32 getB() const
+    TF32 get_B() const
     {
       return this->m_B;
     }
 
     //! Get member C
-    Fw::ExternalString& getC()
+    Fw::ExternalString& get_C()
     {
       return this->m_C;
     }
 
     //! Get member C (const)
-    const Fw::ExternalString& getC() const
+    const Fw::ExternalString& get_C() const
     {
       return this->m_C;
     }
 
     //! Get member D
-    Fw::ExternalString& getD()
+    Fw::ExternalString& get_D()
     {
       return this->m_D;
     }
 
     //! Get member D (const)
-    const Fw::ExternalString& getD() const
+    const Fw::ExternalString& get_D() const
     {
       return this->m_D;
     }
@@ -166,16 +166,16 @@ class Basic :
     );
 
     //! Set member A
-    void setA(TU32 A);
+    void set_A(TU32 A);
 
     //! Set member B
-    void setB(TF32 B);
+    void set_B(TF32 B);
 
     //! Set member C
-    void setC(const Fw::StringBase& C);
+    void set_C(const Fw::StringBase& C);
 
     //! Set member D
-    void setD(const Fw::StringBase& D);
+    void set_D(const Fw::StringBase& D);
 
   protected:
 

--- a/compiler/tools/fpp-to-cpp/test/alias/NamespaceSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/alias/NamespaceSerializableAc.ref.cpp
@@ -201,25 +201,25 @@ void Namespace ::
 }
 
 void Namespace ::
-  setA(SimpleCType A)
+  set_A(SimpleCType A)
 {
   this->m_A = A;
 }
 
 void Namespace ::
-  setB(SimpleCType2 B)
+  set_B(SimpleCType2 B)
 {
   this->m_B = B;
 }
 
 void Namespace ::
-  setC(M::M2::NamespacedAliasType C)
+  set_C(M::M2::NamespacedAliasType C)
 {
   this->m_C = C;
 }
 
 void Namespace ::
-  setD(M::NamespacedAliasType2 D)
+  set_D(M::NamespacedAliasType2 D)
 {
   this->m_D = D;
 }

--- a/compiler/tools/fpp-to-cpp/test/alias/NamespaceSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/alias/NamespaceSerializableAc.ref.hpp
@@ -118,25 +118,25 @@ class Namespace :
     // ----------------------------------------------------------------------
 
     //! Get member A
-    SimpleCType getA() const
+    SimpleCType get_A() const
     {
       return this->m_A;
     }
 
     //! Get member B
-    SimpleCType2 getB() const
+    SimpleCType2 get_B() const
     {
       return this->m_B;
     }
 
     //! Get member C
-    M::M2::NamespacedAliasType getC() const
+    M::M2::NamespacedAliasType get_C() const
     {
       return this->m_C;
     }
 
     //! Get member D
-    M::NamespacedAliasType2 getD() const
+    M::NamespacedAliasType2 get_D() const
     {
       return this->m_D;
     }
@@ -154,16 +154,16 @@ class Namespace :
     );
 
     //! Set member A
-    void setA(SimpleCType A);
+    void set_A(SimpleCType A);
 
     //! Set member B
-    void setB(SimpleCType2 B);
+    void set_B(SimpleCType2 B);
 
     //! Set member C
-    void setC(M::M2::NamespacedAliasType C);
+    void set_C(M::M2::NamespacedAliasType C);
 
     //! Set member D
-    void setD(M::NamespacedAliasType2 D);
+    void set_D(M::NamespacedAliasType2 D);
 
   protected:
 

--- a/compiler/tools/fpp-to-cpp/test/array/S1SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/S1SerializableAc.ref.cpp
@@ -370,73 +370,73 @@ namespace M {
   }
 
   void S1 ::
-    setmF32(F32 mF32)
+    set_mF32(F32 mF32)
   {
     this->m_mF32 = mF32;
   }
 
   void S1 ::
-    setmF64(F64 mF64)
+    set_mF64(F64 mF64)
   {
     this->m_mF64 = mF64;
   }
 
   void S1 ::
-    setmI16(I16 mI16)
+    set_mI16(I16 mI16)
   {
     this->m_mI16 = mI16;
   }
 
   void S1 ::
-    setmI32(I32 mI32)
+    set_mI32(I32 mI32)
   {
     this->m_mI32 = mI32;
   }
 
   void S1 ::
-    setmI64(I64 mI64)
+    set_mI64(I64 mI64)
   {
     this->m_mI64 = mI64;
   }
 
   void S1 ::
-    setmI8(I8 mI8)
+    set_mI8(I8 mI8)
   {
     this->m_mI8 = mI8;
   }
 
   void S1 ::
-    setmU16(U16 mU16)
+    set_mU16(U16 mU16)
   {
     this->m_mU16 = mU16;
   }
 
   void S1 ::
-    setmU32(U32 mU32)
+    set_mU32(U32 mU32)
   {
     this->m_mU32 = mU32;
   }
 
   void S1 ::
-    setmU64(U64 mU64)
+    set_mU64(U64 mU64)
   {
     this->m_mU64 = mU64;
   }
 
   void S1 ::
-    setmU8(U8 mU8)
+    set_mU8(U8 mU8)
   {
     this->m_mU8 = mU8;
   }
 
   void S1 ::
-    setmBool(bool mBool)
+    set_mBool(bool mBool)
   {
     this->m_mBool = mBool;
   }
 
   void S1 ::
-    setmString(const Fw::StringBase& mString)
+    set_mString(const Fw::StringBase& mString)
   {
     this->m_mString = mString;
   }

--- a/compiler/tools/fpp-to-cpp/test/array/S1SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/S1SerializableAc.ref.hpp
@@ -132,79 +132,79 @@ namespace M {
       // ----------------------------------------------------------------------
 
       //! Get member mF32
-      F32 getmF32() const
+      F32 get_mF32() const
       {
         return this->m_mF32;
       }
 
       //! Get member mF64
-      F64 getmF64() const
+      F64 get_mF64() const
       {
         return this->m_mF64;
       }
 
       //! Get member mI16
-      I16 getmI16() const
+      I16 get_mI16() const
       {
         return this->m_mI16;
       }
 
       //! Get member mI32
-      I32 getmI32() const
+      I32 get_mI32() const
       {
         return this->m_mI32;
       }
 
       //! Get member mI64
-      I64 getmI64() const
+      I64 get_mI64() const
       {
         return this->m_mI64;
       }
 
       //! Get member mI8
-      I8 getmI8() const
+      I8 get_mI8() const
       {
         return this->m_mI8;
       }
 
       //! Get member mU16
-      U16 getmU16() const
+      U16 get_mU16() const
       {
         return this->m_mU16;
       }
 
       //! Get member mU32
-      U32 getmU32() const
+      U32 get_mU32() const
       {
         return this->m_mU32;
       }
 
       //! Get member mU64
-      U64 getmU64() const
+      U64 get_mU64() const
       {
         return this->m_mU64;
       }
 
       //! Get member mU8
-      U8 getmU8() const
+      U8 get_mU8() const
       {
         return this->m_mU8;
       }
 
       //! Get member mBool
-      bool getmBool() const
+      bool get_mBool() const
       {
         return this->m_mBool;
       }
 
       //! Get member mString
-      Fw::ExternalString& getmString()
+      Fw::ExternalString& get_mString()
       {
         return this->m_mString;
       }
 
       //! Get member mString (const)
-      const Fw::ExternalString& getmString() const
+      const Fw::ExternalString& get_mString() const
       {
         return this->m_mString;
       }
@@ -230,40 +230,40 @@ namespace M {
       );
 
       //! Set member mF32
-      void setmF32(F32 mF32);
+      void set_mF32(F32 mF32);
 
       //! Set member mF64
-      void setmF64(F64 mF64);
+      void set_mF64(F64 mF64);
 
       //! Set member mI16
-      void setmI16(I16 mI16);
+      void set_mI16(I16 mI16);
 
       //! Set member mI32
-      void setmI32(I32 mI32);
+      void set_mI32(I32 mI32);
 
       //! Set member mI64
-      void setmI64(I64 mI64);
+      void set_mI64(I64 mI64);
 
       //! Set member mI8
-      void setmI8(I8 mI8);
+      void set_mI8(I8 mI8);
 
       //! Set member mU16
-      void setmU16(U16 mU16);
+      void set_mU16(U16 mU16);
 
       //! Set member mU32
-      void setmU32(U32 mU32);
+      void set_mU32(U32 mU32);
 
       //! Set member mU64
-      void setmU64(U64 mU64);
+      void set_mU64(U64 mU64);
 
       //! Set member mU8
-      void setmU8(U8 mU8);
+      void set_mU8(U8 mU8);
 
       //! Set member mBool
-      void setmBool(bool mBool);
+      void set_mBool(bool mBool);
 
       //! Set member mString
-      void setmString(const Fw::StringBase& mString);
+      void set_mString(const Fw::StringBase& mString);
 
     protected:
 

--- a/compiler/tools/fpp-to-cpp/test/array/S2SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/S2SerializableAc.ref.cpp
@@ -131,7 +131,7 @@ void S2 ::
 }
 
 void S2 ::
-  sets1(const M::S1& s1)
+  set_s1(const M::S1& s1)
 {
   this->m_s1 = s1;
 }

--- a/compiler/tools/fpp-to-cpp/test/array/S2SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/S2SerializableAc.ref.hpp
@@ -107,13 +107,13 @@ class S2 :
     // ----------------------------------------------------------------------
 
     //! Get member s1
-    M::S1& gets1()
+    M::S1& get_s1()
     {
       return this->m_s1;
     }
 
     //! Get member s1 (const)
-    const M::S1& gets1() const
+    const M::S1& get_s1() const
     {
       return this->m_s1;
     }
@@ -126,7 +126,7 @@ class S2 :
     void set(const M::S1& s1);
 
     //! Set member s1
-    void sets1(const M::S1& s1);
+    void set_s1(const M::S1& s1);
 
   protected:
 

--- a/compiler/tools/fpp-to-cpp/test/array/S3SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/S3SerializableAc.ref.cpp
@@ -201,7 +201,7 @@ namespace S {
   }
 
   void S3 ::
-    setmU32Array(const Type_of_mU32Array& mU32Array)
+    set_mU32Array(const Type_of_mU32Array& mU32Array)
   {
     for (FwSizeType i = 0; i < 3; i++) {
       this->m_mU32Array[i] = mU32Array[i];
@@ -209,7 +209,7 @@ namespace S {
   }
 
   void S3 ::
-    setmF64(F64 mF64)
+    set_mF64(F64 mF64)
   {
     this->m_mF64 = mF64;
   }

--- a/compiler/tools/fpp-to-cpp/test/array/S3SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/S3SerializableAc.ref.hpp
@@ -128,19 +128,19 @@ namespace S {
       // ----------------------------------------------------------------------
 
       //! Get member mU32Array
-      Type_of_mU32Array& getmU32Array()
+      Type_of_mU32Array& get_mU32Array()
       {
         return this->m_mU32Array;
       }
 
       //! Get member mU32Array (const)
-      const Type_of_mU32Array& getmU32Array() const
+      const Type_of_mU32Array& get_mU32Array() const
       {
         return this->m_mU32Array;
       }
 
       //! Get member mF64
-      F64 getmF64() const
+      F64 get_mF64() const
       {
         return this->m_mF64;
       }
@@ -156,10 +156,10 @@ namespace S {
       );
 
       //! Set member mU32Array
-      void setmU32Array(const Type_of_mU32Array& mU32Array);
+      void set_mU32Array(const Type_of_mU32Array& mU32Array);
 
       //! Set member mF64
-      void setmF64(F64 mF64);
+      void set_mF64(F64 mF64);
 
     protected:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/SSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SSerializableAc.ref.cpp
@@ -158,13 +158,13 @@ void S ::
 }
 
 void S ::
-  setx(U32 x)
+  set_x(U32 x)
 {
   this->m_x = x;
 }
 
 void S ::
-  sety(const Fw::StringBase& y)
+  set_y(const Fw::StringBase& y)
 {
   this->m_y = y;
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/SSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SSerializableAc.ref.hpp
@@ -111,19 +111,19 @@ class S :
     // ----------------------------------------------------------------------
 
     //! Get member x
-    U32 getx() const
+    U32 get_x() const
     {
       return this->m_x;
     }
 
     //! Get member y
-    Fw::ExternalString& gety()
+    Fw::ExternalString& get_y()
     {
       return this->m_y;
     }
 
     //! Get member y (const)
-    const Fw::ExternalString& gety() const
+    const Fw::ExternalString& get_y() const
     {
       return this->m_y;
     }
@@ -139,10 +139,10 @@ class S :
     );
 
     //! Set member x
-    void setx(U32 x);
+    void set_x(U32 x);
 
     //! Set member y
-    void sety(const Fw::StringBase& y);
+    void set_y(const Fw::StringBase& y);
 
   protected:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/StructWithAliasSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/StructWithAliasSerializableAc.ref.cpp
@@ -221,31 +221,31 @@ void StructWithAlias ::
 }
 
 void StructWithAlias ::
-  setx(AliasPrim1 x)
+  set_x(AliasPrim1 x)
 {
   this->m_x = x;
 }
 
 void StructWithAlias ::
-  sety(const Fw::StringBase& y)
+  set_y(const Fw::StringBase& y)
 {
   this->m_y = y;
 }
 
 void StructWithAlias ::
-  setz(const AliasArray& z)
+  set_z(const AliasArray& z)
 {
   this->m_z = z;
 }
 
 void StructWithAlias ::
-  setw(const AliasAliasArray& w)
+  set_w(const AliasAliasArray& w)
 {
   this->m_w = w;
 }
 
 void StructWithAlias ::
-  setq(const AliasArrayAliasArray& q)
+  set_q(const AliasArrayAliasArray& q)
 {
   this->m_q = q;
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/StructWithAliasSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/StructWithAliasSerializableAc.ref.hpp
@@ -121,55 +121,55 @@ class StructWithAlias :
     // ----------------------------------------------------------------------
 
     //! Get member x
-    AliasPrim1 getx() const
+    AliasPrim1 get_x() const
     {
       return this->m_x;
     }
 
     //! Get member y
-    Fw::ExternalString& gety()
+    Fw::ExternalString& get_y()
     {
       return this->m_y;
     }
 
     //! Get member y (const)
-    const Fw::ExternalString& gety() const
+    const Fw::ExternalString& get_y() const
     {
       return this->m_y;
     }
 
     //! Get member z
-    AliasArray& getz()
+    AliasArray& get_z()
     {
       return this->m_z;
     }
 
     //! Get member z (const)
-    const AliasArray& getz() const
+    const AliasArray& get_z() const
     {
       return this->m_z;
     }
 
     //! Get member w
-    AliasAliasArray& getw()
+    AliasAliasArray& get_w()
     {
       return this->m_w;
     }
 
     //! Get member w (const)
-    const AliasAliasArray& getw() const
+    const AliasAliasArray& get_w() const
     {
       return this->m_w;
     }
 
     //! Get member q
-    AliasArrayAliasArray& getq()
+    AliasArrayAliasArray& get_q()
     {
       return this->m_q;
     }
 
     //! Get member q (const)
-    const AliasArrayAliasArray& getq() const
+    const AliasArrayAliasArray& get_q() const
     {
       return this->m_q;
     }
@@ -188,19 +188,19 @@ class StructWithAlias :
     );
 
     //! Set member x
-    void setx(AliasPrim1 x);
+    void set_x(AliasPrim1 x);
 
     //! Set member y
-    void sety(const Fw::StringBase& y);
+    void set_y(const Fw::StringBase& y);
 
     //! Set member z
-    void setz(const AliasArray& z);
+    void set_z(const AliasArray& z);
 
     //! Set member w
-    void setw(const AliasAliasArray& w);
+    void set_w(const AliasAliasArray& w);
 
     //! Set member q
-    void setq(const AliasArrayAliasArray& q);
+    void set_q(const AliasArrayAliasArray& q);
 
   protected:
 

--- a/compiler/tools/fpp-to-cpp/test/struct/AbsTypeSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/AbsTypeSerializableAc.ref.cpp
@@ -131,7 +131,7 @@ void AbsType ::
 }
 
 void AbsType ::
-  sett(const T& t)
+  set_t(const T& t)
 {
   this->m_t = t;
 }

--- a/compiler/tools/fpp-to-cpp/test/struct/AbsTypeSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/AbsTypeSerializableAc.ref.hpp
@@ -107,13 +107,13 @@ class AbsType :
     // ----------------------------------------------------------------------
 
     //! Get member t
-    T& gett()
+    T& get_t()
     {
       return this->m_t;
     }
 
     //! Get member t (const)
-    const T& gett() const
+    const T& get_t() const
     {
       return this->m_t;
     }
@@ -126,7 +126,7 @@ class AbsType :
     void set(const T& t);
 
     //! Set member t
-    void sett(const T& t);
+    void set_t(const T& t);
 
   protected:
 

--- a/compiler/tools/fpp-to-cpp/test/struct/AliasTypeSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/AliasTypeSerializableAc.ref.cpp
@@ -239,19 +239,19 @@ void AliasType ::
 }
 
 void AliasType ::
-  setx(U16Alias x)
+  set_x(U16Alias x)
 {
   this->m_x = x;
 }
 
 void AliasType ::
-  sety(const TAlias& y)
+  set_y(const TAlias& y)
 {
   this->m_y = y;
 }
 
 void AliasType ::
-  setz(const Type_of_z& z)
+  set_z(const Type_of_z& z)
 {
   for (FwSizeType i = 0; i < 10; i++) {
     this->m_z[i] = z[i];

--- a/compiler/tools/fpp-to-cpp/test/struct/AliasTypeSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/AliasTypeSerializableAc.ref.hpp
@@ -131,31 +131,31 @@ class AliasType :
     // ----------------------------------------------------------------------
 
     //! Get member x
-    U16Alias getx() const
+    U16Alias get_x() const
     {
       return this->m_x;
     }
 
     //! Get member y
-    TAlias& gety()
+    TAlias& get_y()
     {
       return this->m_y;
     }
 
     //! Get member y (const)
-    const TAlias& gety() const
+    const TAlias& get_y() const
     {
       return this->m_y;
     }
 
     //! Get member z
-    Type_of_z& getz()
+    Type_of_z& get_z()
     {
       return this->m_z;
     }
 
     //! Get member z (const)
-    const Type_of_z& getz() const
+    const Type_of_z& get_z() const
     {
       return this->m_z;
     }
@@ -172,13 +172,13 @@ class AliasType :
     );
 
     //! Set member x
-    void setx(U16Alias x);
+    void set_x(U16Alias x);
 
     //! Set member y
-    void sety(const TAlias& y);
+    void set_y(const TAlias& y);
 
     //! Set member z
-    void setz(const Type_of_z& z);
+    void set_z(const Type_of_z& z);
 
   protected:
 

--- a/compiler/tools/fpp-to-cpp/test/struct/C_SSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/C_SSerializableAc.ref.cpp
@@ -131,7 +131,7 @@ void C_S ::
 }
 
 void C_S ::
-  setx(U32 x)
+  set_x(U32 x)
 {
   this->m_x = x;
 }

--- a/compiler/tools/fpp-to-cpp/test/struct/C_SSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/C_SSerializableAc.ref.hpp
@@ -106,7 +106,7 @@ class C_S :
     // ----------------------------------------------------------------------
 
     //! Get member x
-    U32 getx() const
+    U32 get_x() const
     {
       return this->m_x;
     }
@@ -119,7 +119,7 @@ class C_S :
     void set(U32 x);
 
     //! Set member x
-    void setx(U32 x);
+    void set_x(U32 x);
 
   protected:
 

--- a/compiler/tools/fpp-to-cpp/test/struct/DefaultSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/DefaultSerializableAc.ref.cpp
@@ -179,19 +179,19 @@ void Default ::
 }
 
 void Default ::
-  setmU32(U32 mU32)
+  set_mU32(U32 mU32)
 {
   this->m_mU32 = mU32;
 }
 
 void Default ::
-  setmS1(const Fw::StringBase& mS1)
+  set_mS1(const Fw::StringBase& mS1)
 {
   this->m_mS1 = mS1;
 }
 
 void Default ::
-  setmF64(F64 mF64)
+  set_mF64(F64 mF64)
 {
   this->m_mF64 = mF64;
 }

--- a/compiler/tools/fpp-to-cpp/test/struct/DefaultSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/DefaultSerializableAc.ref.hpp
@@ -112,25 +112,25 @@ class Default :
     // ----------------------------------------------------------------------
 
     //! Get member mU32
-    U32 getmU32() const
+    U32 get_mU32() const
     {
       return this->m_mU32;
     }
 
     //! Get member mS1
-    Fw::ExternalString& getmS1()
+    Fw::ExternalString& get_mS1()
     {
       return this->m_mS1;
     }
 
     //! Get member mS1 (const)
-    const Fw::ExternalString& getmS1() const
+    const Fw::ExternalString& get_mS1() const
     {
       return this->m_mS1;
     }
 
     //! Get member mF64
-    F64 getmF64() const
+    F64 get_mF64() const
     {
       return this->m_mF64;
     }
@@ -147,13 +147,13 @@ class Default :
     );
 
     //! Set member mU32
-    void setmU32(U32 mU32);
+    void set_mU32(U32 mU32);
 
     //! Set member mS1
-    void setmS1(const Fw::StringBase& mS1);
+    void set_mS1(const Fw::StringBase& mS1);
 
     //! Set member mF64
-    void setmF64(F64 mF64);
+    void set_mF64(F64 mF64);
 
   protected:
 

--- a/compiler/tools/fpp-to-cpp/test/struct/EnumSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/EnumSerializableAc.ref.cpp
@@ -199,13 +199,13 @@ void Enum ::
 }
 
 void Enum ::
-  sete(M::E::T e)
+  set_e(M::E::T e)
 {
   this->m_e = e;
 }
 
 void Enum ::
-  seteArr(const Type_of_eArr& eArr)
+  set_eArr(const Type_of_eArr& eArr)
 {
   for (FwSizeType i = 0; i < 3; i++) {
     this->m_eArr[i] = eArr[i];

--- a/compiler/tools/fpp-to-cpp/test/struct/EnumSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/EnumSerializableAc.ref.hpp
@@ -126,19 +126,19 @@ class Enum :
     // ----------------------------------------------------------------------
 
     //! Get member e
-    M::E::T gete() const
+    M::E::T get_e() const
     {
       return this->m_e.e;
     }
 
     //! Get member eArr
-    Type_of_eArr& geteArr()
+    Type_of_eArr& get_eArr()
     {
       return this->m_eArr;
     }
 
     //! Get member eArr (const)
-    const Type_of_eArr& geteArr() const
+    const Type_of_eArr& get_eArr() const
     {
       return this->m_eArr;
     }
@@ -154,10 +154,10 @@ class Enum :
     );
 
     //! Set member e
-    void sete(M::E::T e);
+    void set_e(M::E::T e);
 
     //! Set member eArr
-    void seteArr(const Type_of_eArr& eArr);
+    void set_eArr(const Type_of_eArr& eArr);
 
   protected:
 

--- a/compiler/tools/fpp-to-cpp/test/struct/FormatSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/FormatSerializableAc.ref.cpp
@@ -474,103 +474,103 @@ void Format ::
 }
 
 void Format ::
-  setm1(I32 m1)
+  set_m1(I32 m1)
 {
   this->m_m1 = m1;
 }
 
 void Format ::
-  setm2(U32 m2)
+  set_m2(U32 m2)
 {
   this->m_m2 = m2;
 }
 
 void Format ::
-  setm3(I32 m3)
+  set_m3(I32 m3)
 {
   this->m_m3 = m3;
 }
 
 void Format ::
-  setm4(U32 m4)
+  set_m4(U32 m4)
 {
   this->m_m4 = m4;
 }
 
 void Format ::
-  setm5(I32 m5)
+  set_m5(I32 m5)
 {
   this->m_m5 = m5;
 }
 
 void Format ::
-  setm6(U32 m6)
+  set_m6(U32 m6)
 {
   this->m_m6 = m6;
 }
 
 void Format ::
-  setm7(I32 m7)
+  set_m7(I32 m7)
 {
   this->m_m7 = m7;
 }
 
 void Format ::
-  setm8(U32 m8)
+  set_m8(U32 m8)
 {
   this->m_m8 = m8;
 }
 
 void Format ::
-  setm9(I32 m9)
+  set_m9(I32 m9)
 {
   this->m_m9 = m9;
 }
 
 void Format ::
-  setm10(U32 m10)
+  set_m10(U32 m10)
 {
   this->m_m10 = m10;
 }
 
 void Format ::
-  setm11(F32 m11)
+  set_m11(F32 m11)
 {
   this->m_m11 = m11;
 }
 
 void Format ::
-  setm12(F32 m12)
+  set_m12(F32 m12)
 {
   this->m_m12 = m12;
 }
 
 void Format ::
-  setm13(F32 m13)
+  set_m13(F32 m13)
 {
   this->m_m13 = m13;
 }
 
 void Format ::
-  setm14(F32 m14)
+  set_m14(F32 m14)
 {
   this->m_m14 = m14;
 }
 
 void Format ::
-  setm15(F32 m15)
+  set_m15(F32 m15)
 {
   this->m_m15 = m15;
 }
 
 void Format ::
-  setm16(F32 m16)
+  set_m16(F32 m16)
 {
   this->m_m16 = m16;
 }
 
 void Format ::
-  setm17(F32 m17)
+  set_m17(F32 m17)
 {
   this->m_m17 = m17;
 }

--- a/compiler/tools/fpp-to-cpp/test/struct/FormatSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/FormatSerializableAc.ref.hpp
@@ -140,103 +140,103 @@ class Format :
     // ----------------------------------------------------------------------
 
     //! Get member m1
-    I32 getm1() const
+    I32 get_m1() const
     {
       return this->m_m1;
     }
 
     //! Get member m2
-    U32 getm2() const
+    U32 get_m2() const
     {
       return this->m_m2;
     }
 
     //! Get member m3
-    I32 getm3() const
+    I32 get_m3() const
     {
       return this->m_m3;
     }
 
     //! Get member m4
-    U32 getm4() const
+    U32 get_m4() const
     {
       return this->m_m4;
     }
 
     //! Get member m5
-    I32 getm5() const
+    I32 get_m5() const
     {
       return this->m_m5;
     }
 
     //! Get member m6
-    U32 getm6() const
+    U32 get_m6() const
     {
       return this->m_m6;
     }
 
     //! Get member m7
-    I32 getm7() const
+    I32 get_m7() const
     {
       return this->m_m7;
     }
 
     //! Get member m8
-    U32 getm8() const
+    U32 get_m8() const
     {
       return this->m_m8;
     }
 
     //! Get member m9
-    I32 getm9() const
+    I32 get_m9() const
     {
       return this->m_m9;
     }
 
     //! Get member m10
-    U32 getm10() const
+    U32 get_m10() const
     {
       return this->m_m10;
     }
 
     //! Get member m11
-    F32 getm11() const
+    F32 get_m11() const
     {
       return this->m_m11;
     }
 
     //! Get member m12
-    F32 getm12() const
+    F32 get_m12() const
     {
       return this->m_m12;
     }
 
     //! Get member m13
-    F32 getm13() const
+    F32 get_m13() const
     {
       return this->m_m13;
     }
 
     //! Get member m14
-    F32 getm14() const
+    F32 get_m14() const
     {
       return this->m_m14;
     }
 
     //! Get member m15
-    F32 getm15() const
+    F32 get_m15() const
     {
       return this->m_m15;
     }
 
     //! Get member m16
-    F32 getm16() const
+    F32 get_m16() const
     {
       return this->m_m16;
     }
 
     //! Get member m17
-    F32 getm17() const
+    F32 get_m17() const
     {
       return this->m_m17;
     }
@@ -267,55 +267,55 @@ class Format :
     );
 
     //! Set member m1
-    void setm1(I32 m1);
+    void set_m1(I32 m1);
 
     //! Set member m2
-    void setm2(U32 m2);
+    void set_m2(U32 m2);
 
     //! Set member m3
-    void setm3(I32 m3);
+    void set_m3(I32 m3);
 
     //! Set member m4
-    void setm4(U32 m4);
+    void set_m4(U32 m4);
 
     //! Set member m5
-    void setm5(I32 m5);
+    void set_m5(I32 m5);
 
     //! Set member m6
-    void setm6(U32 m6);
+    void set_m6(U32 m6);
 
     //! Set member m7
-    void setm7(I32 m7);
+    void set_m7(I32 m7);
 
     //! Set member m8
-    void setm8(U32 m8);
+    void set_m8(U32 m8);
 
     //! Set member m9
-    void setm9(I32 m9);
+    void set_m9(I32 m9);
 
     //! Set member m10
-    void setm10(U32 m10);
+    void set_m10(U32 m10);
 
     //! Set member m11
-    void setm11(F32 m11);
+    void set_m11(F32 m11);
 
     //! Set member m12
-    void setm12(F32 m12);
+    void set_m12(F32 m12);
 
     //! Set member m13
-    void setm13(F32 m13);
+    void set_m13(F32 m13);
 
     //! Set member m14
-    void setm14(F32 m14);
+    void set_m14(F32 m14);
 
     //! Set member m15
-    void setm15(F32 m15);
+    void set_m15(F32 m15);
 
     //! Set member m16
-    void setm16(F32 m16);
+    void set_m16(F32 m16);
 
     //! Set member m17
-    void setm17(F32 m17);
+    void set_m17(F32 m17);
 
   protected:
 

--- a/compiler/tools/fpp-to-cpp/test/struct/IncludedSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/IncludedSerializableAc.ref.cpp
@@ -131,7 +131,7 @@ void Included ::
 }
 
 void Included ::
-  setx(U32 x)
+  set_x(U32 x)
 {
   this->m_x = x;
 }

--- a/compiler/tools/fpp-to-cpp/test/struct/IncludedSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/IncludedSerializableAc.ref.hpp
@@ -106,7 +106,7 @@ class Included :
     // ----------------------------------------------------------------------
 
     //! Get member x
-    U32 getx() const
+    U32 get_x() const
     {
       return this->m_x;
     }
@@ -119,7 +119,7 @@ class Included :
     void set(U32 x);
 
     //! Set member x
-    void setx(U32 x);
+    void set_x(U32 x);
 
   protected:
 

--- a/compiler/tools/fpp-to-cpp/test/struct/IncludingSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/IncludingSerializableAc.ref.cpp
@@ -131,7 +131,7 @@ void Including ::
 }
 
 void Including ::
-  setx(const Included& x)
+  set_x(const Included& x)
 {
   this->m_x = x;
 }

--- a/compiler/tools/fpp-to-cpp/test/struct/IncludingSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/IncludingSerializableAc.ref.hpp
@@ -107,13 +107,13 @@ class Including :
     // ----------------------------------------------------------------------
 
     //! Get member x
-    Included& getx()
+    Included& get_x()
     {
       return this->m_x;
     }
 
     //! Get member x (const)
-    const Included& getx() const
+    const Included& get_x() const
     {
       return this->m_x;
     }
@@ -126,7 +126,7 @@ class Including :
     void set(const Included& x);
 
     //! Set member x
-    void setx(const Included& x);
+    void set_x(const Included& x);
 
   protected:
 

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules1SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules1SerializableAc.ref.cpp
@@ -161,13 +161,13 @@ namespace M {
   }
 
   void Modules1 ::
-    setx(U32 x)
+    set_x(U32 x)
   {
     this->m_x = x;
   }
 
   void Modules1 ::
-    sety(F32 y)
+    set_y(F32 y)
   {
     this->m_y = y;
   }

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules1SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules1SerializableAc.ref.hpp
@@ -112,13 +112,13 @@ namespace M {
       // ----------------------------------------------------------------------
 
       //! Get member x
-      U32 getx() const
+      U32 get_x() const
       {
         return this->m_x;
       }
 
       //! Get member y
-      F32 gety() const
+      F32 get_y() const
       {
         return this->m_y;
       }
@@ -134,10 +134,10 @@ namespace M {
       );
 
       //! Set member x
-      void setx(U32 x);
+      void set_x(U32 x);
 
       //! Set member y
-      void sety(F32 y);
+      void set_y(F32 y);
 
     protected:
 

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules2SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules2SerializableAc.ref.cpp
@@ -133,7 +133,7 @@ namespace M {
   }
 
   void Modules2 ::
-    setx(const M::Modules1& x)
+    set_x(const M::Modules1& x)
   {
     this->m_x = x;
   }

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules2SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules2SerializableAc.ref.hpp
@@ -109,13 +109,13 @@ namespace M {
       // ----------------------------------------------------------------------
 
       //! Get member x
-      M::Modules1& getx()
+      M::Modules1& get_x()
       {
         return this->m_x;
       }
 
       //! Get member x (const)
-      const M::Modules1& getx() const
+      const M::Modules1& get_x() const
       {
         return this->m_x;
       }
@@ -128,7 +128,7 @@ namespace M {
       void set(const M::Modules1& x);
 
       //! Set member x
-      void setx(const M::Modules1& x);
+      void set_x(const M::Modules1& x);
 
     protected:
 

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules3SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules3SerializableAc.ref.cpp
@@ -199,13 +199,13 @@ void Modules3 ::
 }
 
 void Modules3 ::
-  setx(const M::Modules2& x)
+  set_x(const M::Modules2& x)
 {
   this->m_x = x;
 }
 
 void Modules3 ::
-  setarr(const Type_of_arr& arr)
+  set_arr(const Type_of_arr& arr)
 {
   for (FwSizeType i = 0; i < 3; i++) {
     this->m_arr[i] = arr[i];

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules3SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules3SerializableAc.ref.hpp
@@ -126,25 +126,25 @@ class Modules3 :
     // ----------------------------------------------------------------------
 
     //! Get member x
-    M::Modules2& getx()
+    M::Modules2& get_x()
     {
       return this->m_x;
     }
 
     //! Get member x (const)
-    const M::Modules2& getx() const
+    const M::Modules2& get_x() const
     {
       return this->m_x;
     }
 
     //! Get member arr
-    Type_of_arr& getarr()
+    Type_of_arr& get_arr()
     {
       return this->m_arr;
     }
 
     //! Get member arr (const)
-    const Type_of_arr& getarr() const
+    const Type_of_arr& get_arr() const
     {
       return this->m_arr;
     }
@@ -160,10 +160,10 @@ class Modules3 :
     );
 
     //! Set member x
-    void setx(const M::Modules2& x);
+    void set_x(const M::Modules2& x);
 
     //! Set member arr
-    void setarr(const Type_of_arr& arr);
+    void set_arr(const Type_of_arr& arr);
 
   protected:
 

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules4SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules4SerializableAc.ref.cpp
@@ -222,7 +222,7 @@ void Modules4 ::
 }
 
 void Modules4 ::
-  setarr1(const Type_of_arr1& arr1)
+  set_arr1(const Type_of_arr1& arr1)
 {
   for (FwSizeType i = 0; i < 3; i++) {
     this->m_arr1[i] = arr1[i];
@@ -230,7 +230,7 @@ void Modules4 ::
 }
 
 void Modules4 ::
-  setarr2(const Type_of_arr2& arr2)
+  set_arr2(const Type_of_arr2& arr2)
 {
   for (FwSizeType i = 0; i < 6; i++) {
     this->m_arr2[i] = arr2[i];

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules4SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules4SerializableAc.ref.hpp
@@ -129,25 +129,25 @@ class Modules4 :
     // ----------------------------------------------------------------------
 
     //! Get member arr1
-    Type_of_arr1& getarr1()
+    Type_of_arr1& get_arr1()
     {
       return this->m_arr1;
     }
 
     //! Get member arr1 (const)
-    const Type_of_arr1& getarr1() const
+    const Type_of_arr1& get_arr1() const
     {
       return this->m_arr1;
     }
 
     //! Get member arr2
-    Type_of_arr2& getarr2()
+    Type_of_arr2& get_arr2()
     {
       return this->m_arr2;
     }
 
     //! Get member arr2 (const)
-    const Type_of_arr2& getarr2() const
+    const Type_of_arr2& get_arr2() const
     {
       return this->m_arr2;
     }
@@ -163,10 +163,10 @@ class Modules4 :
     );
 
     //! Set member arr1
-    void setarr1(const Type_of_arr1& arr1);
+    void set_arr1(const Type_of_arr1& arr1);
 
     //! Set member arr2
-    void setarr2(const Type_of_arr2& arr2);
+    void set_arr2(const Type_of_arr2& arr2);
 
   protected:
 

--- a/compiler/tools/fpp-to-cpp/test/struct/PrimitiveSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/PrimitiveSerializableAc.ref.cpp
@@ -430,7 +430,7 @@ void Primitive ::
 }
 
 void Primitive ::
-  setmF32(const Type_of_mF32& mF32)
+  set_mF32(const Type_of_mF32& mF32)
 {
   for (FwSizeType i = 0; i < 3; i++) {
     this->m_mF32[i] = mF32[i];
@@ -438,67 +438,67 @@ void Primitive ::
 }
 
 void Primitive ::
-  setmF64(F64 mF64)
+  set_mF64(F64 mF64)
 {
   this->m_mF64 = mF64;
 }
 
 void Primitive ::
-  setmI16(I16 mI16)
+  set_mI16(I16 mI16)
 {
   this->m_mI16 = mI16;
 }
 
 void Primitive ::
-  setmI32(I32 mI32)
+  set_mI32(I32 mI32)
 {
   this->m_mI32 = mI32;
 }
 
 void Primitive ::
-  setmI64(I64 mI64)
+  set_mI64(I64 mI64)
 {
   this->m_mI64 = mI64;
 }
 
 void Primitive ::
-  setmI8(I8 mI8)
+  set_mI8(I8 mI8)
 {
   this->m_mI8 = mI8;
 }
 
 void Primitive ::
-  setmU16(U16 mU16)
+  set_mU16(U16 mU16)
 {
   this->m_mU16 = mU16;
 }
 
 void Primitive ::
-  setmU32(U32 mU32)
+  set_mU32(U32 mU32)
 {
   this->m_mU32 = mU32;
 }
 
 void Primitive ::
-  setmU64(U64 mU64)
+  set_mU64(U64 mU64)
 {
   this->m_mU64 = mU64;
 }
 
 void Primitive ::
-  setmU8(U8 mU8)
+  set_mU8(U8 mU8)
 {
   this->m_mU8 = mU8;
 }
 
 void Primitive ::
-  setm_bool(bool m_bool)
+  set_m_bool(bool m_bool)
 {
   this->m_m_bool = m_bool;
 }
 
 void Primitive ::
-  setm_string(const Fw::StringBase& m_string)
+  set_m_string(const Fw::StringBase& m_string)
 {
   this->m_m_string = m_string;
 }

--- a/compiler/tools/fpp-to-cpp/test/struct/PrimitiveSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/PrimitiveSerializableAc.ref.hpp
@@ -157,85 +157,85 @@ class Primitive :
     // ----------------------------------------------------------------------
 
     //! Get member mF32
-    Type_of_mF32& getmF32()
+    Type_of_mF32& get_mF32()
     {
       return this->m_mF32;
     }
 
     //! Get member mF32 (const)
-    const Type_of_mF32& getmF32() const
+    const Type_of_mF32& get_mF32() const
     {
       return this->m_mF32;
     }
 
     //! Get member mF64
-    F64 getmF64() const
+    F64 get_mF64() const
     {
       return this->m_mF64;
     }
 
     //! Get member mI16
-    I16 getmI16() const
+    I16 get_mI16() const
     {
       return this->m_mI16;
     }
 
     //! Get member mI32
-    I32 getmI32() const
+    I32 get_mI32() const
     {
       return this->m_mI32;
     }
 
     //! Get member mI64
-    I64 getmI64() const
+    I64 get_mI64() const
     {
       return this->m_mI64;
     }
 
     //! Get member mI8
-    I8 getmI8() const
+    I8 get_mI8() const
     {
       return this->m_mI8;
     }
 
     //! Get member mU16
-    U16 getmU16() const
+    U16 get_mU16() const
     {
       return this->m_mU16;
     }
 
     //! Get member mU32
-    U32 getmU32() const
+    U32 get_mU32() const
     {
       return this->m_mU32;
     }
 
     //! Get member mU64
-    U64 getmU64() const
+    U64 get_mU64() const
     {
       return this->m_mU64;
     }
 
     //! Get member mU8
-    U8 getmU8() const
+    U8 get_mU8() const
     {
       return this->m_mU8;
     }
 
     //! Get member m_bool
-    bool getm_bool() const
+    bool get_m_bool() const
     {
       return this->m_m_bool;
     }
 
     //! Get member m_string
-    Fw::ExternalString& getm_string()
+    Fw::ExternalString& get_m_string()
     {
       return this->m_m_string;
     }
 
     //! Get member m_string (const)
-    const Fw::ExternalString& getm_string() const
+    const Fw::ExternalString& get_m_string() const
     {
       return this->m_m_string;
     }
@@ -261,40 +261,40 @@ class Primitive :
     );
 
     //! Set member mF32
-    void setmF32(const Type_of_mF32& mF32);
+    void set_mF32(const Type_of_mF32& mF32);
 
     //! Set member mF64
-    void setmF64(F64 mF64);
+    void set_mF64(F64 mF64);
 
     //! Set member mI16
-    void setmI16(I16 mI16);
+    void set_mI16(I16 mI16);
 
     //! Set member mI32
-    void setmI32(I32 mI32);
+    void set_mI32(I32 mI32);
 
     //! Set member mI64
-    void setmI64(I64 mI64);
+    void set_mI64(I64 mI64);
 
     //! Set member mI8
-    void setmI8(I8 mI8);
+    void set_mI8(I8 mI8);
 
     //! Set member mU16
-    void setmU16(U16 mU16);
+    void set_mU16(U16 mU16);
 
     //! Set member mU32
-    void setmU32(U32 mU32);
+    void set_mU32(U32 mU32);
 
     //! Set member mU64
-    void setmU64(U64 mU64);
+    void set_mU64(U64 mU64);
 
     //! Set member mU8
-    void setmU8(U8 mU8);
+    void set_mU8(U8 mU8);
 
     //! Set member m_bool
-    void setm_bool(bool m_bool);
+    void set_m_bool(bool m_bool);
 
     //! Set member m_string
-    void setm_string(const Fw::StringBase& m_string);
+    void set_m_string(const Fw::StringBase& m_string);
 
   protected:
 

--- a/compiler/tools/fpp-to-cpp/test/struct/PrimitiveStructSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/PrimitiveStructSerializableAc.ref.cpp
@@ -131,7 +131,7 @@ void PrimitiveStruct ::
 }
 
 void PrimitiveStruct ::
-  sets1(const Primitive& s1)
+  set_s1(const Primitive& s1)
 {
   this->m_s1 = s1;
 }

--- a/compiler/tools/fpp-to-cpp/test/struct/PrimitiveStructSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/PrimitiveStructSerializableAc.ref.hpp
@@ -107,13 +107,13 @@ class PrimitiveStruct :
     // ----------------------------------------------------------------------
 
     //! Get member s1
-    Primitive& gets1()
+    Primitive& get_s1()
     {
       return this->m_s1;
     }
 
     //! Get member s1 (const)
-    const Primitive& gets1() const
+    const Primitive& get_s1() const
     {
       return this->m_s1;
     }
@@ -126,7 +126,7 @@ class PrimitiveStruct :
     void set(const Primitive& s1);
 
     //! Set member s1
-    void sets1(const Primitive& s1);
+    void set_s1(const Primitive& s1);
 
   protected:
 

--- a/compiler/tools/fpp-to-cpp/test/struct/SSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/SSerializableAc.ref.cpp
@@ -131,7 +131,7 @@ void S ::
 }
 
 void S ::
-  setx(U32 x)
+  set_x(U32 x)
 {
   this->m_x = x;
 }

--- a/compiler/tools/fpp-to-cpp/test/struct/SSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/SSerializableAc.ref.hpp
@@ -107,7 +107,7 @@ class S :
     // ----------------------------------------------------------------------
 
     //! Get member x
-    U32 getx() const
+    U32 get_x() const
     {
       return this->m_x;
     }
@@ -120,7 +120,7 @@ class S :
     void set(U32 x);
 
     //! Set member x
-    void setx(U32 x);
+    void set_x(U32 x);
 
   protected:
 

--- a/compiler/tools/fpp-to-cpp/test/struct/StringArraySerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/StringArraySerializableAc.ref.cpp
@@ -213,13 +213,13 @@ void StringArray ::
 }
 
 void StringArray ::
-  sets1(const Fw::StringBase& s1)
+  set_s1(const Fw::StringBase& s1)
 {
   this->m_s1 = s1;
 }
 
 void StringArray ::
-  sets2(const Type_of_s2& s2)
+  set_s2(const Type_of_s2& s2)
 {
   for (FwSizeType i = 0; i < 16; i++) {
     this->m_s2[i] = s2[i];

--- a/compiler/tools/fpp-to-cpp/test/struct/StringArraySerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/StringArraySerializableAc.ref.hpp
@@ -125,25 +125,25 @@ class StringArray :
     // ----------------------------------------------------------------------
 
     //! Get member s1
-    Fw::ExternalString& gets1()
+    Fw::ExternalString& get_s1()
     {
       return this->m_s1;
     }
 
     //! Get member s1 (const)
-    const Fw::ExternalString& gets1() const
+    const Fw::ExternalString& get_s1() const
     {
       return this->m_s1;
     }
 
     //! Get member s2
-    Type_of_s2& gets2()
+    Type_of_s2& get_s2()
     {
       return this->m_s2;
     }
 
     //! Get member s2 (const)
-    const Type_of_s2& gets2() const
+    const Type_of_s2& get_s2() const
     {
       return this->m_s2;
     }
@@ -159,10 +159,10 @@ class StringArray :
     );
 
     //! Set member s1
-    void sets1(const Fw::StringBase& s1);
+    void set_s1(const Fw::StringBase& s1);
 
     //! Set member s2
-    void sets2(const Type_of_s2& s2);
+    void set_s2(const Type_of_s2& s2);
 
   protected:
 

--- a/compiler/tools/fpp-to-cpp/test/struct/StringSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/StringSerializableAc.ref.cpp
@@ -156,13 +156,13 @@ void String ::
 }
 
 void String ::
-  sets1(const Fw::StringBase& s1)
+  set_s1(const Fw::StringBase& s1)
 {
   this->m_s1 = s1;
 }
 
 void String ::
-  sets2(const Fw::StringBase& s2)
+  set_s2(const Fw::StringBase& s2)
 {
   this->m_s2 = s2;
 }

--- a/compiler/tools/fpp-to-cpp/test/struct/StringSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/StringSerializableAc.ref.hpp
@@ -110,25 +110,25 @@ class String :
     // ----------------------------------------------------------------------
 
     //! Get member s1
-    Fw::ExternalString& gets1()
+    Fw::ExternalString& get_s1()
     {
       return this->m_s1;
     }
 
     //! Get member s1 (const)
-    const Fw::ExternalString& gets1() const
+    const Fw::ExternalString& get_s1() const
     {
       return this->m_s1;
     }
 
     //! Get member s2
-    Fw::ExternalString& gets2()
+    Fw::ExternalString& get_s2()
     {
       return this->m_s2;
     }
 
     //! Get member s2 (const)
-    const Fw::ExternalString& gets2() const
+    const Fw::ExternalString& get_s2() const
     {
       return this->m_s2;
     }
@@ -144,10 +144,10 @@ class String :
     );
 
     //! Set member s1
-    void sets1(const Fw::StringBase& s1);
+    void set_s1(const Fw::StringBase& s1);
 
     //! Set member s2
-    void sets2(const Fw::StringBase& s2);
+    void set_s2(const Fw::StringBase& s2);
 
   protected:
 


### PR DESCRIPTION
This adds an `_` between the `get`/`set` token of a struct's getters/setters and the field name. Fixes: https://github.com/nasa/fprime/issues/3785.

This compiles against: https://github.com/nasa/fprime/pull/3917