### PR TITLE
Use dynamic size for array and struct records

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/ArrayCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ArrayCppWriter.scala
@@ -437,7 +437,7 @@ case class ArrayCppWriter (
     ))
     val serializedSize = eltType.getUnderlyingType match {
       case ts: (Type.String | Type.Array | Type.Struct) => {
-        List(
+        List.concat(
           lines("FwSizeType size = 0;"),
           indexIterator(lines(
             "size += this->elements[index].serializedSize();"
@@ -445,7 +445,7 @@ case class ArrayCppWriter (
           lines("return size;")
         )
       }
-      case _ => List(lines("return SERIALIZED_SIZE;"))
+      case _ => lines("return SERIALIZED_SIZE;")
     }
 
     List(
@@ -499,11 +499,11 @@ case class ArrayCppWriter (
         ).flatten,
       ),
       functionClassMember(
-        Some("Serialized Size"),
+        Some("Get the dynamic serialized size of the array"),
         "serializedSize",
         List(),
         CppDoc.Type("FwSizeType"),
-        serializedSize.flatten,
+        serializedSize,
         CppDoc.Function.NonSV,
         CppDoc.Function.Const
       )

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ArrayCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ArrayCppWriter.scala
@@ -149,7 +149,7 @@ case class ArrayCppWriter (
                     |ELEMENT_SERIALIZED_SIZE = Fw::StringBase::STATIC_SERIALIZED_SIZE(ELEMENT_STRING_SIZE),"""
               case _ =>
                 s"""|//! The serialized size of each element
-                    |ELEMENT_SERIALIZED_SIZE = ${writeSerializedSizeExpr(s, eltType, eltTypeName)},"""
+                    |ELEMENT_SERIALIZED_SIZE = ${writeStaticSerializedSizeExpr(s, eltType, eltTypeName)},"""
             }
             lines(s"""|//! The size of the array
                       |SIZE = $arraySize,
@@ -435,6 +435,18 @@ case class ArrayCppWriter (
           |}
           |"""
     ))
+    val serializedSize = eltType.getUnderlyingType match {
+      case ts: (Type.String | Type.Array | Type.Struct) => {
+        List(
+          lines("FwSizeType size = 0;"),
+          indexIterator(lines(
+            "size += this->elements[index].serializedSize();"
+          )),
+          lines("return size;")
+        )
+      }
+      case _ => List(lines("return SERIALIZED_SIZE;"))
+    }
 
     List(
       linesClassMember(
@@ -485,7 +497,16 @@ case class ArrayCppWriter (
           ),
           lines("return status;"),
         ).flatten,
-    )
+      ),
+      functionClassMember(
+        Some("Serialized Size"),
+        "serializedSize",
+        List(),
+        CppDoc.Type("FwSizeType"),
+        serializedSize.flatten,
+        CppDoc.Function.NonSV,
+        CppDoc.Function.Const
+      )
     ) ++
       wrapClassMembersInIfDirective(
         "\n#if FW_SERIALIZABLE_TO_STRING",

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriter.scala
@@ -346,7 +346,7 @@ case class ComponentCppWriter (
           s"BYTE ${p.getUnqualifiedName}IntIfSize[",
           lines(
             p.aNode._2.data.params.map(param =>
-              writeSerializedSizeExpr(
+              writeStaticSerializedSizeExpr(
                 s,
                 s.a.typeMap(param._2.data.typeName.id),
                 writeInternalPortParamType(param._2.data)

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentDataProducts.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentDataProducts.scala
@@ -15,7 +15,7 @@ case class ComponentDataProducts (
       val data = record.aNode._2.data
       val constantName = s"SIZE_OF_${data.name}_RECORD"
       val typeName = TypeCppWriter.getName(s, record.recordType)
-      val eltSize = writeSerializedSizeExpr(s, record.recordType, typeName)
+      val eltSize = writeStaticSerializedSizeExpr(s, record.recordType, typeName)
       if record.isArray
       then s"""|static constexpr FwSizeType $constantName(FwSizeType arraySize) {
                |  return sizeof(FwDpIdType) + sizeof(FwSizeStoreType) + arraySize * $eltSize;
@@ -423,8 +423,14 @@ case class ComponentDataProducts (
               |const FwSizeType sizeDelta =
               |  sizeof(FwDpIdType) +
               |  elt.serializedTruncatedSize(stringSize);"""
+        case ts: (Type.Array | Type.Struct)  => {
+          val serialSize = "elt.serializedSize()"
+          s"""|const FwSizeType sizeDelta =
+              |  sizeof(FwDpIdType) +
+              |  $serialSize;"""
+        }
         case _ =>
-          val serialSize = writeSerializedSizeExpr(s, t, typeName)
+          val serialSize = writeStaticSerializedSizeExpr(s, t, typeName)
           s"""|const FwSizeType sizeDelta =
               |  sizeof(FwDpIdType) +
               |  $serialSize;"""

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentEvents.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentEvents.scala
@@ -142,7 +142,7 @@ case class ComponentEvents (
                         s"""|#if FW_AMPCS_COMPATIBLE
                             |// Serialize the argument size
                             |_status = _logBuff.serialize(
-                            |  static_cast<U8>(${writeSerializedSizeExpr(s, t, typeName)})
+                            |  static_cast<U8>(${writeStaticSerializedSizeExpr(s, t, typeName)})
                             |);
                             |FW_ASSERT(
                             |  _status == Fw::FW_SERIALIZE_OK,

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentInternalStateMachines.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentInternalStateMachines.scala
@@ -693,7 +693,7 @@ case class ComponentInternalStateMachines(
       t.getUnderlyingType match {
         case _: Type.String =>
           s"Fw::StringBase::STATIC_SERIALIZED_SIZE(${signalStringSize.toString})"
-        case _ => writeSerializedSizeExpr(s, t, TypeCppWriter.getName(s, t))
+        case _ => writeStaticSerializedSizeExpr(s, t, TypeCppWriter.getName(s, t))
       }
 
   }

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentTesterBaseWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentTesterBaseWriter.scala
@@ -921,7 +921,7 @@ case class ComponentTesterBaseWriter(
             val name = s"_event_arg_${data.name}"
             val tn = writeFormalParamType(data, "Fw::LogStringArg")
             val paramType = s.a.typeMap(data.typeName.id)
-            val serializedSizeExpr = writeSerializedSizeExpr(s, paramType, tn)
+            val serializedSizeExpr = writeStaticSerializedSizeExpr(s, paramType, tn)
 
             lines(
               s"""|

--- a/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterUtils.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterUtils.scala
@@ -302,7 +302,7 @@ trait CppWriterUtils extends LineUtils {
       getOrElse(s.defaultStringSize.toString)
 
   /** Write a C++ expression for static serialized size */
-  def writeSerializedSizeExpr(s: CppWriterState, t: Type, typeName: String): String =
+  def writeStaticSerializedSizeExpr(s: CppWriterState, t: Type, typeName: String): String =
     (t.getUnderlyingType, s.isPrimitive(t, typeName))  match {
       // sizeof(bool) is not defined in C++
       // F Prime serializes bool as U8

--- a/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter.scala
@@ -218,7 +218,7 @@ case class PortCppWriter (
                 else
                   line("SERIALIZED_SIZE =") ::
                     lines(paramList.map((n, tn, _) =>
-                      writeSerializedSizeExpr(s, paramTypeMap(n), tn)
+                      writeStaticSerializedSizeExpr(s, paramTypeMap(n), tn)
                     ).mkString(" +\n")).map(indentIn)
               ).flatten
             )

--- a/compiler/lib/src/main/scala/codegen/CppWriter/StructCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/StructCppWriter.scala
@@ -452,7 +452,7 @@ case class StructCppWriter(
       }
 
     val serializedSize = 
-      List(
+      List.concat(
         lines("FwSizeType size = 0;"),
         lines(memberList.map((n, tn) => 
           s"${getSerializedSize(n, tn)}"
@@ -526,11 +526,11 @@ case class StructCppWriter(
           ).flatten
         ),
         functionClassMember(
-          Some("Serialized Size"),
+          Some("Get the dynamic serialized size of the struct"),
           "serializedSize",
           List(),
           CppDoc.Type("FwSizeType"),
-          serializedSize.flatten,
+          serializedSize,
           CppDoc.Function.NonSV,
           CppDoc.Function.Const
         )

--- a/compiler/lib/src/main/scala/codegen/CppWriter/StructCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/StructCppWriter.scala
@@ -139,7 +139,7 @@ case class StructCppWriter(
                 lines("//! The size of the serial representation"),
                 lines("SERIALIZED_SIZE ="),
                 lines(memberList.map((n, tn) =>
-                  writeSerializedSizeExpr(s, typeMembers(n), tn) + (
+                  writeStaticSerializedSizeExpr(s, typeMembers(n), tn) + (
                     if sizes.contains(n) then s" * ${sizes(n)}"
                     else ""
                     )).mkString(" +\n")).map(indentIn),
@@ -427,6 +427,39 @@ case class StructCppWriter(
           getMemberToString(node, n, tn),
       ))
 
+    def sizeIterator(size: Int, ll: List[Line]): List[Line] =
+      wrapInForLoop(
+        "U32 index = 0",
+        s"index < $size",
+        "index++",
+        ll,
+      )
+
+    def getSerializedSize(n: String, tn: String) = 
+      typeMembers(n).getUnderlyingType match {
+        case ts: (Type.Array | Type.Struct | Type.String) => {
+          if sizes.contains(n) then
+            sizeIterator(
+              sizes(n),
+              lines(s"size += this->m_$n[index].serializedSize();")
+            ).mkString("\n")
+          else s"size += this->m_$n.serializedSize();"
+        }
+        case ts => s"size += ${writeStaticSerializedSizeExpr(s, ts, tn) + (
+            if sizes.contains(n) then s" * ${sizes(n)};"
+            else ";"
+        )}"
+      }
+
+    val serializedSize = 
+      List(
+        lines("FwSizeType size = 0;"),
+        lines(memberList.map((n, tn) => 
+          s"${getSerializedSize(n, tn)}"
+        ).mkString("\n")),
+        lines("return size;")
+      )
+
     def writeSerializeStatusCheck =
       wrapInIf(
         "status != Fw::FW_SERIALIZE_OK",
@@ -491,6 +524,15 @@ case class StructCppWriter(
             ),
             Line.blank :: lines("return status;"),
           ).flatten
+        ),
+        functionClassMember(
+          Some("Serialized Size"),
+          "serializedSize",
+          List(),
+          CppDoc.Type("FwSizeType"),
+          serializedSize.flatten,
+          CppDoc.Function.NonSV,
+          CppDoc.Function.Const
         )
       ),
       wrapClassMembersInIfDirective(

--- a/compiler/lib/src/main/scala/codegen/CppWriter/TlmPacketSetCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/TlmPacketSetCppWriter.scala
@@ -178,7 +178,7 @@ case class TlmPacketSetCppWriter(
       val nameStr = CppWriter.identFromQualifiedName(name)
       val t = entry.tlmChannel.channelType
       val tn = TypeCppWriter.getName(s, t)
-      val sizeStr = writeSerializedSizeExpr(s, t, tn)
+      val sizeStr = writeStaticSerializedSizeExpr(s, t, tn)
       lines(
         s"""|
             |//! The serialized size of channel $name

--- a/compiler/tools/fpp-to-cpp/test/alias/AbsSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/alias/AbsSerializableAc.ref.cpp
@@ -103,6 +103,14 @@ Fw::SerializeStatus Abs ::
   return status;
 }
 
+FwSizeType Abs ::
+  serializedSize() const
+{
+  FwSizeType size = 0;
+  size += AbsType::SERIALIZED_SIZE;
+  return size;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void Abs ::

--- a/compiler/tools/fpp-to-cpp/test/alias/AbsSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/alias/AbsSerializableAc.ref.hpp
@@ -93,6 +93,9 @@ class Abs :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert struct to string

--- a/compiler/tools/fpp-to-cpp/test/alias/AbsSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/alias/AbsSerializableAc.ref.hpp
@@ -93,7 +93,7 @@ class Abs :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the struct
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/alias/BasicSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/alias/BasicSerializableAc.ref.cpp
@@ -147,6 +147,17 @@ Fw::SerializeStatus Basic ::
   return status;
 }
 
+FwSizeType Basic ::
+  serializedSize() const
+{
+  FwSizeType size = 0;
+  size += sizeof(TU32);
+  size += sizeof(TF32);
+  size += this->m_C.serializedSize();
+  size += this->m_D.serializedSize();
+  return size;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void Basic ::

--- a/compiler/tools/fpp-to-cpp/test/alias/BasicSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/alias/BasicSerializableAc.ref.hpp
@@ -104,7 +104,7 @@ class Basic :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the struct
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/alias/BasicSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/alias/BasicSerializableAc.ref.hpp
@@ -104,6 +104,9 @@ class Basic :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert struct to string

--- a/compiler/tools/fpp-to-cpp/test/alias/NamespaceSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/alias/NamespaceSerializableAc.ref.cpp
@@ -147,6 +147,17 @@ Fw::SerializeStatus Namespace ::
   return status;
 }
 
+FwSizeType Namespace ::
+  serializedSize() const
+{
+  FwSizeType size = 0;
+  size += sizeof(SimpleCType);
+  size += sizeof(SimpleCType2);
+  size += sizeof(M::M2::NamespacedAliasType);
+  size += sizeof(M::NamespacedAliasType2);
+  return size;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void Namespace ::

--- a/compiler/tools/fpp-to-cpp/test/alias/NamespaceSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/alias/NamespaceSerializableAc.ref.hpp
@@ -104,7 +104,7 @@ class Namespace :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the struct
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/alias/NamespaceSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/alias/NamespaceSerializableAc.ref.hpp
@@ -104,6 +104,9 @@ class Namespace :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert struct to string

--- a/compiler/tools/fpp-to-cpp/test/array/AArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/AArrayAc.ref.cpp
@@ -170,6 +170,12 @@ Fw::SerializeStatus A ::
   return status;
 }
 
+FwSizeType A ::
+  serializedSize() const
+{
+  return SERIALIZED_SIZE;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void A ::

--- a/compiler/tools/fpp-to-cpp/test/array/AArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/AArrayAc.ref.hpp
@@ -139,6 +139,9 @@ class A :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert array to string

--- a/compiler/tools/fpp-to-cpp/test/array/AArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/AArrayAc.ref.hpp
@@ -139,7 +139,7 @@ class A :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the array
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/array/AbsTypeArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/AbsTypeArrayAc.ref.cpp
@@ -170,6 +170,12 @@ Fw::SerializeStatus AbsType ::
   return status;
 }
 
+FwSizeType AbsType ::
+  serializedSize() const
+{
+  return SERIALIZED_SIZE;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void AbsType ::

--- a/compiler/tools/fpp-to-cpp/test/array/AbsTypeArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/AbsTypeArrayAc.ref.hpp
@@ -140,7 +140,7 @@ class AbsType :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the array
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/array/AbsTypeArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/AbsTypeArrayAc.ref.hpp
@@ -140,6 +140,9 @@ class AbsType :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert array to string

--- a/compiler/tools/fpp-to-cpp/test/array/AliasTypeArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/AliasTypeArrayAc.ref.cpp
@@ -170,6 +170,12 @@ Fw::SerializeStatus AliasType ::
   return status;
 }
 
+FwSizeType AliasType ::
+  serializedSize() const
+{
+  return SERIALIZED_SIZE;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void AliasType ::

--- a/compiler/tools/fpp-to-cpp/test/array/AliasTypeArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/AliasTypeArrayAc.ref.hpp
@@ -140,7 +140,7 @@ class AliasType :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the array
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/array/AliasTypeArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/AliasTypeArrayAc.ref.hpp
@@ -140,6 +140,9 @@ class AliasType :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert array to string

--- a/compiler/tools/fpp-to-cpp/test/array/C_AArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/C_AArrayAc.ref.cpp
@@ -170,6 +170,12 @@ Fw::SerializeStatus C_A ::
   return status;
 }
 
+FwSizeType C_A ::
+  serializedSize() const
+{
+  return SERIALIZED_SIZE;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void C_A ::

--- a/compiler/tools/fpp-to-cpp/test/array/C_AArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/C_AArrayAc.ref.hpp
@@ -138,7 +138,7 @@ class C_A :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the array
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/array/C_AArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/C_AArrayAc.ref.hpp
@@ -138,6 +138,9 @@ class C_A :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert array to string

--- a/compiler/tools/fpp-to-cpp/test/array/Enum1ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Enum1ArrayAc.ref.cpp
@@ -167,6 +167,12 @@ Fw::SerializeStatus Enum1 ::
   return status;
 }
 
+FwSizeType Enum1 ::
+  serializedSize() const
+{
+  return SERIALIZED_SIZE;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void Enum1 ::

--- a/compiler/tools/fpp-to-cpp/test/array/Enum1ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Enum1ArrayAc.ref.hpp
@@ -139,6 +139,9 @@ class Enum1 :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert array to string

--- a/compiler/tools/fpp-to-cpp/test/array/Enum1ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Enum1ArrayAc.ref.hpp
@@ -139,7 +139,7 @@ class Enum1 :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the array
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/array/Enum2ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Enum2ArrayAc.ref.cpp
@@ -176,6 +176,12 @@ Fw::SerializeStatus Enum2 ::
   return status;
 }
 
+FwSizeType Enum2 ::
+  serializedSize() const
+{
+  return SERIALIZED_SIZE;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void Enum2 ::

--- a/compiler/tools/fpp-to-cpp/test/array/Enum2ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Enum2ArrayAc.ref.hpp
@@ -141,7 +141,7 @@ class Enum2 :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the array
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/array/Enum2ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Enum2ArrayAc.ref.hpp
@@ -141,6 +141,9 @@ class Enum2 :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert array to string

--- a/compiler/tools/fpp-to-cpp/test/array/HeaderPathArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/HeaderPathArrayAc.ref.cpp
@@ -170,6 +170,12 @@ Fw::SerializeStatus HeaderPath ::
   return status;
 }
 
+FwSizeType HeaderPath ::
+  serializedSize() const
+{
+  return SERIALIZED_SIZE;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void HeaderPath ::

--- a/compiler/tools/fpp-to-cpp/test/array/HeaderPathArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/HeaderPathArrayAc.ref.hpp
@@ -140,7 +140,7 @@ class HeaderPath :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the array
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/array/HeaderPathArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/HeaderPathArrayAc.ref.hpp
@@ -140,6 +140,9 @@ class HeaderPath :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert array to string

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveArrayArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveArrayArrayAc.ref.cpp
@@ -176,6 +176,16 @@ Fw::SerializeStatus PrimitiveArray ::
   return status;
 }
 
+FwSizeType PrimitiveArray ::
+  serializedSize() const
+{
+  FwSizeType size = 0;
+  for (U32 index = 0; index < SIZE; index++) {
+    size += this->elements[index].serializedSize();
+  }
+  return size;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void PrimitiveArray ::

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveArrayArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveArrayArrayAc.ref.hpp
@@ -142,6 +142,9 @@ class PrimitiveArray :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert array to string

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveArrayArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveArrayArrayAc.ref.hpp
@@ -142,7 +142,7 @@ class PrimitiveArray :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the array
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveBoolArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveBoolArrayAc.ref.cpp
@@ -172,6 +172,12 @@ namespace M {
     return status;
   }
 
+  FwSizeType PrimitiveBool ::
+    serializedSize() const
+  {
+    return SERIALIZED_SIZE;
+  }
+
 #if FW_SERIALIZABLE_TO_STRING
 
   void PrimitiveBool ::

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveBoolArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveBoolArrayAc.ref.hpp
@@ -140,6 +140,9 @@ namespace M {
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 
+      //! Serialized Size
+      FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
       //! Convert array to string

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveBoolArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveBoolArrayAc.ref.hpp
@@ -140,7 +140,7 @@ namespace M {
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 
-      //! Serialized Size
+      //! Get the dynamic serialized size of the array
       FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32eArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32eArrayAc.ref.cpp
@@ -172,6 +172,12 @@ namespace M {
     return status;
   }
 
+  FwSizeType PrimitiveF32e ::
+    serializedSize() const
+  {
+    return SERIALIZED_SIZE;
+  }
+
 #if FW_SERIALIZABLE_TO_STRING
 
   void PrimitiveF32e ::

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32eArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32eArrayAc.ref.hpp
@@ -141,6 +141,9 @@ namespace M {
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 
+      //! Serialized Size
+      FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
       //! Convert array to string

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32eArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32eArrayAc.ref.hpp
@@ -141,7 +141,7 @@ namespace M {
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 
-      //! Serialized Size
+      //! Get the dynamic serialized size of the array
       FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32fArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32fArrayAc.ref.cpp
@@ -172,6 +172,12 @@ namespace M {
     return status;
   }
 
+  FwSizeType PrimitiveF32f ::
+    serializedSize() const
+  {
+    return SERIALIZED_SIZE;
+  }
+
 #if FW_SERIALIZABLE_TO_STRING
 
   void PrimitiveF32f ::

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32fArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32fArrayAc.ref.hpp
@@ -141,6 +141,9 @@ namespace M {
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 
+      //! Serialized Size
+      FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
       //! Convert array to string

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32fArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32fArrayAc.ref.hpp
@@ -141,7 +141,7 @@ namespace M {
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 
-      //! Serialized Size
+      //! Get the dynamic serialized size of the array
       FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveF64ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveF64ArrayAc.ref.cpp
@@ -178,6 +178,12 @@ namespace M {
     return status;
   }
 
+  FwSizeType PrimitiveF64 ::
+    serializedSize() const
+  {
+    return SERIALIZED_SIZE;
+  }
+
 #if FW_SERIALIZABLE_TO_STRING
 
   void PrimitiveF64 ::

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveF64ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveF64ArrayAc.ref.hpp
@@ -143,6 +143,9 @@ namespace M {
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 
+      //! Serialized Size
+      FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
       //! Convert array to string

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveF64ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveF64ArrayAc.ref.hpp
@@ -143,7 +143,7 @@ namespace M {
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 
-      //! Serialized Size
+      //! Get the dynamic serialized size of the array
       FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveI32ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveI32ArrayAc.ref.cpp
@@ -172,6 +172,12 @@ namespace M {
     return status;
   }
 
+  FwSizeType PrimitiveI32 ::
+    serializedSize() const
+  {
+    return SERIALIZED_SIZE;
+  }
+
 #if FW_SERIALIZABLE_TO_STRING
 
   void PrimitiveI32 ::

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveI32ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveI32ArrayAc.ref.hpp
@@ -141,6 +141,9 @@ namespace M {
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 
+      //! Serialized Size
+      FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
       //! Convert array to string

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveI32ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveI32ArrayAc.ref.hpp
@@ -141,7 +141,7 @@ namespace M {
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 
-      //! Serialized Size
+      //! Get the dynamic serialized size of the array
       FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveI64ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveI64ArrayAc.ref.cpp
@@ -172,6 +172,12 @@ namespace M {
     return status;
   }
 
+  FwSizeType PrimitiveI64 ::
+    serializedSize() const
+  {
+    return SERIALIZED_SIZE;
+  }
+
 #if FW_SERIALIZABLE_TO_STRING
 
   void PrimitiveI64 ::

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveI64ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveI64ArrayAc.ref.hpp
@@ -141,6 +141,9 @@ namespace M {
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 
+      //! Serialized Size
+      FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
       //! Convert array to string

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveI64ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveI64ArrayAc.ref.hpp
@@ -141,7 +141,7 @@ namespace M {
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 
-      //! Serialized Size
+      //! Get the dynamic serialized size of the array
       FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveU16ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveU16ArrayAc.ref.cpp
@@ -172,6 +172,12 @@ namespace M {
     return status;
   }
 
+  FwSizeType PrimitiveU16 ::
+    serializedSize() const
+  {
+    return SERIALIZED_SIZE;
+  }
+
 #if FW_SERIALIZABLE_TO_STRING
 
   void PrimitiveU16 ::

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveU16ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveU16ArrayAc.ref.hpp
@@ -140,6 +140,9 @@ namespace M {
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 
+      //! Serialized Size
+      FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
       //! Convert array to string

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveU16ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveU16ArrayAc.ref.hpp
@@ -140,7 +140,7 @@ namespace M {
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 
-      //! Serialized Size
+      //! Get the dynamic serialized size of the array
       FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveU8ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveU8ArrayAc.ref.cpp
@@ -172,6 +172,12 @@ namespace M {
     return status;
   }
 
+  FwSizeType PrimitiveU8 ::
+    serializedSize() const
+  {
+    return SERIALIZED_SIZE;
+  }
+
 #if FW_SERIALIZABLE_TO_STRING
 
   void PrimitiveU8 ::

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveU8ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveU8ArrayAc.ref.hpp
@@ -140,6 +140,9 @@ namespace M {
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 
+      //! Serialized Size
+      FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
       //! Convert array to string

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveU8ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveU8ArrayAc.ref.hpp
@@ -140,7 +140,7 @@ namespace M {
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 
-      //! Serialized Size
+      //! Get the dynamic serialized size of the array
       FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/array/S1SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/S1SerializableAc.ref.cpp
@@ -253,6 +253,25 @@ namespace M {
     return status;
   }
 
+  FwSizeType S1 ::
+    serializedSize() const
+  {
+    FwSizeType size = 0;
+    size += sizeof(F32);
+    size += sizeof(F64);
+    size += sizeof(I16);
+    size += sizeof(I32);
+    size += sizeof(I64);
+    size += sizeof(I8);
+    size += sizeof(U16);
+    size += sizeof(U32);
+    size += sizeof(U64);
+    size += sizeof(U8);
+    size += sizeof(U8);
+    size += this->m_mString.serializedSize();
+    return size;
+  }
+
 #if FW_SERIALIZABLE_TO_STRING
 
   void S1 ::

--- a/compiler/tools/fpp-to-cpp/test/array/S1SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/S1SerializableAc.ref.hpp
@@ -118,6 +118,9 @@ namespace M {
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 
+      //! Serialized Size
+      FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
       //! Convert struct to string

--- a/compiler/tools/fpp-to-cpp/test/array/S1SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/S1SerializableAc.ref.hpp
@@ -118,7 +118,7 @@ namespace M {
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 
-      //! Serialized Size
+      //! Get the dynamic serialized size of the struct
       FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/array/S2SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/S2SerializableAc.ref.cpp
@@ -103,6 +103,14 @@ Fw::SerializeStatus S2 ::
   return status;
 }
 
+FwSizeType S2 ::
+  serializedSize() const
+{
+  FwSizeType size = 0;
+  size += this->m_s1.serializedSize();
+  return size;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void S2 ::

--- a/compiler/tools/fpp-to-cpp/test/array/S2SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/S2SerializableAc.ref.hpp
@@ -93,7 +93,7 @@ class S2 :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the struct
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/array/S2SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/S2SerializableAc.ref.hpp
@@ -93,6 +93,9 @@ class S2 :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert struct to string

--- a/compiler/tools/fpp-to-cpp/test/array/S3SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/S3SerializableAc.ref.cpp
@@ -153,6 +153,15 @@ namespace S {
     return status;
   }
 
+  FwSizeType S3 ::
+    serializedSize() const
+  {
+    FwSizeType size = 0;
+    size += sizeof(U32) * 3;
+    size += sizeof(F64);
+    return size;
+  }
+
 #if FW_SERIALIZABLE_TO_STRING
 
   void S3 ::

--- a/compiler/tools/fpp-to-cpp/test/array/S3SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/S3SerializableAc.ref.hpp
@@ -114,7 +114,7 @@ namespace S {
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 
-      //! Serialized Size
+      //! Get the dynamic serialized size of the struct
       FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/array/S3SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/S3SerializableAc.ref.hpp
@@ -114,6 +114,9 @@ namespace S {
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 
+      //! Serialized Size
+      FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
       //! Convert struct to string

--- a/compiler/tools/fpp-to-cpp/test/array/SingleElementArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/SingleElementArrayAc.ref.cpp
@@ -153,6 +153,12 @@ Fw::SerializeStatus SingleElement ::
   return status;
 }
 
+FwSizeType SingleElement ::
+  serializedSize() const
+{
+  return SERIALIZED_SIZE;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void SingleElement ::

--- a/compiler/tools/fpp-to-cpp/test/array/SingleElementArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/SingleElementArrayAc.ref.hpp
@@ -132,6 +132,9 @@ class SingleElement :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert array to string

--- a/compiler/tools/fpp-to-cpp/test/array/SingleElementArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/SingleElementArrayAc.ref.hpp
@@ -132,7 +132,7 @@ class SingleElement :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the array
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/array/String1ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/String1ArrayAc.ref.cpp
@@ -175,6 +175,16 @@ Fw::SerializeStatus String1 ::
   return status;
 }
 
+FwSizeType String1 ::
+  serializedSize() const
+{
+  FwSizeType size = 0;
+  for (U32 index = 0; index < SIZE; index++) {
+    size += this->elements[index].serializedSize();
+  }
+  return size;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void String1 ::

--- a/compiler/tools/fpp-to-cpp/test/array/String1ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/String1ArrayAc.ref.hpp
@@ -143,6 +143,9 @@ class String1 :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert array to string

--- a/compiler/tools/fpp-to-cpp/test/array/String1ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/String1ArrayAc.ref.hpp
@@ -143,7 +143,7 @@ class String1 :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the array
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/array/String2ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/String2ArrayAc.ref.cpp
@@ -172,6 +172,16 @@ Fw::SerializeStatus String2 ::
   return status;
 }
 
+FwSizeType String2 ::
+  serializedSize() const
+{
+  FwSizeType size = 0;
+  for (U32 index = 0; index < SIZE; index++) {
+    size += this->elements[index].serializedSize();
+  }
+  return size;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void String2 ::

--- a/compiler/tools/fpp-to-cpp/test/array/String2ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/String2ArrayAc.ref.hpp
@@ -142,7 +142,7 @@ class String2 :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the array
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/array/String2ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/String2ArrayAc.ref.hpp
@@ -142,6 +142,9 @@ class String2 :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert array to string

--- a/compiler/tools/fpp-to-cpp/test/array/StringArrayArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/StringArrayArrayAc.ref.cpp
@@ -176,6 +176,16 @@ Fw::SerializeStatus StringArray ::
   return status;
 }
 
+FwSizeType StringArray ::
+  serializedSize() const
+{
+  FwSizeType size = 0;
+  for (U32 index = 0; index < SIZE; index++) {
+    size += this->elements[index].serializedSize();
+  }
+  return size;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void StringArray ::

--- a/compiler/tools/fpp-to-cpp/test/array/StringArrayArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/StringArrayArrayAc.ref.hpp
@@ -142,6 +142,9 @@ class StringArray :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert array to string

--- a/compiler/tools/fpp-to-cpp/test/array/StringArrayArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/StringArrayArrayAc.ref.hpp
@@ -142,7 +142,7 @@ class StringArray :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the array
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/array/Struct1ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Struct1ArrayAc.ref.cpp
@@ -176,6 +176,16 @@ Fw::SerializeStatus Struct1 ::
   return status;
 }
 
+FwSizeType Struct1 ::
+  serializedSize() const
+{
+  FwSizeType size = 0;
+  for (U32 index = 0; index < SIZE; index++) {
+    size += this->elements[index].serializedSize();
+  }
+  return size;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void Struct1 ::

--- a/compiler/tools/fpp-to-cpp/test/array/Struct1ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Struct1ArrayAc.ref.hpp
@@ -142,7 +142,7 @@ class Struct1 :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the array
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/array/Struct1ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Struct1ArrayAc.ref.hpp
@@ -142,6 +142,9 @@ class Struct1 :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert array to string

--- a/compiler/tools/fpp-to-cpp/test/array/Struct2ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Struct2ArrayAc.ref.cpp
@@ -170,6 +170,16 @@ Fw::SerializeStatus Struct2 ::
   return status;
 }
 
+FwSizeType Struct2 ::
+  serializedSize() const
+{
+  FwSizeType size = 0;
+  for (U32 index = 0; index < SIZE; index++) {
+    size += this->elements[index].serializedSize();
+  }
+  return size;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void Struct2 ::

--- a/compiler/tools/fpp-to-cpp/test/array/Struct2ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Struct2ArrayAc.ref.hpp
@@ -140,7 +140,7 @@ class Struct2 :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the array
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/array/Struct2ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Struct2ArrayAc.ref.hpp
@@ -140,6 +140,9 @@ class Struct2 :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert array to string

--- a/compiler/tools/fpp-to-cpp/test/array/Struct3ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Struct3ArrayAc.ref.cpp
@@ -170,6 +170,16 @@ Fw::SerializeStatus Struct3 ::
   return status;
 }
 
+FwSizeType Struct3 ::
+  serializedSize() const
+{
+  FwSizeType size = 0;
+  for (U32 index = 0; index < SIZE; index++) {
+    size += this->elements[index].serializedSize();
+  }
+  return size;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void Struct3 ::

--- a/compiler/tools/fpp-to-cpp/test/array/Struct3ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Struct3ArrayAc.ref.hpp
@@ -140,7 +140,7 @@ class Struct3 :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the array
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/array/Struct3ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Struct3ArrayAc.ref.hpp
@@ -140,6 +140,9 @@ class Struct3 :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert array to string

--- a/compiler/tools/fpp-to-cpp/test/component/base/AArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/AArrayAc.ref.cpp
@@ -170,6 +170,12 @@ Fw::SerializeStatus A ::
   return status;
 }
 
+FwSizeType A ::
+  serializedSize() const
+{
+  return SERIALIZED_SIZE;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void A ::

--- a/compiler/tools/fpp-to-cpp/test/component/base/AArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/AArrayAc.ref.hpp
@@ -139,6 +139,9 @@ class A :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert array to string

--- a/compiler/tools/fpp-to-cpp/test/component/base/AArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/AArrayAc.ref.hpp
@@ -139,7 +139,7 @@ class A :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the array
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductsComponentAc.ref.cpp
@@ -132,7 +132,7 @@ Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
 {
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    ActiveAsyncProducts_Data::SERIALIZED_SIZE;
+    elt.serializedSize();
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveGetProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveGetProductsComponentAc.ref.cpp
@@ -130,7 +130,7 @@ Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
 {
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    ActiveGetProducts_Data::SERIALIZED_SIZE;
+    elt.serializedSize();
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveGuardedProductsComponentAc.ref.cpp
@@ -130,7 +130,7 @@ Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
 {
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    ActiveGuardedProducts_Data::SERIALIZED_SIZE;
+    elt.serializedSize();
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSyncProductsComponentAc.ref.cpp
@@ -130,7 +130,7 @@ Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
 {
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    ActiveSyncProducts_Data::SERIALIZED_SIZE;
+    elt.serializedSize();
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
@@ -168,7 +168,7 @@ namespace M {
   {
     const FwSizeType sizeDelta =
       sizeof(FwDpIdType) +
-      M::ActiveTest_Data::SERIALIZED_SIZE;
+      elt.serializedSize();
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
       const FwDpIdType id = this->m_baseId + RecordId::DataRecord;

--- a/compiler/tools/fpp-to-cpp/test/component/base/ArrayAliasArrayArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ArrayAliasArrayArrayAc.ref.cpp
@@ -170,6 +170,16 @@ Fw::SerializeStatus ArrayAliasArray ::
   return status;
 }
 
+FwSizeType ArrayAliasArray ::
+  serializedSize() const
+{
+  FwSizeType size = 0;
+  for (U32 index = 0; index < SIZE; index++) {
+    size += this->elements[index].serializedSize();
+  }
+  return size;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void ArrayAliasArray ::

--- a/compiler/tools/fpp-to-cpp/test/component/base/ArrayAliasArrayArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ArrayAliasArrayArrayAc.ref.hpp
@@ -139,6 +139,9 @@ class ArrayAliasArray :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert array to string

--- a/compiler/tools/fpp-to-cpp/test/component/base/ArrayAliasArrayArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ArrayAliasArrayArrayAc.ref.hpp
@@ -139,7 +139,7 @@ class ArrayAliasArray :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the array
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveGetProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveGetProductsComponentAc.ref.cpp
@@ -72,7 +72,7 @@ Fw::SerializeStatus PassiveGetProductsComponentBase::DpContainer ::
 {
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    PassiveGetProducts_Data::SERIALIZED_SIZE;
+    elt.serializedSize();
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveGuardedProductsComponentAc.ref.cpp
@@ -72,7 +72,7 @@ Fw::SerializeStatus PassiveGuardedProductsComponentBase::DpContainer ::
 {
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    PassiveGuardedProducts_Data::SERIALIZED_SIZE;
+    elt.serializedSize();
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductsComponentAc.ref.cpp
@@ -72,7 +72,7 @@ Fw::SerializeStatus PassiveSyncProductsComponentBase::DpContainer ::
 {
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    PassiveSyncProducts_Data::SERIALIZED_SIZE;
+    elt.serializedSize();
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
@@ -72,7 +72,7 @@ Fw::SerializeStatus PassiveTestComponentBase::DpContainer ::
 {
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    PassiveTest_Data::SERIALIZED_SIZE;
+    elt.serializedSize();
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductsComponentAc.ref.cpp
@@ -132,7 +132,7 @@ Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
 {
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    QueuedAsyncProducts_Data::SERIALIZED_SIZE;
+    elt.serializedSize();
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedGetProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedGetProductsComponentAc.ref.cpp
@@ -130,7 +130,7 @@ Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
 {
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    QueuedGetProducts_Data::SERIALIZED_SIZE;
+    elt.serializedSize();
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedGuardedProductsComponentAc.ref.cpp
@@ -130,7 +130,7 @@ Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
 {
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    QueuedGuardedProducts_Data::SERIALIZED_SIZE;
+    elt.serializedSize();
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSyncProductsComponentAc.ref.cpp
@@ -130,7 +130,7 @@ Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
 {
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    QueuedSyncProducts_Data::SERIALIZED_SIZE;
+    elt.serializedSize();
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
@@ -166,7 +166,7 @@ Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
 {
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    QueuedTest_Data::SERIALIZED_SIZE;
+    elt.serializedSize();
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;

--- a/compiler/tools/fpp-to-cpp/test/component/base/SSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SSerializableAc.ref.cpp
@@ -121,6 +121,15 @@ Fw::SerializeStatus S ::
   return status;
 }
 
+FwSizeType S ::
+  serializedSize() const
+{
+  FwSizeType size = 0;
+  size += sizeof(U32);
+  size += this->m_y.serializedSize();
+  return size;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void S ::

--- a/compiler/tools/fpp-to-cpp/test/component/base/SSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SSerializableAc.ref.hpp
@@ -97,6 +97,9 @@ class S :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert struct to string

--- a/compiler/tools/fpp-to-cpp/test/component/base/SSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SSerializableAc.ref.hpp
@@ -97,7 +97,7 @@ class S :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the struct
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/component/base/StructWithAliasSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/StructWithAliasSerializableAc.ref.cpp
@@ -160,6 +160,18 @@ Fw::SerializeStatus StructWithAlias ::
   return status;
 }
 
+FwSizeType StructWithAlias ::
+  serializedSize() const
+{
+  FwSizeType size = 0;
+  size += sizeof(AliasPrim1);
+  size += this->m_y.serializedSize();
+  size += this->m_z.serializedSize();
+  size += this->m_w.serializedSize();
+  size += this->m_q.serializedSize();
+  return size;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void StructWithAlias ::

--- a/compiler/tools/fpp-to-cpp/test/component/base/StructWithAliasSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/StructWithAliasSerializableAc.ref.hpp
@@ -107,7 +107,7 @@ class StructWithAlias :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the struct
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/component/base/StructWithAliasSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/StructWithAliasSerializableAc.ref.hpp
@@ -107,6 +107,9 @@ class StructWithAlias :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert struct to string

--- a/compiler/tools/fpp-to-cpp/test/struct/AbsTypeSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/AbsTypeSerializableAc.ref.cpp
@@ -103,6 +103,14 @@ Fw::SerializeStatus AbsType ::
   return status;
 }
 
+FwSizeType AbsType ::
+  serializedSize() const
+{
+  FwSizeType size = 0;
+  size += T::SERIALIZED_SIZE;
+  return size;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void AbsType ::

--- a/compiler/tools/fpp-to-cpp/test/struct/AbsTypeSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/AbsTypeSerializableAc.ref.hpp
@@ -93,7 +93,7 @@ class AbsType :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the struct
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/struct/AbsTypeSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/AbsTypeSerializableAc.ref.hpp
@@ -93,6 +93,9 @@ class AbsType :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert struct to string

--- a/compiler/tools/fpp-to-cpp/test/struct/AliasTypeSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/AliasTypeSerializableAc.ref.cpp
@@ -180,6 +180,18 @@ Fw::SerializeStatus AliasType ::
   return status;
 }
 
+FwSizeType AliasType ::
+  serializedSize() const
+{
+  FwSizeType size = 0;
+  size += sizeof(U16Alias);
+  size += TAlias::SERIALIZED_SIZE;
+  for (U32 index = 0; index < 10; index++) {
+    size += this->m_z[index].serializedSize();
+  }
+  return size;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void AliasType ::

--- a/compiler/tools/fpp-to-cpp/test/struct/AliasTypeSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/AliasTypeSerializableAc.ref.hpp
@@ -117,6 +117,9 @@ class AliasType :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert struct to string

--- a/compiler/tools/fpp-to-cpp/test/struct/AliasTypeSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/AliasTypeSerializableAc.ref.hpp
@@ -117,7 +117,7 @@ class AliasType :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the struct
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/struct/C_SSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/C_SSerializableAc.ref.cpp
@@ -103,6 +103,14 @@ Fw::SerializeStatus C_S ::
   return status;
 }
 
+FwSizeType C_S ::
+  serializedSize() const
+{
+  FwSizeType size = 0;
+  size += sizeof(U32);
+  return size;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void C_S ::

--- a/compiler/tools/fpp-to-cpp/test/struct/C_SSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/C_SSerializableAc.ref.hpp
@@ -92,6 +92,9 @@ class C_S :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert struct to string

--- a/compiler/tools/fpp-to-cpp/test/struct/C_SSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/C_SSerializableAc.ref.hpp
@@ -92,7 +92,7 @@ class C_S :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the struct
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/struct/DefaultSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/DefaultSerializableAc.ref.cpp
@@ -134,6 +134,16 @@ Fw::SerializeStatus Default ::
   return status;
 }
 
+FwSizeType Default ::
+  serializedSize() const
+{
+  FwSizeType size = 0;
+  size += sizeof(U32);
+  size += this->m_mS1.serializedSize();
+  size += sizeof(F64);
+  return size;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void Default ::

--- a/compiler/tools/fpp-to-cpp/test/struct/DefaultSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/DefaultSerializableAc.ref.hpp
@@ -98,6 +98,9 @@ class Default :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert struct to string

--- a/compiler/tools/fpp-to-cpp/test/struct/DefaultSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/DefaultSerializableAc.ref.hpp
@@ -98,7 +98,7 @@ class Default :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the struct
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/struct/EnumSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/EnumSerializableAc.ref.cpp
@@ -151,6 +151,15 @@ Fw::SerializeStatus Enum ::
   return status;
 }
 
+FwSizeType Enum ::
+  serializedSize() const
+{
+  FwSizeType size = 0;
+  size += M::E::SERIALIZED_SIZE;
+  size += M::E::SERIALIZED_SIZE * 3;
+  return size;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void Enum ::

--- a/compiler/tools/fpp-to-cpp/test/struct/EnumSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/EnumSerializableAc.ref.hpp
@@ -112,6 +112,9 @@ class Enum :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert struct to string

--- a/compiler/tools/fpp-to-cpp/test/struct/EnumSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/EnumSerializableAc.ref.hpp
@@ -112,7 +112,7 @@ class Enum :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the struct
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/struct/FormatSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/FormatSerializableAc.ref.cpp
@@ -316,6 +316,30 @@ Fw::SerializeStatus Format ::
   return status;
 }
 
+FwSizeType Format ::
+  serializedSize() const
+{
+  FwSizeType size = 0;
+  size += sizeof(I32);
+  size += sizeof(U32);
+  size += sizeof(I32);
+  size += sizeof(U32);
+  size += sizeof(I32);
+  size += sizeof(U32);
+  size += sizeof(I32);
+  size += sizeof(U32);
+  size += sizeof(I32);
+  size += sizeof(U32);
+  size += sizeof(F32);
+  size += sizeof(F32);
+  size += sizeof(F32);
+  size += sizeof(F32);
+  size += sizeof(F32);
+  size += sizeof(F32);
+  size += sizeof(F32);
+  return size;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void Format ::

--- a/compiler/tools/fpp-to-cpp/test/struct/FormatSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/FormatSerializableAc.ref.hpp
@@ -126,7 +126,7 @@ class Format :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the struct
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/struct/FormatSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/FormatSerializableAc.ref.hpp
@@ -126,6 +126,9 @@ class Format :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert struct to string

--- a/compiler/tools/fpp-to-cpp/test/struct/IncludedSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/IncludedSerializableAc.ref.cpp
@@ -103,6 +103,14 @@ Fw::SerializeStatus Included ::
   return status;
 }
 
+FwSizeType Included ::
+  serializedSize() const
+{
+  FwSizeType size = 0;
+  size += sizeof(U32);
+  return size;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void Included ::

--- a/compiler/tools/fpp-to-cpp/test/struct/IncludedSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/IncludedSerializableAc.ref.hpp
@@ -92,6 +92,9 @@ class Included :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert struct to string

--- a/compiler/tools/fpp-to-cpp/test/struct/IncludedSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/IncludedSerializableAc.ref.hpp
@@ -92,7 +92,7 @@ class Included :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the struct
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/struct/IncludingSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/IncludingSerializableAc.ref.cpp
@@ -103,6 +103,14 @@ Fw::SerializeStatus Including ::
   return status;
 }
 
+FwSizeType Including ::
+  serializedSize() const
+{
+  FwSizeType size = 0;
+  size += this->m_x.serializedSize();
+  return size;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void Including ::

--- a/compiler/tools/fpp-to-cpp/test/struct/IncludingSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/IncludingSerializableAc.ref.hpp
@@ -93,6 +93,9 @@ class Including :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert struct to string

--- a/compiler/tools/fpp-to-cpp/test/struct/IncludingSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/IncludingSerializableAc.ref.hpp
@@ -93,7 +93,7 @@ class Including :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the struct
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules1SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules1SerializableAc.ref.cpp
@@ -123,6 +123,15 @@ namespace M {
     return status;
   }
 
+  FwSizeType Modules1 ::
+    serializedSize() const
+  {
+    FwSizeType size = 0;
+    size += sizeof(U32);
+    size += sizeof(F32);
+    return size;
+  }
+
 #if FW_SERIALIZABLE_TO_STRING
 
   void Modules1 ::

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules1SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules1SerializableAc.ref.hpp
@@ -98,6 +98,9 @@ namespace M {
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 
+      //! Serialized Size
+      FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
       //! Convert struct to string

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules1SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules1SerializableAc.ref.hpp
@@ -98,7 +98,7 @@ namespace M {
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 
-      //! Serialized Size
+      //! Get the dynamic serialized size of the struct
       FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules2SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules2SerializableAc.ref.cpp
@@ -105,6 +105,14 @@ namespace M {
     return status;
   }
 
+  FwSizeType Modules2 ::
+    serializedSize() const
+  {
+    FwSizeType size = 0;
+    size += this->m_x.serializedSize();
+    return size;
+  }
+
 #if FW_SERIALIZABLE_TO_STRING
 
   void Modules2 ::

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules2SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules2SerializableAc.ref.hpp
@@ -95,6 +95,9 @@ namespace M {
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 
+      //! Serialized Size
+      FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
       //! Convert struct to string

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules2SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules2SerializableAc.ref.hpp
@@ -95,7 +95,7 @@ namespace M {
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 
-      //! Serialized Size
+      //! Get the dynamic serialized size of the struct
       FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules3SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules3SerializableAc.ref.cpp
@@ -151,6 +151,17 @@ Fw::SerializeStatus Modules3 ::
   return status;
 }
 
+FwSizeType Modules3 ::
+  serializedSize() const
+{
+  FwSizeType size = 0;
+  size += this->m_x.serializedSize();
+  for (U32 index = 0; index < 3; index++) {
+    size += this->m_arr[index].serializedSize();
+  }
+  return size;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void Modules3 ::

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules3SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules3SerializableAc.ref.hpp
@@ -112,6 +112,9 @@ class Modules3 :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert struct to string

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules3SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules3SerializableAc.ref.hpp
@@ -112,7 +112,7 @@ class Modules3 :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the struct
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules4SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules4SerializableAc.ref.cpp
@@ -165,6 +165,19 @@ Fw::SerializeStatus Modules4 ::
   return status;
 }
 
+FwSizeType Modules4 ::
+  serializedSize() const
+{
+  FwSizeType size = 0;
+  for (U32 index = 0; index < 3; index++) {
+    size += this->m_arr1[index].serializedSize();
+  }
+  for (U32 index = 0; index < 6; index++) {
+    size += this->m_arr2[index].serializedSize();
+  }
+  return size;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void Modules4 ::

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules4SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules4SerializableAc.ref.hpp
@@ -115,6 +115,9 @@ class Modules4 :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert struct to string

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules4SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules4SerializableAc.ref.hpp
@@ -115,7 +115,7 @@ class Modules4 :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the struct
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/struct/PrimitiveSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/PrimitiveSerializableAc.ref.cpp
@@ -303,6 +303,25 @@ Fw::SerializeStatus Primitive ::
   return status;
 }
 
+FwSizeType Primitive ::
+  serializedSize() const
+{
+  FwSizeType size = 0;
+  size += sizeof(F32) * 3;
+  size += sizeof(F64);
+  size += sizeof(I16);
+  size += sizeof(I32);
+  size += sizeof(I64);
+  size += sizeof(I8);
+  size += sizeof(U16);
+  size += sizeof(U32);
+  size += sizeof(U64);
+  size += sizeof(U8);
+  size += sizeof(U8);
+  size += this->m_m_string.serializedSize();
+  return size;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void Primitive ::

--- a/compiler/tools/fpp-to-cpp/test/struct/PrimitiveSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/PrimitiveSerializableAc.ref.hpp
@@ -143,7 +143,7 @@ class Primitive :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the struct
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/struct/PrimitiveSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/PrimitiveSerializableAc.ref.hpp
@@ -143,6 +143,9 @@ class Primitive :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert struct to string

--- a/compiler/tools/fpp-to-cpp/test/struct/PrimitiveStructSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/PrimitiveStructSerializableAc.ref.cpp
@@ -103,6 +103,14 @@ Fw::SerializeStatus PrimitiveStruct ::
   return status;
 }
 
+FwSizeType PrimitiveStruct ::
+  serializedSize() const
+{
+  FwSizeType size = 0;
+  size += this->m_s1.serializedSize();
+  return size;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void PrimitiveStruct ::

--- a/compiler/tools/fpp-to-cpp/test/struct/PrimitiveStructSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/PrimitiveStructSerializableAc.ref.hpp
@@ -93,6 +93,9 @@ class PrimitiveStruct :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert struct to string

--- a/compiler/tools/fpp-to-cpp/test/struct/PrimitiveStructSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/PrimitiveStructSerializableAc.ref.hpp
@@ -93,7 +93,7 @@ class PrimitiveStruct :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the struct
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/struct/SSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/SSerializableAc.ref.cpp
@@ -103,6 +103,14 @@ Fw::SerializeStatus S ::
   return status;
 }
 
+FwSizeType S ::
+  serializedSize() const
+{
+  FwSizeType size = 0;
+  size += sizeof(U32);
+  return size;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void S ::

--- a/compiler/tools/fpp-to-cpp/test/struct/SSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/SSerializableAc.ref.hpp
@@ -93,7 +93,7 @@ class S :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the struct
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/struct/SSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/SSerializableAc.ref.hpp
@@ -93,6 +93,9 @@ class S :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert struct to string

--- a/compiler/tools/fpp-to-cpp/test/struct/StringArraySerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/StringArraySerializableAc.ref.cpp
@@ -163,6 +163,17 @@ Fw::SerializeStatus StringArray ::
   return status;
 }
 
+FwSizeType StringArray ::
+  serializedSize() const
+{
+  FwSizeType size = 0;
+  size += this->m_s1.serializedSize();
+  for (U32 index = 0; index < 16; index++) {
+    size += this->m_s2[index].serializedSize();
+  }
+  return size;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void StringArray ::

--- a/compiler/tools/fpp-to-cpp/test/struct/StringArraySerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/StringArraySerializableAc.ref.hpp
@@ -111,6 +111,9 @@ class StringArray :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert struct to string

--- a/compiler/tools/fpp-to-cpp/test/struct/StringArraySerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/StringArraySerializableAc.ref.hpp
@@ -111,7 +111,7 @@ class StringArray :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the struct
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING

--- a/compiler/tools/fpp-to-cpp/test/struct/StringSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/StringSerializableAc.ref.cpp
@@ -121,6 +121,15 @@ Fw::SerializeStatus String ::
   return status;
 }
 
+FwSizeType String ::
+  serializedSize() const
+{
+  FwSizeType size = 0;
+  size += this->m_s1.serializedSize();
+  size += this->m_s2.serializedSize();
+  return size;
+}
+
 #if FW_SERIALIZABLE_TO_STRING
 
 void String ::

--- a/compiler/tools/fpp-to-cpp/test/struct/StringSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/StringSerializableAc.ref.hpp
@@ -96,6 +96,9 @@ class String :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
+    //! Serialized Size
+    FwSizeType serializedSize() const;
+
 #if FW_SERIALIZABLE_TO_STRING
 
     //! Convert struct to string

--- a/compiler/tools/fpp-to-cpp/test/struct/StringSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/StringSerializableAc.ref.hpp
@@ -96,7 +96,7 @@ class String :
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 
-    //! Serialized Size
+    //! Get the dynamic serialized size of the struct
     FwSizeType serializedSize() const;
 
 #if FW_SERIALIZABLE_TO_STRING


### PR DESCRIPTION
Use dynamic string size to compute record size for array and struct records.

Closes #759. 