### PR TITLE
Deprecate serialize/deserialize in favor of [de]serialize[From/To]

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/ArrayCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ArrayCppWriter.scala
@@ -446,7 +446,7 @@ case class ArrayCppWriter (
       ),
       functionClassMember(
         Some("Serialization"),
-        "serialize",
+        "serializeTo",
         List(
           CppDoc.Function.Param(
             CppDoc.Type("Fw::SerializeBufferBase&"),
@@ -458,7 +458,7 @@ case class ArrayCppWriter (
         List(
           lines("Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;"),
           indexIterator(
-            line("status = buffer.serialize((*this)[index]);") ::
+            line("status = buffer.serializeFrom((*this)[index]);") ::
               wrapInIf("status != Fw::FW_SERIALIZE_OK", lines("return status;")),
           ),
           lines("return status;"),
@@ -468,7 +468,7 @@ case class ArrayCppWriter (
       ),
       functionClassMember(
         Some("Deserialization"),
-        "deserialize",
+        "deserializeFrom",
         List(
           CppDoc.Function.Param(
             CppDoc.Type("Fw::SerializeBufferBase&"),
@@ -480,7 +480,7 @@ case class ArrayCppWriter (
         List(
           lines("Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;"),
           indexIterator(
-            line("status = buffer.deserialize((*this)[index]);") ::
+            line("status = buffer.deserializeTo((*this)[index]);") ::
               wrapInIf("status != Fw::FW_SERIALIZE_OK", lines("return status;")),
           ),
           lines("return status;"),

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCommands.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCommands.scala
@@ -158,7 +158,7 @@ case class ComponentCommands (
                       |Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
                       |
                       |// Serialize for IPC
-                      |_status = msg.serialize(static_cast<FwEnumStoreType>(${commandCppConstantName(cmd)}));
+                      |_status = msg.serializeFrom(static_cast<FwEnumStoreType>(${commandCppConstantName(cmd)}));
                       |FW_ASSERT (
                       |  _status == Fw::FW_SERIALIZE_OK,
                       |  static_cast<FwAssertArgType>(_status)
@@ -171,7 +171,7 @@ case class ComponentCommands (
                 intersperseBlankLines(
                   List("port", "opCode", "cmdSeq", "args").map(s =>
                     lines(
-                      s"""|_status = msg.serialize($s);
+                      s"""|_status = msg.serializeFrom($s);
                           |FW_ASSERT (
                           |  _status == Fw::FW_SERIALIZE_OK,
                           |  static_cast<FwAssertArgType>(_status)
@@ -207,7 +207,7 @@ case class ComponentCommands (
                   cmdParamTypeMap(opcode).map((n, tn, _) =>
                     lines(
                       s"""|$tn $n;
-                          |_status = args.deserialize($n);
+                          |_status = args.deserializeTo($n);
                           |if (_status != Fw::FW_SERIALIZE_OK) {
                           |  if (this->${portVariableName(cmdRespPort.get)}[0].isConnected()) {
                           |    this->${portVariableName(cmdRespPort.get)}[0].invoke(

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriter.scala
@@ -622,7 +622,7 @@ case class ComponentCppWriter (
                 lines(
                   s"""|// Deserialize argument $n
                       |$varDecl
-                      |_deserStatus = _msg.deserialize($n);
+                      |_deserStatus = _msg.deserializeTo($n);
                       |FW_ASSERT(
                       |  _deserStatus == Fw::FW_SERIALIZE_OK,
                       |  static_cast<FwAssertArgType>(_deserStatus)
@@ -646,7 +646,7 @@ case class ComponentCppWriter (
               |  handBuff,
               |  static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
               |);
-              |_deserStatus = _msg.deserialize(serHandBuff);
+              |_deserStatus = _msg.deserializeTo(serHandBuff);
               |FW_ASSERT(
               |  _deserStatus == Fw::FW_SERIALIZE_OK,
               |  static_cast<FwAssertArgType>(_deserStatus)
@@ -672,7 +672,7 @@ case class ComponentCppWriter (
           lines(
             """|// Deserialize opcode
                |FwOpcodeType _opCode = 0;
-               |_deserStatus = _msg.deserialize(_opCode);
+               |_deserStatus = _msg.deserializeTo(_opCode);
                |FW_ASSERT (
                |  _deserStatus == Fw::FW_SERIALIZE_OK,
                |  static_cast<FwAssertArgType>(_deserStatus)
@@ -680,7 +680,7 @@ case class ComponentCppWriter (
                |
                |// Deserialize command sequence
                |U32 _cmdSeq = 0;
-               |_deserStatus = _msg.deserialize(_cmdSeq);
+               |_deserStatus = _msg.deserializeTo(_cmdSeq);
                |FW_ASSERT (
                |  _deserStatus == Fw::FW_SERIALIZE_OK,
                |  static_cast<FwAssertArgType>(_deserStatus)
@@ -688,7 +688,7 @@ case class ComponentCppWriter (
                |
                |// Deserialize command argument buffer
                |Fw::CmdArgBuffer args;
-               |_deserStatus = _msg.deserialize(args);
+               |_deserStatus = _msg.deserializeTo(args);
                |FW_ASSERT (
                |  _deserStatus == Fw::FW_SERIALIZE_OK,
                |  static_cast<FwAssertArgType>(_deserStatus)
@@ -703,7 +703,7 @@ case class ComponentCppWriter (
               lines(
                 s"""|// Deserialize argument $n
                     |$tn $n;
-                    |_deserStatus = args.deserialize($n);
+                    |_deserStatus = args.deserializeTo($n);
                     |if (_deserStatus != Fw::FW_SERIALIZE_OK) {
                     |  if (this->$cmdRespVarName[0].isConnected()) {
                     |    this->cmdResponse_out(
@@ -757,7 +757,7 @@ case class ComponentCppWriter (
             portParamTypeMap(p.getUnqualifiedName).map((n, tn, _) =>
               lines(
                 s"""|$tn $n;
-                    |_deserStatus = _msg.deserialize($n);
+                    |_deserStatus = _msg.deserializeTo($n);
                     |
                     |// Internal interface should always deserialize
                     |FW_ASSERT(
@@ -853,7 +853,7 @@ case class ComponentCppWriter (
                    |_msg.resetDeser();
                    |
                    |FwEnumStoreType _desMsg = 0;
-                   |Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+                   |Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
                    |FW_ASSERT(
                    |  _deserStatus == Fw::FW_SERIALIZE_OK,
                    |  static_cast<FwAssertArgType>(_deserStatus)
@@ -869,7 +869,7 @@ case class ComponentCppWriter (
               lines(
                 """|
                    |FwIndexType portNum = 0;
-                   |_deserStatus = _msg.deserialize(portNum);
+                   |_deserStatus = _msg.deserializeTo(portNum);
                    |FW_ASSERT(
                    |  _deserStatus == Fw::FW_SERIALIZE_OK,
                    |  static_cast<FwAssertArgType>(_deserStatus)

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentDataProducts.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentDataProducts.scala
@@ -433,8 +433,8 @@ case class ComponentDataProducts (
       // For strings this is a truncated serialization
       val serialExpr = t.getUnderlyingType match {
         case ts: Type.String =>
-          "elt.serialize(this->m_dataBuffer, stringSize)"
-        case _ => "this->m_dataBuffer.serialize(elt)"
+          "elt.serializeTo(this->m_dataBuffer, stringSize)"
+        case _ => "this->m_dataBuffer.serializeFrom(elt)"
       }
       // Construct the function body
       val body = lines(
@@ -442,7 +442,7 @@ case class ComponentDataProducts (
             |Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
             |if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
             |  const FwDpIdType id = this->m_baseId + RecordId::$name;
-            |  status = this->m_dataBuffer.serialize(id);
+            |  status = this->m_dataBuffer.serializeFrom(id);
             |  FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
             |  status = $serialExpr;
             |  FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
@@ -503,20 +503,20 @@ case class ComponentDataProducts (
       val serializeElts = (t.getUnderlyingType match {
         // Optimize the U8 case
         case Type.U8 =>
-          """|  status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
+          """|  status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
              |  FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));"""
         // Handle the string case
         case ts: Type.String =>
           s"""|  for (FwSizeType i = 0; i < size; i++) {
               |    const Fw::StringBase *const sbPtr = array[i];
               |    FW_ASSERT(sbPtr != nullptr);
-              |    status = sbPtr->serialize(this->m_dataBuffer, stringSize);
+              |    status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
               |    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
               |  }"""
         // Handle the general case
         case _ =>
           """|  for (FwSizeType i = 0; i < size; i++) {
-             |    status = this->m_dataBuffer.serialize(array[i]);
+             |    status = this->m_dataBuffer.serializeFrom(array[i]);
              |    FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
              |  }"""
       }).stripMargin
@@ -529,7 +529,7 @@ case class ComponentDataProducts (
             |Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
             |if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
             |  const FwDpIdType id = this->m_baseId + RecordId::$name;
-            |  status = this->m_dataBuffer.serialize(id);
+            |  status = this->m_dataBuffer.serializeFrom(id);
             |  FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
             |  status = this->m_dataBuffer.serializeSize(size);
             |  FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentEvents.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentEvents.scala
@@ -96,20 +96,20 @@ case class ComponentEvents (
                 event.aNode._2.data.severity match {
                   case Ast.SpecEvent.Fatal if eventParamTypeMap(id).nonEmpty => lines(
                     s"""|// Serialize the number of arguments
-                        |_status = _logBuff.serialize(static_cast<U8>(${eventParamTypeMap(id).length} + 1));
+                        |_status = _logBuff.serializeFrom(static_cast<U8>(${eventParamTypeMap(id).length} + 1));
                         |FW_ASSERT(
                         |  _status == Fw::FW_SERIALIZE_OK,
                         |  static_cast<FwAssertArgType>(_status)
                         |);
                         |
                         |// For FATAL, add stack size of 4 and a dummy entry. No support for stacks yet.
-                        |_status = _logBuff.serialize(static_cast<U8>(4));
+                        |_status = _logBuff.serializeFrom(static_cast<U8>(4));
                         |FW_ASSERT(
                         |  _status == Fw::FW_SERIALIZE_OK,
                         |  static_cast<FwAssertArgType>(_status)
                         |);
                         |
-                        |_status = _logBuff.serialize(static_cast<U32>(0));
+                        |_status = _logBuff.serializeFrom(static_cast<U32>(0));
                         |FW_ASSERT(
                         |  _status == Fw::FW_SERIALIZE_OK,
                         |  static_cast<FwAssertArgType>(_status)
@@ -118,7 +118,7 @@ case class ComponentEvents (
                   )
                   case _ => lines(
                     s"""|// Serialize the number of arguments
-                        |_status = _logBuff.serialize(static_cast<U8>(${eventParamTypeMap(id).length}));
+                        |_status = _logBuff.serializeFrom(static_cast<U8>(${eventParamTypeMap(id).length}));
                         |FW_ASSERT(
                         |  _status == Fw::FW_SERIALIZE_OK,
                         |  static_cast<FwAssertArgType>(_status)
@@ -136,12 +136,12 @@ case class ComponentEvents (
                       case t: Type.String =>
                         val serialSize = writeStringSize(s, t)
                         lines(
-                          s"_status = $name.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, $serialSize));"
+                          s"_status = $name.serializeTo(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, $serialSize));"
                         )
                       case t => lines(
                         s"""|#if FW_AMPCS_COMPATIBLE
                             |// Serialize the argument size
-                            |_status = _logBuff.serialize(
+                            |_status = _logBuff.serializeFrom(
                             |  static_cast<U8>(${writeSerializedSizeExpr(s, t, typeName)})
                             |);
                             |FW_ASSERT(
@@ -149,7 +149,7 @@ case class ComponentEvents (
                             |  static_cast<FwAssertArgType>(_status)
                             |);
                             |#endif
-                            |_status = _logBuff.serialize($name);
+                            |_status = _logBuff.serializeFrom($name);
                             |"""
                       )
                     },

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentExternalStateMachines.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentExternalStateMachines.scala
@@ -89,32 +89,32 @@ case class ComponentExternalStateMachines(
               |Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
               |
               |// Serialize the message ID
-              |_status = _msg.serialize(static_cast<FwEnumStoreType>($externalStateMachineCppConstantName));
+              |_status = _msg.serializeFrom(static_cast<FwEnumStoreType>($externalStateMachineCppConstantName));
               |FW_ASSERT (
               |  _status == Fw::FW_SERIALIZE_OK,
               |  static_cast<FwAssertArgType>(_status)
               |);
               |
               |// Fake port number to make message dequeue work
-              |_status = _msg.serialize(static_cast<FwIndexType>(0));
+              |_status = _msg.serializeFrom(static_cast<FwIndexType>(0));
               |FW_ASSERT (
               |  _status == Fw::FW_SERIALIZE_OK,
               |  static_cast<FwAssertArgType>(_status)
               |);
               |
-              |_status = _msg.serialize(static_cast<FwEnumStoreType>(${writeSmIdName(smi.getName)}));
+              |_status = _msg.serializeFrom(static_cast<FwEnumStoreType>(${writeSmIdName(smi.getName)}));
               |FW_ASSERT(
               |  _status == Fw::FW_SERIALIZE_OK,
               |  static_cast<FwAssertArgType>(_status)
               |);
               |
-              |_status = _msg.serialize(static_cast<FwEnumStoreType>(signal));
+              |_status = _msg.serializeFrom(static_cast<FwEnumStoreType>(signal));
               |FW_ASSERT(
               |  _status == Fw::FW_SERIALIZE_OK,
               |  static_cast<FwAssertArgType>(_status)
               |);
               |
-              |_status = _msg.serialize(data);
+              |_status = _msg.serializeFrom(data);
               |FW_ASSERT(
               |  _status == Fw::FW_SERIALIZE_OK,
               |  static_cast<FwAssertArgType>(_status)
@@ -151,7 +151,7 @@ case class ComponentExternalStateMachines(
   private val writeDeserializeSmVars = lines(
     """|// Deserialize the state machine ID to an FwEnumStoreType
        |FwEnumStoreType enumStoreSmId = 0;
-       |_deserStatus = _msg.deserialize(enumStoreSmId);
+       |_deserStatus = _msg.deserializeTo(enumStoreSmId);
        |FW_ASSERT(
        |  _deserStatus == Fw::FW_SERIALIZE_OK,
        |  static_cast<FwAssertArgType>(_deserStatus)
@@ -163,7 +163,7 @@ case class ComponentExternalStateMachines(
        |// This value will be cast to the correct type in the
        |// switch statement that calls the state machine update function.
        |FwEnumStoreType enumStoreSmSignal = 0;
-       |_deserStatus = _msg.deserialize(enumStoreSmSignal);
+       |_deserStatus = _msg.deserializeTo(enumStoreSmSignal);
        |FW_ASSERT(
        |  _deserStatus == Fw::FW_SERIALIZE_OK,
        |  static_cast<FwAssertArgType>(_deserStatus)
@@ -171,7 +171,7 @@ case class ComponentExternalStateMachines(
        |
        |// Deserialize the state machine data
        |Fw::SmSignalBuffer data;
-       |_deserStatus = _msg.deserialize(data);
+       |_deserStatus = _msg.deserializeTo(data);
        |FW_ASSERT(
        |  Fw::FW_SERIALIZE_OK == _deserStatus,
        |  static_cast<FwAssertArgType>(_deserStatus)

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentInputPorts.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentInputPorts.scala
@@ -134,7 +134,7 @@ case class ComponentInputPorts(
           },
           lines(
             s"""|// Serialize message ID
-                |_status = $bufferName.serialize(
+                |_status = $bufferName.serializeFrom(
                 |  static_cast<FwEnumStoreType>(${portCppConstantName(p)})
                 |);
                 |FW_ASSERT(
@@ -143,7 +143,7 @@ case class ComponentInputPorts(
                 |);
                 |
                 |// Serialize port number
-                |_status = $bufferName.serialize(portNum);
+                |_status = $bufferName.serializeFrom(portNum);
                 |FW_ASSERT(
                 |  _status == Fw::FW_SERIALIZE_OK,
                 |  static_cast<FwAssertArgType>(_status)
@@ -155,8 +155,8 @@ case class ComponentInputPorts(
               val serializeExpr = tyOpt match {
                 case Some(t: Type.String) =>
                   val serialSize = writeStringSize(s, t)
-                  s"$n.serialize($bufferName, $serialSize)"
-                case _ => s"$bufferName.serialize($n)"
+                  s"$n.serializeTo($bufferName, $serialSize)"
+                case _ => s"$bufferName.serializeFrom($n)"
               }
               lines(
               s"""|// Serialize argument $n

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentInternalPort.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentInternalPort.scala
@@ -79,14 +79,14 @@ case class ComponentInternalPort (
                     |Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
                     |
                     |// Serialize the message ID
-                    |_status = msg.serialize(static_cast<FwEnumStoreType>(${internalPortCppConstantName(p)}));
+                    |_status = msg.serializeFrom(static_cast<FwEnumStoreType>(${internalPortCppConstantName(p)}));
                     |FW_ASSERT (
                     |  _status == Fw::FW_SERIALIZE_OK,
                     |  static_cast<FwAssertArgType>(_status)
                     |);
                     |
                     |// Fake port number to make message dequeue work
-                    |_status = msg.serialize(static_cast<FwIndexType>(0));
+                    |_status = msg.serializeFrom(static_cast<FwIndexType>(0));
                     |FW_ASSERT (
                     |  _status == Fw::FW_SERIALIZE_OK,
                     |  static_cast<FwAssertArgType>(_status)
@@ -96,7 +96,7 @@ case class ComponentInternalPort (
               intersperseBlankLines(
                 getPortParams(p).map((n, _, _) =>
                   lines(
-                    s"""|_status = msg.serialize($n);
+                    s"""|_status = msg.serializeFrom($n);
                         |FW_ASSERT(
                         |  _status == Fw::FW_SERIALIZE_OK,
                         |  static_cast<FwAssertArgType>(_status)

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentInternalStateMachines.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentInternalStateMachines.scala
@@ -184,11 +184,11 @@ case class ComponentInternalStateMachines(
             |FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
             |
             |// Deserialize the state machine ID
-            |status = buffer.deserialize(smId);
+            |status = buffer.deserializeTo(smId);
             |FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
             |
             |// Deserialize the signal
-            |status = buffer.deserialize(signal);
+            |status = buffer.deserializeTo(signal);
             |FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));"""
       ),
       CppDoc.Function.Static
@@ -309,8 +309,8 @@ case class ComponentInternalStateMachines(
             val serializeExpr = s.a.typeMap(id).getUnderlyingType match {
               case t: Type.String =>
                 val serialSize = writeStringSize(s, t)
-                s"$paramName.serialize(buffer, $serialSize)"
-              case _ => s"buffer.serialize($paramName)"
+                s"$paramName.serializeTo(buffer, $serialSize)"
+              case _ => s"buffer.serializeFrom($paramName)"
             }
             lines(
               s"""|// Serialize the signal data
@@ -375,19 +375,19 @@ case class ComponentInternalStateMachines(
         s"""|Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
             |
             |// Serialize the message type
-            |status = buffer.serialize(static_cast<FwEnumStoreType>($internalStateMachineMsgType));
+            |status = buffer.serializeFrom(static_cast<FwEnumStoreType>($internalStateMachineMsgType));
             |FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
             |
             |// Serialize the port number
-            |status = buffer.serialize(static_cast<FwIndexType>(0));
+            |status = buffer.serializeFrom(static_cast<FwIndexType>(0));
             |FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
             |
             |// Serialize the state machine ID
-            |status = buffer.serialize(static_cast<FwEnumStoreType>(smId));
+            |status = buffer.serializeFrom(static_cast<FwEnumStoreType>(smId));
             |FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
             |
             |// Serialize the signal
-            |status = buffer.serialize(static_cast<FwEnumStoreType>(signal));
+            |status = buffer.serializeFrom(static_cast<FwEnumStoreType>(signal));
             |FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));"""
       )
     )
@@ -480,7 +480,7 @@ case class ComponentInternalStateMachines(
                       lines(
                         s"""|// Deserialize the data
                             |${writeVarDecl(s, cppTypeName, "value", t)}
-                            |const Fw::SerializeStatus status = buffer.deserialize(value);
+                            |const Fw::SerializeStatus status = buffer.deserializeTo(value);
                             |FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));"""
                       )
                     case None => Nil

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentParameters.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentParameters.scala
@@ -203,7 +203,7 @@ case class ComponentParameters (
                       ),
                       wrapInIfElse(
                         s"this->${paramValidityFlagName(param.getName)} == Fw::ParamValid::VALID",
-                        line(s"_stat = _buff.deserialize(this->${paramVariableName(param.getName)});") ::
+                        line(s"_stat = _buff.deserializeTo(this->${paramVariableName(param.getName)});") ::
                           wrapInIf(
                             "_stat != Fw::FW_SERIALIZE_OK",
                             param.default match {
@@ -325,7 +325,7 @@ case class ComponentParameters (
                   |// Get the external parameter from the delegate
                   |Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
                   |if(_stat == Fw::FW_SERIALIZE_OK) {
-                  |  _stat = _getBuff.deserialize(_local);
+                  |  _stat = _getBuff.deserializeTo(_local);
                   |  FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
                   |  valid = Fw::ParamValid::VALID;
                   |} else {
@@ -398,7 +398,7 @@ case class ComponentParameters (
           } else {
             lines(
               s"""|${writeParamType(param.paramType, "Fw::ParamString")} _localVal{};
-                  |const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+                  |const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
                   |if (_stat != Fw::FW_SERIALIZE_OK) {
                   |  return Fw::CmdResponse::VALIDATION_ERROR;
                   |}
@@ -460,7 +460,7 @@ case class ComponentParameters (
                   lines(
                     s"""|this->m_paramLock.lock();
                         |
-                        |_stat = _saveBuff.serialize(${paramVariableName(param.getName)});
+                        |_stat = _saveBuff.serializeFrom(${paramVariableName(param.getName)});
                         |
                         |this->m_paramLock.unLock();
                         |"""

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentTelemetry.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentTelemetry.scala
@@ -114,9 +114,9 @@ case class ComponentTelemetry (
               channel.channelType.getUnderlyingType match {
                 case t: Type.String =>
                   val serialSize = writeStringSize(s, t)
-                  s"Fw::SerializeStatus _stat = arg.serialize(_tlmBuff, FW_MIN(FW_TLM_STRING_MAX_SIZE, $serialSize));"
+                  s"Fw::SerializeStatus _stat = arg.serializeTo(_tlmBuff, FW_MIN(FW_TLM_STRING_MAX_SIZE, $serialSize));"
                 case _ =>
-                  "Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);"
+                  "Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);"
               }
             ),
             lines(

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentTesterBaseWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentTesterBaseWriter.scala
@@ -746,7 +746,7 @@ case class ComponentTesterBaseWriter(
                   t.getUnderlyingType match {
                     case ts: Type.String =>
                       lines(
-                        s"""|_status = $varName.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+                        s"""|_status = $varName.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
                             |FW_ASSERT(
                             |  _status == Fw::FW_SERIALIZE_OK,
                             |  static_cast<FwAssertArgType>(_status)
@@ -755,7 +755,7 @@ case class ComponentTesterBaseWriter(
                       )
                     case _ =>
                       lines(
-                        s"""|_status = buf.serialize($varName);
+                        s"""|_status = buf.serializeFrom($varName);
                             |FW_ASSERT(
                             |  _status == Fw::FW_SERIALIZE_OK,
                             |  static_cast<FwAssertArgType>(_status)
@@ -847,7 +847,7 @@ case class ComponentTesterBaseWriter(
                  |// For AMPCS, decode zero arguments
                  |Fw::SerializeStatus _zero_status = Fw::FW_SERIALIZE_OK;
                  |U8 _noArgs;
-                 |_zero_status = args.deserialize(_noArgs);
+                 |_zero_status = args.deserializeTo(_noArgs);
                  |FW_ASSERT(
                  |  _zero_status == Fw::FW_SERIALIZE_OK,
                  |  static_cast<FwAssertArgType>(_zero_status)
@@ -862,7 +862,7 @@ case class ComponentTesterBaseWriter(
                    |#if FW_AMPCS_COMPATIBLE
                    |// Deserialize the number of arguments.
                    |U8 _numArgs;
-                   |_status = args.deserialize(_numArgs);
+                   |_status = args.deserializeTo(_numArgs);
                    |FW_ASSERT(
                    |  _status == Fw::FW_SERIALIZE_OK,
                    |  static_cast<FwAssertArgType>(_status)
@@ -882,7 +882,7 @@ case class ComponentTesterBaseWriter(
                         |
                         |// For FATAL, there is a stack size of 4 and a dummy entry
                         |U8 stackArgLen;
-                        |_status = args.deserialize(stackArgLen);
+                        |_status = args.deserializeTo(stackArgLen);
                         |FW_ASSERT(
                         |    _status == Fw::FW_SERIALIZE_OK,
                         |    static_cast<FwAssertArgType>(_status)
@@ -893,7 +893,7 @@ case class ComponentTesterBaseWriter(
                         |);
                         |
                         |U32 dummyStackArg;
-                        |_status = args.deserialize(dummyStackArg);
+                        |_status = args.deserializeTo(dummyStackArg);
                         |FW_ASSERT(
                         |    _status == Fw::FW_SERIALIZE_OK,
                         |    static_cast<FwAssertArgType>(_status)
@@ -930,7 +930,7 @@ case class ComponentTesterBaseWriter(
                   |{
                   |  // Deserialize the argument size
                   |  U8 _argSize;
-                  |  _status = args.deserialize(_argSize);
+                  |  _status = args.deserializeTo(_argSize);
                   |  FW_ASSERT(
                   |    _status == Fw::FW_SERIALIZE_OK,
                   |    static_cast<FwAssertArgType>(_status)
@@ -942,7 +942,7 @@ case class ComponentTesterBaseWriter(
                   |  );
                   |}
                   |#endif
-                  |_status = args.deserialize($name);
+                  |_status = args.deserializeTo($name);
                   |FW_ASSERT(
                   |  _status == Fw::FW_SERIALIZE_OK,
                   |  static_cast<FwAssertArgType>(_status)
@@ -1105,7 +1105,7 @@ case class ComponentTesterBaseWriter(
             s"case $className::$constantName: {",
             lines(
               s"""|$channelType arg;
-                  |const Fw::SerializeStatus _status = val.deserialize(arg);
+                  |const Fw::SerializeStatus _status = val.deserializeTo(arg);
                   |
                   |if (_status != Fw::FW_SERIALIZE_OK) {
                   |  printf("Error deserializing $channelName: %d\\n", _status);
@@ -1276,7 +1276,7 @@ case class ComponentTesterBaseWriter(
                 s"""|// Build command for parameter set
                     |Fw::CmdArgBuffer args;
                     |FW_ASSERT(
-                    |  args.serialize(this->$paramVar) == Fw::FW_SERIALIZE_OK
+                    |  args.serializeFrom(this->$paramVar) == Fw::FW_SERIALIZE_OK
                     |);
                     |
                     |const U32 idBase = this->getIdBase();
@@ -1370,7 +1370,7 @@ case class ComponentTesterBaseWriter(
               wrapInScope(
                 s"case $className::$idConstantName: {",
                 lines(
-                  s"""|_status = $value.serialize(_testerBase->$varName);
+                  s"""|_status = $value.serializeFrom(_testerBase->$varName);
                       |_ret = _testerBase->$validityFlagName;
                       |FW_ASSERT(
                       |  _status == Fw::FW_SERIALIZE_OK,
@@ -1424,7 +1424,7 @@ case class ComponentTesterBaseWriter(
               s"case $className::$idConstantName: {",
               lines(
                 s"""|$paramType $paramNameVal;
-                    |_status = $value.deserialize($paramNameVal);
+                    |_status = $value.deserializeTo($paramNameVal);
                     |FW_ASSERT(
                     |  _status == Fw::FW_SERIALIZE_OK,
                     |  static_cast<FwAssertArgType>(_status)
@@ -1750,7 +1750,7 @@ case class ExternalParameterDelegate(
                 lines(
                   s"""|  // ${prm.getName}
                       |  case ${componentClassName}::${paramIdConstantName(prm.getName)}:
-                      |    stat = buff.deserialize(this->${paramVariableName(prm.getName)});
+                      |    stat = buff.deserializeTo(this->${paramVariableName(prm.getName)});
                       |    break;
                       |
                       |"""
@@ -1806,7 +1806,7 @@ case class ExternalParameterDelegate(
                 lines(
                   s"""|  // ${prm.getName}
                       |  case ${componentClassName}::${paramIdConstantName(prm.getName)}:
-                      |    stat = buff.serialize(this->${paramVariableName(prm.getName)});
+                      |    stat = buff.serializeFrom(this->${paramVariableName(prm.getName)});
                       |    break;
                       |
                       |"""

--- a/compiler/lib/src/main/scala/codegen/CppWriter/EnumCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/EnumCppWriter.scala
@@ -310,7 +310,7 @@ case class EnumCppWriter(
       ),
       functionClassMember(
         Some(s"Serialize raw enum value to SerialType"),
-        "serialize",
+        "serializeTo",
         List(
           CppDoc.Function.Param(
             CppDoc.Type("Fw::SerializeBufferBase&"),
@@ -320,7 +320,7 @@ case class EnumCppWriter(
         ),
         CppDoc.Type("Fw::SerializeStatus"),
         lines(
-          s"""|const Fw::SerializeStatus status = buffer.serialize(
+          s"""|const Fw::SerializeStatus status = buffer.serializeFrom(
               |    static_cast<SerialType>(this->e)
               |);
               |return status;"""
@@ -330,7 +330,7 @@ case class EnumCppWriter(
       ),
       functionClassMember(
         Some(s"Deserialize raw enum value from SerialType"),
-        "deserialize",
+        "deserializeFrom",
         List(
           CppDoc.Function.Param(
             CppDoc.Type("Fw::SerializeBufferBase&"),
@@ -341,7 +341,7 @@ case class EnumCppWriter(
         CppDoc.Type("Fw::SerializeStatus"),
         lines(
           s"""|SerialType es;
-              |Fw::SerializeStatus status = buffer.deserialize(es);
+              |Fw::SerializeStatus status = buffer.deserializeTo(es);
               |if (status == Fw::FW_SERIALIZE_OK) {
               |  this->e = static_cast<T>(es);
               |  if (!this->isValid()) {

--- a/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter.scala
@@ -282,7 +282,7 @@ case class PortCppWriter (
             lines(
               s"""|
                   |$varDecl
-                  |_status = _buffer.deserialize($n);
+                  |_status = _buffer.deserializeTo($n);
                   |if (_status != Fw::FW_SERIALIZE_OK) {
                   |  return _status;
                   |}
@@ -431,7 +431,7 @@ case class PortCppWriter (
         paramList.flatMap((n, _, _) => {
           lines(
             s"""|
-                |  _status = _buffer.serialize($n);
+                |  _status = _buffer.serializeFrom($n);
                 |  FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
                 |"""
           )

--- a/compiler/lib/src/main/scala/codegen/CppWriter/StructCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/StructCppWriter.scala
@@ -433,9 +433,9 @@ case class StructCppWriter(
         lines("return status;")
       )
     def writeSerializeCall(n: String) =
-      line(s"status = buffer.serialize(this->m_$n);") :: writeSerializeStatusCheck
+      line(s"status = buffer.serializeFrom(this->m_$n);") :: writeSerializeStatusCheck
     def writeDeserializeCall(n: String) =
-      line(s"status = buffer.deserialize(this->m_$n);") :: writeSerializeStatusCheck
+      line(s"status = buffer.deserializeTo(this->m_$n);") :: writeSerializeStatusCheck
 
     List(
       List(
@@ -448,7 +448,7 @@ case class StructCppWriter(
         ),
         functionClassMember(
           Some("Serialization"),
-          "serialize",
+          "serializeTo",
           List(
             CppDoc.Function.Param(
               CppDoc.Type("Fw::SerializeBufferBase&"),
@@ -472,7 +472,7 @@ case class StructCppWriter(
         ),
         functionClassMember(
           Some("Deserialization"),
-          "deserialize",
+          "deserializeFrom",
           List(
             CppDoc.Function.Param(
               CppDoc.Type("Fw::SerializeBufferBase&"),

--- a/compiler/tools/fpp-to-cpp/test/alias/AbsSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/alias/AbsSerializableAc.ref.cpp
@@ -78,11 +78,11 @@ std::ostream& operator<<(std::ostream& os, const Abs& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus Abs ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status;
 
-  status = buffer.serialize(this->m_A);
+  status = buffer.serializeFrom(this->m_A);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
@@ -91,11 +91,11 @@ Fw::SerializeStatus Abs ::
 }
 
 Fw::SerializeStatus Abs ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status;
 
-  status = buffer.deserialize(this->m_A);
+  status = buffer.deserializeTo(this->m_A);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }

--- a/compiler/tools/fpp-to-cpp/test/alias/AbsSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/alias/AbsSerializableAc.ref.hpp
@@ -84,12 +84,12 @@ class Abs :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/alias/BasicSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/alias/BasicSerializableAc.ref.cpp
@@ -98,23 +98,23 @@ std::ostream& operator<<(std::ostream& os, const Basic& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus Basic ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status;
 
-  status = buffer.serialize(this->m_A);
+  status = buffer.serializeFrom(this->m_A);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_B);
+  status = buffer.serializeFrom(this->m_B);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_C);
+  status = buffer.serializeFrom(this->m_C);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_D);
+  status = buffer.serializeFrom(this->m_D);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
@@ -123,23 +123,23 @@ Fw::SerializeStatus Basic ::
 }
 
 Fw::SerializeStatus Basic ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status;
 
-  status = buffer.deserialize(this->m_A);
+  status = buffer.deserializeTo(this->m_A);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_B);
+  status = buffer.deserializeTo(this->m_B);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_C);
+  status = buffer.deserializeTo(this->m_C);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_D);
+  status = buffer.deserializeTo(this->m_D);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }

--- a/compiler/tools/fpp-to-cpp/test/alias/BasicSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/alias/BasicSerializableAc.ref.hpp
@@ -95,12 +95,12 @@ class Basic :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/alias/NamespaceSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/alias/NamespaceSerializableAc.ref.cpp
@@ -98,23 +98,23 @@ std::ostream& operator<<(std::ostream& os, const Namespace& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus Namespace ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status;
 
-  status = buffer.serialize(this->m_A);
+  status = buffer.serializeFrom(this->m_A);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_B);
+  status = buffer.serializeFrom(this->m_B);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_C);
+  status = buffer.serializeFrom(this->m_C);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_D);
+  status = buffer.serializeFrom(this->m_D);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
@@ -123,23 +123,23 @@ Fw::SerializeStatus Namespace ::
 }
 
 Fw::SerializeStatus Namespace ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status;
 
-  status = buffer.deserialize(this->m_A);
+  status = buffer.deserializeTo(this->m_A);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_B);
+  status = buffer.deserializeTo(this->m_B);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_C);
+  status = buffer.deserializeTo(this->m_C);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_D);
+  status = buffer.deserializeTo(this->m_D);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }

--- a/compiler/tools/fpp-to-cpp/test/alias/NamespaceSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/alias/NamespaceSerializableAc.ref.hpp
@@ -95,12 +95,12 @@ class Namespace :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/array/AArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/AArrayAc.ref.cpp
@@ -145,11 +145,11 @@ std::ostream& operator<<(std::ostream& os, const A& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus A ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   for (U32 index = 0; index < SIZE; index++) {
-    status = buffer.serialize((*this)[index]);
+    status = buffer.serializeFrom((*this)[index]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
@@ -158,11 +158,11 @@ Fw::SerializeStatus A ::
 }
 
 Fw::SerializeStatus A ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   for (U32 index = 0; index < SIZE; index++) {
-    status = buffer.deserialize((*this)[index]);
+    status = buffer.deserializeTo((*this)[index]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }

--- a/compiler/tools/fpp-to-cpp/test/array/AArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/AArrayAc.ref.hpp
@@ -130,12 +130,12 @@ class A :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/array/AbsTypeArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/AbsTypeArrayAc.ref.cpp
@@ -145,11 +145,11 @@ std::ostream& operator<<(std::ostream& os, const AbsType& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus AbsType ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   for (U32 index = 0; index < SIZE; index++) {
-    status = buffer.serialize((*this)[index]);
+    status = buffer.serializeFrom((*this)[index]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
@@ -158,11 +158,11 @@ Fw::SerializeStatus AbsType ::
 }
 
 Fw::SerializeStatus AbsType ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   for (U32 index = 0; index < SIZE; index++) {
-    status = buffer.deserialize((*this)[index]);
+    status = buffer.deserializeTo((*this)[index]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }

--- a/compiler/tools/fpp-to-cpp/test/array/AbsTypeArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/AbsTypeArrayAc.ref.hpp
@@ -131,12 +131,12 @@ class AbsType :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/array/AliasTypeArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/AliasTypeArrayAc.ref.cpp
@@ -145,11 +145,11 @@ std::ostream& operator<<(std::ostream& os, const AliasType& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus AliasType ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   for (U32 index = 0; index < SIZE; index++) {
-    status = buffer.serialize((*this)[index]);
+    status = buffer.serializeFrom((*this)[index]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
@@ -158,11 +158,11 @@ Fw::SerializeStatus AliasType ::
 }
 
 Fw::SerializeStatus AliasType ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   for (U32 index = 0; index < SIZE; index++) {
-    status = buffer.deserialize((*this)[index]);
+    status = buffer.deserializeTo((*this)[index]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }

--- a/compiler/tools/fpp-to-cpp/test/array/AliasTypeArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/AliasTypeArrayAc.ref.hpp
@@ -131,12 +131,12 @@ class AliasType :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/array/C_AArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/C_AArrayAc.ref.cpp
@@ -145,11 +145,11 @@ std::ostream& operator<<(std::ostream& os, const C_A& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus C_A ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   for (U32 index = 0; index < SIZE; index++) {
-    status = buffer.serialize((*this)[index]);
+    status = buffer.serializeFrom((*this)[index]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
@@ -158,11 +158,11 @@ Fw::SerializeStatus C_A ::
 }
 
 Fw::SerializeStatus C_A ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   for (U32 index = 0; index < SIZE; index++) {
-    status = buffer.deserialize((*this)[index]);
+    status = buffer.deserializeTo((*this)[index]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }

--- a/compiler/tools/fpp-to-cpp/test/array/C_AArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/C_AArrayAc.ref.hpp
@@ -129,12 +129,12 @@ class C_A :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/array/E1EnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/E1EnumAc.ref.cpp
@@ -53,19 +53,19 @@ namespace M {
   }
 
   Fw::SerializeStatus E1 ::
-    serialize(Fw::SerializeBufferBase& buffer) const
+    serializeTo(Fw::SerializeBufferBase& buffer) const
   {
-    const Fw::SerializeStatus status = buffer.serialize(
+    const Fw::SerializeStatus status = buffer.serializeFrom(
         static_cast<SerialType>(this->e)
     );
     return status;
   }
 
   Fw::SerializeStatus E1 ::
-    deserialize(Fw::SerializeBufferBase& buffer)
+    deserializeFrom(Fw::SerializeBufferBase& buffer)
   {
     SerialType es;
-    Fw::SerializeStatus status = buffer.deserialize(es);
+    Fw::SerializeStatus status = buffer.deserializeTo(es);
     if (status == Fw::FW_SERIALIZE_OK) {
       this->e = static_cast<T>(es);
       if (!this->isValid()) {

--- a/compiler/tools/fpp-to-cpp/test/array/E1EnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/E1EnumAc.ref.hpp
@@ -132,12 +132,12 @@ namespace M {
       bool isValid() const;
 
       //! Serialize raw enum value to SerialType
-      Fw::SerializeStatus serialize(
+      Fw::SerializeStatus serializeTo(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       ) const;
 
       //! Deserialize raw enum value from SerialType
-      Fw::SerializeStatus deserialize(
+      Fw::SerializeStatus deserializeFrom(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 

--- a/compiler/tools/fpp-to-cpp/test/array/E2EnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/E2EnumAc.ref.cpp
@@ -53,19 +53,19 @@ bool E2 ::
 }
 
 Fw::SerializeStatus E2 ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
-  const Fw::SerializeStatus status = buffer.serialize(
+  const Fw::SerializeStatus status = buffer.serializeFrom(
       static_cast<SerialType>(this->e)
   );
   return status;
 }
 
 Fw::SerializeStatus E2 ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   SerialType es;
-  Fw::SerializeStatus status = buffer.deserialize(es);
+  Fw::SerializeStatus status = buffer.deserializeTo(es);
   if (status == Fw::FW_SERIALIZE_OK) {
     this->e = static_cast<T>(es);
     if (!this->isValid()) {

--- a/compiler/tools/fpp-to-cpp/test/array/E2EnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/E2EnumAc.ref.hpp
@@ -131,12 +131,12 @@ class E2 :
     bool isValid() const;
 
     //! Serialize raw enum value to SerialType
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialize raw enum value from SerialType
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/array/Enum1ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Enum1ArrayAc.ref.cpp
@@ -142,11 +142,11 @@ std::ostream& operator<<(std::ostream& os, const Enum1& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus Enum1 ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   for (U32 index = 0; index < SIZE; index++) {
-    status = buffer.serialize((*this)[index]);
+    status = buffer.serializeFrom((*this)[index]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
@@ -155,11 +155,11 @@ Fw::SerializeStatus Enum1 ::
 }
 
 Fw::SerializeStatus Enum1 ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   for (U32 index = 0; index < SIZE; index++) {
-    status = buffer.deserialize((*this)[index]);
+    status = buffer.deserializeTo((*this)[index]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }

--- a/compiler/tools/fpp-to-cpp/test/array/Enum1ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Enum1ArrayAc.ref.hpp
@@ -130,12 +130,12 @@ class Enum1 :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/array/Enum2ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Enum2ArrayAc.ref.cpp
@@ -151,11 +151,11 @@ std::ostream& operator<<(std::ostream& os, const Enum2& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus Enum2 ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   for (U32 index = 0; index < SIZE; index++) {
-    status = buffer.serialize((*this)[index]);
+    status = buffer.serializeFrom((*this)[index]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
@@ -164,11 +164,11 @@ Fw::SerializeStatus Enum2 ::
 }
 
 Fw::SerializeStatus Enum2 ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   for (U32 index = 0; index < SIZE; index++) {
-    status = buffer.deserialize((*this)[index]);
+    status = buffer.deserializeTo((*this)[index]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }

--- a/compiler/tools/fpp-to-cpp/test/array/Enum2ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Enum2ArrayAc.ref.hpp
@@ -132,12 +132,12 @@ class Enum2 :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/array/HeaderPathArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/HeaderPathArrayAc.ref.cpp
@@ -145,11 +145,11 @@ std::ostream& operator<<(std::ostream& os, const HeaderPath& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus HeaderPath ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   for (U32 index = 0; index < SIZE; index++) {
-    status = buffer.serialize((*this)[index]);
+    status = buffer.serializeFrom((*this)[index]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
@@ -158,11 +158,11 @@ Fw::SerializeStatus HeaderPath ::
 }
 
 Fw::SerializeStatus HeaderPath ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   for (U32 index = 0; index < SIZE; index++) {
-    status = buffer.deserialize((*this)[index]);
+    status = buffer.deserializeTo((*this)[index]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }

--- a/compiler/tools/fpp-to-cpp/test/array/HeaderPathArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/HeaderPathArrayAc.ref.hpp
@@ -131,12 +131,12 @@ class HeaderPath :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveArrayArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveArrayArrayAc.ref.cpp
@@ -151,11 +151,11 @@ std::ostream& operator<<(std::ostream& os, const PrimitiveArray& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus PrimitiveArray ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   for (U32 index = 0; index < SIZE; index++) {
-    status = buffer.serialize((*this)[index]);
+    status = buffer.serializeFrom((*this)[index]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
@@ -164,11 +164,11 @@ Fw::SerializeStatus PrimitiveArray ::
 }
 
 Fw::SerializeStatus PrimitiveArray ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   for (U32 index = 0; index < SIZE; index++) {
-    status = buffer.deserialize((*this)[index]);
+    status = buffer.deserializeTo((*this)[index]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveArrayArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveArrayArrayAc.ref.hpp
@@ -133,12 +133,12 @@ class PrimitiveArray :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveBoolArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveBoolArrayAc.ref.cpp
@@ -147,11 +147,11 @@ namespace M {
   // ----------------------------------------------------------------------
 
   Fw::SerializeStatus PrimitiveBool ::
-    serialize(Fw::SerializeBufferBase& buffer) const
+    serializeTo(Fw::SerializeBufferBase& buffer) const
   {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     for (U32 index = 0; index < SIZE; index++) {
-      status = buffer.serialize((*this)[index]);
+      status = buffer.serializeFrom((*this)[index]);
       if (status != Fw::FW_SERIALIZE_OK) {
         return status;
       }
@@ -160,11 +160,11 @@ namespace M {
   }
 
   Fw::SerializeStatus PrimitiveBool ::
-    deserialize(Fw::SerializeBufferBase& buffer)
+    deserializeFrom(Fw::SerializeBufferBase& buffer)
   {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     for (U32 index = 0; index < SIZE; index++) {
-      status = buffer.deserialize((*this)[index]);
+      status = buffer.deserializeTo((*this)[index]);
       if (status != Fw::FW_SERIALIZE_OK) {
         return status;
       }

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveBoolArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveBoolArrayAc.ref.hpp
@@ -131,12 +131,12 @@ namespace M {
       // ----------------------------------------------------------------------
 
       //! Serialization
-      Fw::SerializeStatus serialize(
+      Fw::SerializeStatus serializeTo(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       ) const;
 
       //! Deserialization
-      Fw::SerializeStatus deserialize(
+      Fw::SerializeStatus deserializeFrom(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32eArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32eArrayAc.ref.cpp
@@ -147,11 +147,11 @@ namespace M {
   // ----------------------------------------------------------------------
 
   Fw::SerializeStatus PrimitiveF32e ::
-    serialize(Fw::SerializeBufferBase& buffer) const
+    serializeTo(Fw::SerializeBufferBase& buffer) const
   {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     for (U32 index = 0; index < SIZE; index++) {
-      status = buffer.serialize((*this)[index]);
+      status = buffer.serializeFrom((*this)[index]);
       if (status != Fw::FW_SERIALIZE_OK) {
         return status;
       }
@@ -160,11 +160,11 @@ namespace M {
   }
 
   Fw::SerializeStatus PrimitiveF32e ::
-    deserialize(Fw::SerializeBufferBase& buffer)
+    deserializeFrom(Fw::SerializeBufferBase& buffer)
   {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     for (U32 index = 0; index < SIZE; index++) {
-      status = buffer.deserialize((*this)[index]);
+      status = buffer.deserializeTo((*this)[index]);
       if (status != Fw::FW_SERIALIZE_OK) {
         return status;
       }

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32eArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32eArrayAc.ref.hpp
@@ -132,12 +132,12 @@ namespace M {
       // ----------------------------------------------------------------------
 
       //! Serialization
-      Fw::SerializeStatus serialize(
+      Fw::SerializeStatus serializeTo(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       ) const;
 
       //! Deserialization
-      Fw::SerializeStatus deserialize(
+      Fw::SerializeStatus deserializeFrom(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32fArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32fArrayAc.ref.cpp
@@ -147,11 +147,11 @@ namespace M {
   // ----------------------------------------------------------------------
 
   Fw::SerializeStatus PrimitiveF32f ::
-    serialize(Fw::SerializeBufferBase& buffer) const
+    serializeTo(Fw::SerializeBufferBase& buffer) const
   {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     for (U32 index = 0; index < SIZE; index++) {
-      status = buffer.serialize((*this)[index]);
+      status = buffer.serializeFrom((*this)[index]);
       if (status != Fw::FW_SERIALIZE_OK) {
         return status;
       }
@@ -160,11 +160,11 @@ namespace M {
   }
 
   Fw::SerializeStatus PrimitiveF32f ::
-    deserialize(Fw::SerializeBufferBase& buffer)
+    deserializeFrom(Fw::SerializeBufferBase& buffer)
   {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     for (U32 index = 0; index < SIZE; index++) {
-      status = buffer.deserialize((*this)[index]);
+      status = buffer.deserializeTo((*this)[index]);
       if (status != Fw::FW_SERIALIZE_OK) {
         return status;
       }

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32fArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32fArrayAc.ref.hpp
@@ -132,12 +132,12 @@ namespace M {
       // ----------------------------------------------------------------------
 
       //! Serialization
-      Fw::SerializeStatus serialize(
+      Fw::SerializeStatus serializeTo(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       ) const;
 
       //! Deserialization
-      Fw::SerializeStatus deserialize(
+      Fw::SerializeStatus deserializeFrom(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveF64ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveF64ArrayAc.ref.cpp
@@ -153,11 +153,11 @@ namespace M {
   // ----------------------------------------------------------------------
 
   Fw::SerializeStatus PrimitiveF64 ::
-    serialize(Fw::SerializeBufferBase& buffer) const
+    serializeTo(Fw::SerializeBufferBase& buffer) const
   {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     for (U32 index = 0; index < SIZE; index++) {
-      status = buffer.serialize((*this)[index]);
+      status = buffer.serializeFrom((*this)[index]);
       if (status != Fw::FW_SERIALIZE_OK) {
         return status;
       }
@@ -166,11 +166,11 @@ namespace M {
   }
 
   Fw::SerializeStatus PrimitiveF64 ::
-    deserialize(Fw::SerializeBufferBase& buffer)
+    deserializeFrom(Fw::SerializeBufferBase& buffer)
   {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     for (U32 index = 0; index < SIZE; index++) {
-      status = buffer.deserialize((*this)[index]);
+      status = buffer.deserializeTo((*this)[index]);
       if (status != Fw::FW_SERIALIZE_OK) {
         return status;
       }

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveF64ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveF64ArrayAc.ref.hpp
@@ -134,12 +134,12 @@ namespace M {
       // ----------------------------------------------------------------------
 
       //! Serialization
-      Fw::SerializeStatus serialize(
+      Fw::SerializeStatus serializeTo(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       ) const;
 
       //! Deserialization
-      Fw::SerializeStatus deserialize(
+      Fw::SerializeStatus deserializeFrom(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveI32ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveI32ArrayAc.ref.cpp
@@ -147,11 +147,11 @@ namespace M {
   // ----------------------------------------------------------------------
 
   Fw::SerializeStatus PrimitiveI32 ::
-    serialize(Fw::SerializeBufferBase& buffer) const
+    serializeTo(Fw::SerializeBufferBase& buffer) const
   {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     for (U32 index = 0; index < SIZE; index++) {
-      status = buffer.serialize((*this)[index]);
+      status = buffer.serializeFrom((*this)[index]);
       if (status != Fw::FW_SERIALIZE_OK) {
         return status;
       }
@@ -160,11 +160,11 @@ namespace M {
   }
 
   Fw::SerializeStatus PrimitiveI32 ::
-    deserialize(Fw::SerializeBufferBase& buffer)
+    deserializeFrom(Fw::SerializeBufferBase& buffer)
   {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     for (U32 index = 0; index < SIZE; index++) {
-      status = buffer.deserialize((*this)[index]);
+      status = buffer.deserializeTo((*this)[index]);
       if (status != Fw::FW_SERIALIZE_OK) {
         return status;
       }

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveI32ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveI32ArrayAc.ref.hpp
@@ -132,12 +132,12 @@ namespace M {
       // ----------------------------------------------------------------------
 
       //! Serialization
-      Fw::SerializeStatus serialize(
+      Fw::SerializeStatus serializeTo(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       ) const;
 
       //! Deserialization
-      Fw::SerializeStatus deserialize(
+      Fw::SerializeStatus deserializeFrom(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveI64ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveI64ArrayAc.ref.cpp
@@ -147,11 +147,11 @@ namespace M {
   // ----------------------------------------------------------------------
 
   Fw::SerializeStatus PrimitiveI64 ::
-    serialize(Fw::SerializeBufferBase& buffer) const
+    serializeTo(Fw::SerializeBufferBase& buffer) const
   {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     for (U32 index = 0; index < SIZE; index++) {
-      status = buffer.serialize((*this)[index]);
+      status = buffer.serializeFrom((*this)[index]);
       if (status != Fw::FW_SERIALIZE_OK) {
         return status;
       }
@@ -160,11 +160,11 @@ namespace M {
   }
 
   Fw::SerializeStatus PrimitiveI64 ::
-    deserialize(Fw::SerializeBufferBase& buffer)
+    deserializeFrom(Fw::SerializeBufferBase& buffer)
   {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     for (U32 index = 0; index < SIZE; index++) {
-      status = buffer.deserialize((*this)[index]);
+      status = buffer.deserializeTo((*this)[index]);
       if (status != Fw::FW_SERIALIZE_OK) {
         return status;
       }

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveI64ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveI64ArrayAc.ref.hpp
@@ -132,12 +132,12 @@ namespace M {
       // ----------------------------------------------------------------------
 
       //! Serialization
-      Fw::SerializeStatus serialize(
+      Fw::SerializeStatus serializeTo(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       ) const;
 
       //! Deserialization
-      Fw::SerializeStatus deserialize(
+      Fw::SerializeStatus deserializeFrom(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveU16ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveU16ArrayAc.ref.cpp
@@ -147,11 +147,11 @@ namespace M {
   // ----------------------------------------------------------------------
 
   Fw::SerializeStatus PrimitiveU16 ::
-    serialize(Fw::SerializeBufferBase& buffer) const
+    serializeTo(Fw::SerializeBufferBase& buffer) const
   {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     for (U32 index = 0; index < SIZE; index++) {
-      status = buffer.serialize((*this)[index]);
+      status = buffer.serializeFrom((*this)[index]);
       if (status != Fw::FW_SERIALIZE_OK) {
         return status;
       }
@@ -160,11 +160,11 @@ namespace M {
   }
 
   Fw::SerializeStatus PrimitiveU16 ::
-    deserialize(Fw::SerializeBufferBase& buffer)
+    deserializeFrom(Fw::SerializeBufferBase& buffer)
   {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     for (U32 index = 0; index < SIZE; index++) {
-      status = buffer.deserialize((*this)[index]);
+      status = buffer.deserializeTo((*this)[index]);
       if (status != Fw::FW_SERIALIZE_OK) {
         return status;
       }

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveU16ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveU16ArrayAc.ref.hpp
@@ -131,12 +131,12 @@ namespace M {
       // ----------------------------------------------------------------------
 
       //! Serialization
-      Fw::SerializeStatus serialize(
+      Fw::SerializeStatus serializeTo(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       ) const;
 
       //! Deserialization
-      Fw::SerializeStatus deserialize(
+      Fw::SerializeStatus deserializeFrom(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveU8ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveU8ArrayAc.ref.cpp
@@ -147,11 +147,11 @@ namespace M {
   // ----------------------------------------------------------------------
 
   Fw::SerializeStatus PrimitiveU8 ::
-    serialize(Fw::SerializeBufferBase& buffer) const
+    serializeTo(Fw::SerializeBufferBase& buffer) const
   {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     for (U32 index = 0; index < SIZE; index++) {
-      status = buffer.serialize((*this)[index]);
+      status = buffer.serializeFrom((*this)[index]);
       if (status != Fw::FW_SERIALIZE_OK) {
         return status;
       }
@@ -160,11 +160,11 @@ namespace M {
   }
 
   Fw::SerializeStatus PrimitiveU8 ::
-    deserialize(Fw::SerializeBufferBase& buffer)
+    deserializeFrom(Fw::SerializeBufferBase& buffer)
   {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     for (U32 index = 0; index < SIZE; index++) {
-      status = buffer.deserialize((*this)[index]);
+      status = buffer.deserializeTo((*this)[index]);
       if (status != Fw::FW_SERIALIZE_OK) {
         return status;
       }

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveU8ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveU8ArrayAc.ref.hpp
@@ -131,12 +131,12 @@ namespace M {
       // ----------------------------------------------------------------------
 
       //! Serialization
-      Fw::SerializeStatus serialize(
+      Fw::SerializeStatus serializeTo(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       ) const;
 
       //! Deserialization
-      Fw::SerializeStatus deserialize(
+      Fw::SerializeStatus deserializeFrom(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 

--- a/compiler/tools/fpp-to-cpp/test/array/S1SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/S1SerializableAc.ref.cpp
@@ -140,55 +140,55 @@ namespace M {
   // ----------------------------------------------------------------------
 
   Fw::SerializeStatus S1 ::
-    serialize(Fw::SerializeBufferBase& buffer) const
+    serializeTo(Fw::SerializeBufferBase& buffer) const
   {
     Fw::SerializeStatus status;
 
-    status = buffer.serialize(this->m_mF32);
+    status = buffer.serializeFrom(this->m_mF32);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
-    status = buffer.serialize(this->m_mF64);
+    status = buffer.serializeFrom(this->m_mF64);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
-    status = buffer.serialize(this->m_mI16);
+    status = buffer.serializeFrom(this->m_mI16);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
-    status = buffer.serialize(this->m_mI32);
+    status = buffer.serializeFrom(this->m_mI32);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
-    status = buffer.serialize(this->m_mI64);
+    status = buffer.serializeFrom(this->m_mI64);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
-    status = buffer.serialize(this->m_mI8);
+    status = buffer.serializeFrom(this->m_mI8);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
-    status = buffer.serialize(this->m_mU16);
+    status = buffer.serializeFrom(this->m_mU16);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
-    status = buffer.serialize(this->m_mU32);
+    status = buffer.serializeFrom(this->m_mU32);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
-    status = buffer.serialize(this->m_mU64);
+    status = buffer.serializeFrom(this->m_mU64);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
-    status = buffer.serialize(this->m_mU8);
+    status = buffer.serializeFrom(this->m_mU8);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
-    status = buffer.serialize(this->m_mBool);
+    status = buffer.serializeFrom(this->m_mBool);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
-    status = buffer.serialize(this->m_mString);
+    status = buffer.serializeFrom(this->m_mString);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
@@ -197,55 +197,55 @@ namespace M {
   }
 
   Fw::SerializeStatus S1 ::
-    deserialize(Fw::SerializeBufferBase& buffer)
+    deserializeFrom(Fw::SerializeBufferBase& buffer)
   {
     Fw::SerializeStatus status;
 
-    status = buffer.deserialize(this->m_mF32);
+    status = buffer.deserializeTo(this->m_mF32);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
-    status = buffer.deserialize(this->m_mF64);
+    status = buffer.deserializeTo(this->m_mF64);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
-    status = buffer.deserialize(this->m_mI16);
+    status = buffer.deserializeTo(this->m_mI16);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
-    status = buffer.deserialize(this->m_mI32);
+    status = buffer.deserializeTo(this->m_mI32);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
-    status = buffer.deserialize(this->m_mI64);
+    status = buffer.deserializeTo(this->m_mI64);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
-    status = buffer.deserialize(this->m_mI8);
+    status = buffer.deserializeTo(this->m_mI8);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
-    status = buffer.deserialize(this->m_mU16);
+    status = buffer.deserializeTo(this->m_mU16);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
-    status = buffer.deserialize(this->m_mU32);
+    status = buffer.deserializeTo(this->m_mU32);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
-    status = buffer.deserialize(this->m_mU64);
+    status = buffer.deserializeTo(this->m_mU64);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
-    status = buffer.deserialize(this->m_mU8);
+    status = buffer.deserializeTo(this->m_mU8);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
-    status = buffer.deserialize(this->m_mBool);
+    status = buffer.deserializeTo(this->m_mBool);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
-    status = buffer.deserialize(this->m_mString);
+    status = buffer.deserializeTo(this->m_mString);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }

--- a/compiler/tools/fpp-to-cpp/test/array/S1SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/S1SerializableAc.ref.hpp
@@ -109,12 +109,12 @@ namespace M {
       // ----------------------------------------------------------------------
 
       //! Serialization
-      Fw::SerializeStatus serialize(
+      Fw::SerializeStatus serializeTo(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       ) const;
 
       //! Deserialization
-      Fw::SerializeStatus deserialize(
+      Fw::SerializeStatus deserializeFrom(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 

--- a/compiler/tools/fpp-to-cpp/test/array/S2SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/S2SerializableAc.ref.cpp
@@ -78,11 +78,11 @@ std::ostream& operator<<(std::ostream& os, const S2& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus S2 ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status;
 
-  status = buffer.serialize(this->m_s1);
+  status = buffer.serializeFrom(this->m_s1);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
@@ -91,11 +91,11 @@ Fw::SerializeStatus S2 ::
 }
 
 Fw::SerializeStatus S2 ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status;
 
-  status = buffer.deserialize(this->m_s1);
+  status = buffer.deserializeTo(this->m_s1);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }

--- a/compiler/tools/fpp-to-cpp/test/array/S2SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/S2SerializableAc.ref.hpp
@@ -84,12 +84,12 @@ class S2 :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/array/S3SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/S3SerializableAc.ref.cpp
@@ -116,17 +116,17 @@ namespace S {
   // ----------------------------------------------------------------------
 
   Fw::SerializeStatus S3 ::
-    serialize(Fw::SerializeBufferBase& buffer) const
+    serializeTo(Fw::SerializeBufferBase& buffer) const
   {
     Fw::SerializeStatus status;
 
     for (FwSizeType i = 0; i < 3; i++) {
-      status = buffer.serialize(this->m_mU32Array[i]);
+      status = buffer.serializeFrom(this->m_mU32Array[i]);
       if (status != Fw::FW_SERIALIZE_OK) {
         return status;
       }
     }
-    status = buffer.serialize(this->m_mF64);
+    status = buffer.serializeFrom(this->m_mF64);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
@@ -135,17 +135,17 @@ namespace S {
   }
 
   Fw::SerializeStatus S3 ::
-    deserialize(Fw::SerializeBufferBase& buffer)
+    deserializeFrom(Fw::SerializeBufferBase& buffer)
   {
     Fw::SerializeStatus status;
 
     for (FwSizeType i = 0; i < 3; i++) {
-      status = buffer.deserialize(this->m_mU32Array[i]);
+      status = buffer.deserializeTo(this->m_mU32Array[i]);
       if (status != Fw::FW_SERIALIZE_OK) {
         return status;
       }
     }
-    status = buffer.deserialize(this->m_mF64);
+    status = buffer.deserializeTo(this->m_mF64);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }

--- a/compiler/tools/fpp-to-cpp/test/array/S3SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/S3SerializableAc.ref.hpp
@@ -105,12 +105,12 @@ namespace S {
       // ----------------------------------------------------------------------
 
       //! Serialization
-      Fw::SerializeStatus serialize(
+      Fw::SerializeStatus serializeTo(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       ) const;
 
       //! Deserialization
-      Fw::SerializeStatus deserialize(
+      Fw::SerializeStatus deserializeFrom(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 

--- a/compiler/tools/fpp-to-cpp/test/array/SingleElementArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/SingleElementArrayAc.ref.cpp
@@ -128,11 +128,11 @@ std::ostream& operator<<(std::ostream& os, const SingleElement& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus SingleElement ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   for (U32 index = 0; index < SIZE; index++) {
-    status = buffer.serialize((*this)[index]);
+    status = buffer.serializeFrom((*this)[index]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
@@ -141,11 +141,11 @@ Fw::SerializeStatus SingleElement ::
 }
 
 Fw::SerializeStatus SingleElement ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   for (U32 index = 0; index < SIZE; index++) {
-    status = buffer.deserialize((*this)[index]);
+    status = buffer.deserializeTo((*this)[index]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }

--- a/compiler/tools/fpp-to-cpp/test/array/SingleElementArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/SingleElementArrayAc.ref.hpp
@@ -123,12 +123,12 @@ class SingleElement :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/array/String1ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/String1ArrayAc.ref.cpp
@@ -150,11 +150,11 @@ std::ostream& operator<<(std::ostream& os, const String1& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus String1 ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   for (U32 index = 0; index < SIZE; index++) {
-    status = buffer.serialize((*this)[index]);
+    status = buffer.serializeFrom((*this)[index]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
@@ -163,11 +163,11 @@ Fw::SerializeStatus String1 ::
 }
 
 Fw::SerializeStatus String1 ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   for (U32 index = 0; index < SIZE; index++) {
-    status = buffer.deserialize((*this)[index]);
+    status = buffer.deserializeTo((*this)[index]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }

--- a/compiler/tools/fpp-to-cpp/test/array/String1ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/String1ArrayAc.ref.hpp
@@ -134,12 +134,12 @@ class String1 :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/array/String2ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/String2ArrayAc.ref.cpp
@@ -147,11 +147,11 @@ std::ostream& operator<<(std::ostream& os, const String2& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus String2 ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   for (U32 index = 0; index < SIZE; index++) {
-    status = buffer.serialize((*this)[index]);
+    status = buffer.serializeFrom((*this)[index]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
@@ -160,11 +160,11 @@ Fw::SerializeStatus String2 ::
 }
 
 Fw::SerializeStatus String2 ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   for (U32 index = 0; index < SIZE; index++) {
-    status = buffer.deserialize((*this)[index]);
+    status = buffer.deserializeTo((*this)[index]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }

--- a/compiler/tools/fpp-to-cpp/test/array/String2ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/String2ArrayAc.ref.hpp
@@ -133,12 +133,12 @@ class String2 :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/array/StringArrayArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/StringArrayArrayAc.ref.cpp
@@ -151,11 +151,11 @@ std::ostream& operator<<(std::ostream& os, const StringArray& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus StringArray ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   for (U32 index = 0; index < SIZE; index++) {
-    status = buffer.serialize((*this)[index]);
+    status = buffer.serializeFrom((*this)[index]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
@@ -164,11 +164,11 @@ Fw::SerializeStatus StringArray ::
 }
 
 Fw::SerializeStatus StringArray ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   for (U32 index = 0; index < SIZE; index++) {
-    status = buffer.deserialize((*this)[index]);
+    status = buffer.deserializeTo((*this)[index]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }

--- a/compiler/tools/fpp-to-cpp/test/array/StringArrayArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/StringArrayArrayAc.ref.hpp
@@ -133,12 +133,12 @@ class StringArray :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/array/Struct1ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Struct1ArrayAc.ref.cpp
@@ -151,11 +151,11 @@ std::ostream& operator<<(std::ostream& os, const Struct1& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus Struct1 ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   for (U32 index = 0; index < SIZE; index++) {
-    status = buffer.serialize((*this)[index]);
+    status = buffer.serializeFrom((*this)[index]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
@@ -164,11 +164,11 @@ Fw::SerializeStatus Struct1 ::
 }
 
 Fw::SerializeStatus Struct1 ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   for (U32 index = 0; index < SIZE; index++) {
-    status = buffer.deserialize((*this)[index]);
+    status = buffer.deserializeTo((*this)[index]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }

--- a/compiler/tools/fpp-to-cpp/test/array/Struct1ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Struct1ArrayAc.ref.hpp
@@ -133,12 +133,12 @@ class Struct1 :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/array/Struct2ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Struct2ArrayAc.ref.cpp
@@ -145,11 +145,11 @@ std::ostream& operator<<(std::ostream& os, const Struct2& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus Struct2 ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   for (U32 index = 0; index < SIZE; index++) {
-    status = buffer.serialize((*this)[index]);
+    status = buffer.serializeFrom((*this)[index]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
@@ -158,11 +158,11 @@ Fw::SerializeStatus Struct2 ::
 }
 
 Fw::SerializeStatus Struct2 ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   for (U32 index = 0; index < SIZE; index++) {
-    status = buffer.deserialize((*this)[index]);
+    status = buffer.deserializeTo((*this)[index]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }

--- a/compiler/tools/fpp-to-cpp/test/array/Struct2ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Struct2ArrayAc.ref.hpp
@@ -131,12 +131,12 @@ class Struct2 :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/array/Struct3ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Struct3ArrayAc.ref.cpp
@@ -145,11 +145,11 @@ std::ostream& operator<<(std::ostream& os, const Struct3& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus Struct3 ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   for (U32 index = 0; index < SIZE; index++) {
-    status = buffer.serialize((*this)[index]);
+    status = buffer.serializeFrom((*this)[index]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
@@ -158,11 +158,11 @@ Fw::SerializeStatus Struct3 ::
 }
 
 Fw::SerializeStatus Struct3 ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   for (U32 index = 0; index < SIZE; index++) {
-    status = buffer.deserialize((*this)[index]);
+    status = buffer.deserializeTo((*this)[index]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }

--- a/compiler/tools/fpp-to-cpp/test/array/Struct3ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Struct3ArrayAc.ref.hpp
@@ -131,12 +131,12 @@ class Struct3 :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/AArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/AArrayAc.ref.cpp
@@ -145,11 +145,11 @@ std::ostream& operator<<(std::ostream& os, const A& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus A ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   for (U32 index = 0; index < SIZE; index++) {
-    status = buffer.serialize((*this)[index]);
+    status = buffer.serializeFrom((*this)[index]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
@@ -158,11 +158,11 @@ Fw::SerializeStatus A ::
 }
 
 Fw::SerializeStatus A ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   for (U32 index = 0; index < SIZE; index++) {
-    status = buffer.deserialize((*this)[index]);
+    status = buffer.deserializeTo((*this)[index]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }

--- a/compiler/tools/fpp-to-cpp/test/component/base/AArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/AArrayAc.ref.hpp
@@ -130,12 +130,12 @@ class A :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductPortsOnlyComponentAc.ref.cpp
@@ -328,7 +328,7 @@ void ActiveAsyncProductPortsOnlyComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(PRODUCTRECVIN_DPRESPONSE)
   );
   FW_ASSERT(
@@ -337,28 +337,28 @@ void ActiveAsyncProductPortsOnlyComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument id
-  _status = msg.serialize(id);
+  _status = msg.serializeFrom(id);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument buffer
-  _status = msg.serialize(buffer);
+  _status = msg.serializeFrom(buffer);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument status
-  _status = msg.serialize(status);
+  _status = msg.serializeFrom(status);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -465,7 +465,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductPortsOnlyComponentB
   _msg.resetDeser();
 
   FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -478,7 +478,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductPortsOnlyComponentB
   }
 
   FwIndexType portNum = 0;
-  _deserStatus = _msg.deserialize(portNum);
+  _deserStatus = _msg.deserializeTo(portNum);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -489,7 +489,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductPortsOnlyComponentB
     case PRODUCTRECVIN_DPRESPONSE: {
       // Deserialize argument id
       FwDpIdType id;
-      _deserStatus = _msg.deserialize(id);
+      _deserStatus = _msg.deserializeTo(id);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -497,7 +497,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductPortsOnlyComponentB
 
       // Deserialize argument buffer
       Fw::Buffer buffer;
-      _deserStatus = _msg.deserialize(buffer);
+      _deserStatus = _msg.deserializeTo(buffer);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -505,7 +505,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductPortsOnlyComponentB
 
       // Deserialize argument status
       Fw::Success status;
-      _deserStatus = _msg.deserialize(status);
+      _deserStatus = _msg.deserializeTo(status);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductsComponentAc.ref.cpp
@@ -111,12 +111,12 @@ Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serialize(array[i]);
+      status = this->m_dataBuffer.serializeFrom(array[i]);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -136,9 +136,9 @@ Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(elt);
+    status = this->m_dataBuffer.serializeFrom(elt);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -169,14 +169,14 @@ Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       const Fw::StringBase *const sbPtr = array[i];
       FW_ASSERT(sbPtr != nullptr);
-      status = sbPtr->serialize(this->m_dataBuffer, stringSize);
+      status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -197,9 +197,9 @@ Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = elt.serialize(this->m_dataBuffer, stringSize);
+    status = elt.serializeTo(this->m_dataBuffer, stringSize);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -225,12 +225,12 @@ Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serialize(array[i]);
+      status = this->m_dataBuffer.serializeFrom(array[i]);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -250,9 +250,9 @@ Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32Record;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(elt);
+    status = this->m_dataBuffer.serializeFrom(elt);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -278,11 +278,11 @@ Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
+    status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -2367,7 +2367,7 @@ void ActiveAsyncProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(PRODUCTRECVIN_DPRESPONSE)
   );
   FW_ASSERT(
@@ -2376,28 +2376,28 @@ void ActiveAsyncProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument id
-  _status = msg.serialize(id);
+  _status = msg.serializeFrom(id);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument buffer
-  _status = msg.serialize(buffer);
+  _status = msg.serializeFrom(buffer);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument status
-  _status = msg.serialize(status);
+  _status = msg.serializeFrom(status);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2452,7 +2452,7 @@ void ActiveAsyncProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
   );
   FW_ASSERT(
@@ -2461,56 +2461,56 @@ void ActiveAsyncProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str2
-  _status = msg.serialize(str2);
+  _status = msg.serializeFrom(str2);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2558,7 +2558,7 @@ void ActiveAsyncProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
   );
   FW_ASSERT(
@@ -2567,7 +2567,7 @@ void ActiveAsyncProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2812,7 +2812,7 @@ void ActiveAsyncProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
   );
   FW_ASSERT(
@@ -2821,56 +2821,56 @@ void ActiveAsyncProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2919,7 +2919,7 @@ void ActiveAsyncProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
   );
   FW_ASSERT(
@@ -2928,56 +2928,56 @@ void ActiveAsyncProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3026,7 +3026,7 @@ void ActiveAsyncProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -3035,56 +3035,56 @@ void ActiveAsyncProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3133,7 +3133,7 @@ void ActiveAsyncProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -3142,56 +3142,56 @@ void ActiveAsyncProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3813,7 +3813,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
   _msg.resetDeser();
 
   FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -3826,7 +3826,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
   }
 
   FwIndexType portNum = 0;
-  _deserStatus = _msg.deserialize(portNum);
+  _deserStatus = _msg.deserializeTo(portNum);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -3837,7 +3837,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
     case PRODUCTRECVIN_DPRESPONSE: {
       // Deserialize argument id
       FwDpIdType id;
-      _deserStatus = _msg.deserialize(id);
+      _deserStatus = _msg.deserializeTo(id);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3845,7 +3845,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
 
       // Deserialize argument buffer
       Fw::Buffer buffer;
-      _deserStatus = _msg.deserialize(buffer);
+      _deserStatus = _msg.deserializeTo(buffer);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3853,7 +3853,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
 
       // Deserialize argument status
       Fw::Success status;
-      _deserStatus = _msg.deserialize(status);
+      _deserStatus = _msg.deserializeTo(status);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3873,7 +3873,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
     case ALIASTYPEDASYNC_ALIASTYPED: {
       // Deserialize argument u32
       AliasPrim1 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3881,7 +3881,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
 
       // Deserialize argument f32
       AliasPrim2 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3889,7 +3889,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
 
       // Deserialize argument b
       AliasBool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3898,7 +3898,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
       // Deserialize argument str2
       char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
       Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserialize(str2);
+      _deserStatus = _msg.deserializeTo(str2);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3906,7 +3906,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
 
       // Deserialize argument e
       AliasEnum e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3914,7 +3914,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
 
       // Deserialize argument a
       AliasArray a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3922,7 +3922,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
 
       // Deserialize argument s
       AliasStruct s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3954,7 +3954,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
     case TYPEDASYNC_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3962,7 +3962,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3970,7 +3970,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3979,7 +3979,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3987,7 +3987,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3995,7 +3995,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4003,7 +4003,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4027,7 +4027,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
     case TYPEDASYNCASSERT_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4035,7 +4035,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4043,7 +4043,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4052,7 +4052,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4060,7 +4060,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4068,7 +4068,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4076,7 +4076,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4100,7 +4100,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
     case TYPEDASYNCBLOCKPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4108,7 +4108,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4116,7 +4116,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4125,7 +4125,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4133,7 +4133,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4141,7 +4141,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4149,7 +4149,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4173,7 +4173,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
     case TYPEDASYNCDROPPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4181,7 +4181,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4189,7 +4189,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4198,7 +4198,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4206,7 +4206,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4214,7 +4214,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4222,7 +4222,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveAsyncProductsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveCommandsComponentAc.ref.cpp
@@ -2066,7 +2066,7 @@ void ActiveCommandsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
   );
   FW_ASSERT(
@@ -2075,56 +2075,56 @@ void ActiveCommandsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str2
-  _status = msg.serialize(str2);
+  _status = msg.serializeFrom(str2);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2172,7 +2172,7 @@ void ActiveCommandsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
   );
   FW_ASSERT(
@@ -2181,7 +2181,7 @@ void ActiveCommandsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2426,7 +2426,7 @@ void ActiveCommandsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
   );
   FW_ASSERT(
@@ -2435,56 +2435,56 @@ void ActiveCommandsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2533,7 +2533,7 @@ void ActiveCommandsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
   );
   FW_ASSERT(
@@ -2542,56 +2542,56 @@ void ActiveCommandsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2640,7 +2640,7 @@ void ActiveCommandsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -2649,56 +2649,56 @@ void ActiveCommandsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2747,7 +2747,7 @@ void ActiveCommandsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -2756,56 +2756,56 @@ void ActiveCommandsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3328,7 +3328,7 @@ void ActiveCommandsComponentBase ::
   args.resetDeser();
 
   U32 u32;
-  _status = args.deserialize(u32);
+  _status = args.deserializeTo(u32);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3341,7 +3341,7 @@ void ActiveCommandsComponentBase ::
   }
 
   F32 f32;
-  _status = args.deserialize(f32);
+  _status = args.deserializeTo(f32);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3354,7 +3354,7 @@ void ActiveCommandsComponentBase ::
   }
 
   bool b;
-  _status = args.deserialize(b);
+  _status = args.deserializeTo(b);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3403,7 +3403,7 @@ void ActiveCommandsComponentBase ::
   args.resetDeser();
 
   Fw::CmdStringArg str1;
-  _status = args.deserialize(str1);
+  _status = args.deserializeTo(str1);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3416,7 +3416,7 @@ void ActiveCommandsComponentBase ::
   }
 
   Fw::CmdStringArg str2;
-  _status = args.deserialize(str2);
+  _status = args.deserializeTo(str2);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3464,7 +3464,7 @@ void ActiveCommandsComponentBase ::
   args.resetDeser();
 
   E e;
-  _status = args.deserialize(e);
+  _status = args.deserializeTo(e);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3511,7 +3511,7 @@ void ActiveCommandsComponentBase ::
   args.resetDeser();
 
   A a;
-  _status = args.deserialize(a);
+  _status = args.deserializeTo(a);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3558,7 +3558,7 @@ void ActiveCommandsComponentBase ::
   args.resetDeser();
 
   S s;
-  _status = args.deserialize(s);
+  _status = args.deserializeTo(s);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3634,7 +3634,7 @@ void ActiveCommandsComponentBase ::
   args.resetDeser();
 
   U32 u32;
-  _status = args.deserialize(u32);
+  _status = args.deserializeTo(u32);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3647,7 +3647,7 @@ void ActiveCommandsComponentBase ::
   }
 
   F32 f32;
-  _status = args.deserialize(f32);
+  _status = args.deserializeTo(f32);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3660,7 +3660,7 @@ void ActiveCommandsComponentBase ::
   }
 
   bool b;
-  _status = args.deserialize(b);
+  _status = args.deserializeTo(b);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3713,7 +3713,7 @@ void ActiveCommandsComponentBase ::
   args.resetDeser();
 
   Fw::CmdStringArg str1;
-  _status = args.deserialize(str1);
+  _status = args.deserializeTo(str1);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3726,7 +3726,7 @@ void ActiveCommandsComponentBase ::
   }
 
   Fw::CmdStringArg str2;
-  _status = args.deserialize(str2);
+  _status = args.deserializeTo(str2);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3778,7 +3778,7 @@ void ActiveCommandsComponentBase ::
   args.resetDeser();
 
   E e;
-  _status = args.deserialize(e);
+  _status = args.deserializeTo(e);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3829,7 +3829,7 @@ void ActiveCommandsComponentBase ::
   args.resetDeser();
 
   A a;
-  _status = args.deserialize(a);
+  _status = args.deserializeTo(a);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3880,7 +3880,7 @@ void ActiveCommandsComponentBase ::
   args.resetDeser();
 
   S s;
-  _status = args.deserialize(s);
+  _status = args.deserializeTo(s);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3933,7 +3933,7 @@ void ActiveCommandsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize for IPC
-  _status = msg.serialize(static_cast<FwEnumStoreType>(CMD_CMD_ASYNC));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_ASYNC));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3942,25 +3942,25 @@ void ActiveCommandsComponentBase ::
   // Fake port number to make message dequeue work
   FwIndexType port = 0;
 
-  _status = msg.serialize(port);
+  _status = msg.serializeFrom(port);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(opCode);
+  _status = msg.serializeFrom(opCode);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(cmdSeq);
+  _status = msg.serializeFrom(cmdSeq);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(args);
+  _status = msg.serializeFrom(args);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3992,7 +3992,7 @@ void ActiveCommandsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize for IPC
-  _status = msg.serialize(static_cast<FwEnumStoreType>(CMD_CMD_PRIORITY));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PRIORITY));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4001,25 +4001,25 @@ void ActiveCommandsComponentBase ::
   // Fake port number to make message dequeue work
   FwIndexType port = 0;
 
-  _status = msg.serialize(port);
+  _status = msg.serializeFrom(port);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(opCode);
+  _status = msg.serializeFrom(opCode);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(cmdSeq);
+  _status = msg.serializeFrom(cmdSeq);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(args);
+  _status = msg.serializeFrom(args);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4051,7 +4051,7 @@ void ActiveCommandsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize for IPC
-  _status = msg.serialize(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4060,25 +4060,25 @@ void ActiveCommandsComponentBase ::
   // Fake port number to make message dequeue work
   FwIndexType port = 0;
 
-  _status = msg.serialize(port);
+  _status = msg.serializeFrom(port);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(opCode);
+  _status = msg.serializeFrom(opCode);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(cmdSeq);
+  _status = msg.serializeFrom(cmdSeq);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(args);
+  _status = msg.serializeFrom(args);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4110,7 +4110,7 @@ void ActiveCommandsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize for IPC
-  _status = msg.serialize(static_cast<FwEnumStoreType>(CMD_CMD_DROP));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_DROP));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4119,25 +4119,25 @@ void ActiveCommandsComponentBase ::
   // Fake port number to make message dequeue work
   FwIndexType port = 0;
 
-  _status = msg.serialize(port);
+  _status = msg.serializeFrom(port);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(opCode);
+  _status = msg.serializeFrom(opCode);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(cmdSeq);
+  _status = msg.serializeFrom(cmdSeq);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(args);
+  _status = msg.serializeFrom(args);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4174,7 +4174,7 @@ void ActiveCommandsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize for IPC
-  _status = msg.serialize(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_DROP));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_DROP));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4183,25 +4183,25 @@ void ActiveCommandsComponentBase ::
   // Fake port number to make message dequeue work
   FwIndexType port = 0;
 
-  _status = msg.serialize(port);
+  _status = msg.serializeFrom(port);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(opCode);
+  _status = msg.serializeFrom(opCode);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(cmdSeq);
+  _status = msg.serializeFrom(cmdSeq);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(args);
+  _status = msg.serializeFrom(args);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4345,7 +4345,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
   _msg.resetDeser();
 
   FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -4358,7 +4358,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
   }
 
   FwIndexType portNum = 0;
-  _deserStatus = _msg.deserialize(portNum);
+  _deserStatus = _msg.deserializeTo(portNum);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -4369,7 +4369,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
     case ALIASTYPEDASYNC_ALIASTYPED: {
       // Deserialize argument u32
       AliasPrim1 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4377,7 +4377,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize argument f32
       AliasPrim2 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4385,7 +4385,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize argument b
       AliasBool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4394,7 +4394,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
       // Deserialize argument str2
       char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
       Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserialize(str2);
+      _deserStatus = _msg.deserializeTo(str2);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4402,7 +4402,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize argument e
       AliasEnum e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4410,7 +4410,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize argument a
       AliasArray a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4418,7 +4418,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize argument s
       AliasStruct s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4450,7 +4450,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
     case TYPEDASYNC_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4458,7 +4458,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4466,7 +4466,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4475,7 +4475,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4483,7 +4483,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4491,7 +4491,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4499,7 +4499,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4523,7 +4523,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
     case TYPEDASYNCASSERT_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4531,7 +4531,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4539,7 +4539,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4548,7 +4548,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4556,7 +4556,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4564,7 +4564,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4572,7 +4572,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4596,7 +4596,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
     case TYPEDASYNCBLOCKPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4604,7 +4604,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4612,7 +4612,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4621,7 +4621,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4629,7 +4629,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4637,7 +4637,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4645,7 +4645,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4669,7 +4669,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
     case TYPEDASYNCDROPPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4677,7 +4677,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4685,7 +4685,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4694,7 +4694,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4702,7 +4702,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4710,7 +4710,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4718,7 +4718,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4742,7 +4742,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
     case CMD_CMD_ASYNC: {
       // Deserialize opcode
       FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserialize(_opCode);
+      _deserStatus = _msg.deserializeTo(_opCode);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4750,7 +4750,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize command sequence
       U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserialize(_cmdSeq);
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4758,7 +4758,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize command argument buffer
       Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserialize(args);
+      _deserStatus = _msg.deserializeTo(args);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4789,7 +4789,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
     case CMD_CMD_PRIORITY: {
       // Deserialize opcode
       FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserialize(_opCode);
+      _deserStatus = _msg.deserializeTo(_opCode);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4797,7 +4797,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize command sequence
       U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserialize(_cmdSeq);
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4805,7 +4805,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize command argument buffer
       Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserialize(args);
+      _deserStatus = _msg.deserializeTo(args);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4836,7 +4836,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
     case CMD_CMD_PARAMS_PRIORITY: {
       // Deserialize opcode
       FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserialize(_opCode);
+      _deserStatus = _msg.deserializeTo(_opCode);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4844,7 +4844,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize command sequence
       U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserialize(_cmdSeq);
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4852,7 +4852,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize command argument buffer
       Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserialize(args);
+      _deserStatus = _msg.deserializeTo(args);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4863,7 +4863,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = args.deserialize(u32);
+      _deserStatus = args.deserializeTo(u32);
       if (_deserStatus != Fw::FW_SERIALIZE_OK) {
         if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
           this->cmdResponse_out(
@@ -4901,7 +4901,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
     case CMD_CMD_DROP: {
       // Deserialize opcode
       FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserialize(_opCode);
+      _deserStatus = _msg.deserializeTo(_opCode);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4909,7 +4909,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize command sequence
       U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserialize(_cmdSeq);
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4917,7 +4917,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize command argument buffer
       Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserialize(args);
+      _deserStatus = _msg.deserializeTo(args);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4948,7 +4948,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
     case CMD_CMD_PARAMS_PRIORITY_DROP: {
       // Deserialize opcode
       FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserialize(_opCode);
+      _deserStatus = _msg.deserializeTo(_opCode);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4956,7 +4956,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize command sequence
       U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserialize(_cmdSeq);
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4964,7 +4964,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize command argument buffer
       Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserialize(args);
+      _deserStatus = _msg.deserializeTo(args);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4975,7 +4975,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
 
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = args.deserialize(u32);
+      _deserStatus = args.deserializeTo(u32);
       if (_deserStatus != Fw::FW_SERIALIZE_OK) {
         if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
           this->cmdResponse_out(

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.cpp
@@ -1985,7 +1985,7 @@ void ActiveEventsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
   );
   FW_ASSERT(
@@ -1994,56 +1994,56 @@ void ActiveEventsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str2
-  _status = msg.serialize(str2);
+  _status = msg.serializeFrom(str2);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2091,7 +2091,7 @@ void ActiveEventsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
   );
   FW_ASSERT(
@@ -2100,7 +2100,7 @@ void ActiveEventsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2345,7 +2345,7 @@ void ActiveEventsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
   );
   FW_ASSERT(
@@ -2354,56 +2354,56 @@ void ActiveEventsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2452,7 +2452,7 @@ void ActiveEventsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
   );
   FW_ASSERT(
@@ -2461,56 +2461,56 @@ void ActiveEventsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2559,7 +2559,7 @@ void ActiveEventsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -2568,56 +2568,56 @@ void ActiveEventsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2666,7 +2666,7 @@ void ActiveEventsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -2675,56 +2675,56 @@ void ActiveEventsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3211,7 +3211,7 @@ void ActiveEventsComponentBase ::
 #if FW_AMPCS_COMPATIBLE
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(0));
+    _status = _logBuff.serializeFrom(static_cast<U8>(0));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3288,7 +3288,7 @@ void ActiveEventsComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(3));
+    _status = _logBuff.serializeFrom(static_cast<U8>(3));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3297,7 +3297,7 @@ void ActiveEventsComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(sizeof(U32))
     );
     FW_ASSERT(
@@ -3305,7 +3305,7 @@ void ActiveEventsComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(u32);
+    _status = _logBuff.serializeFrom(u32);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3313,7 +3313,7 @@ void ActiveEventsComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(sizeof(F32))
     );
     FW_ASSERT(
@@ -3321,7 +3321,7 @@ void ActiveEventsComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(f32);
+    _status = _logBuff.serializeFrom(f32);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3329,7 +3329,7 @@ void ActiveEventsComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(sizeof(U8))
     );
     FW_ASSERT(
@@ -3337,7 +3337,7 @@ void ActiveEventsComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(b);
+    _status = _logBuff.serializeFrom(b);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3407,20 +3407,20 @@ void ActiveEventsComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(2));
+    _status = _logBuff.serializeFrom(static_cast<U8>(2));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 #endif
 
-    _status = str1.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 80));
+    _status = str1.serializeTo(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 80));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = str2.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 100));
+    _status = str2.serializeTo(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 100));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3486,7 +3486,7 @@ void ActiveEventsComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(1));
+    _status = _logBuff.serializeFrom(static_cast<U8>(1));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3495,7 +3495,7 @@ void ActiveEventsComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(E::SERIALIZED_SIZE)
     );
     FW_ASSERT(
@@ -3503,7 +3503,7 @@ void ActiveEventsComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(e);
+    _status = _logBuff.serializeFrom(e);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3579,20 +3579,20 @@ void ActiveEventsComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(1 + 1));
+    _status = _logBuff.serializeFrom(static_cast<U8>(1 + 1));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // For FATAL, add stack size of 4 and a dummy entry. No support for stacks yet.
-    _status = _logBuff.serialize(static_cast<U8>(4));
+    _status = _logBuff.serializeFrom(static_cast<U8>(4));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = _logBuff.serialize(static_cast<U32>(0));
+    _status = _logBuff.serializeFrom(static_cast<U32>(0));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3601,7 +3601,7 @@ void ActiveEventsComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(A::SERIALIZED_SIZE)
     );
     FW_ASSERT(
@@ -3609,7 +3609,7 @@ void ActiveEventsComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(a);
+    _status = _logBuff.serializeFrom(a);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3677,7 +3677,7 @@ void ActiveEventsComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(1));
+    _status = _logBuff.serializeFrom(static_cast<U8>(1));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3686,7 +3686,7 @@ void ActiveEventsComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(S::SERIALIZED_SIZE)
     );
     FW_ASSERT(
@@ -3694,7 +3694,7 @@ void ActiveEventsComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(s);
+    _status = _logBuff.serializeFrom(s);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3770,7 +3770,7 @@ void ActiveEventsComponentBase ::
 #if FW_AMPCS_COMPATIBLE
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(0));
+    _status = _logBuff.serializeFrom(static_cast<U8>(0));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3900,7 +3900,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
   _msg.resetDeser();
 
   FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -3913,7 +3913,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
   }
 
   FwIndexType portNum = 0;
-  _deserStatus = _msg.deserialize(portNum);
+  _deserStatus = _msg.deserializeTo(portNum);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -3924,7 +3924,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
     case ALIASTYPEDASYNC_ALIASTYPED: {
       // Deserialize argument u32
       AliasPrim1 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3932,7 +3932,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
 
       // Deserialize argument f32
       AliasPrim2 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3940,7 +3940,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
 
       // Deserialize argument b
       AliasBool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3949,7 +3949,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
       // Deserialize argument str2
       char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
       Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserialize(str2);
+      _deserStatus = _msg.deserializeTo(str2);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3957,7 +3957,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
 
       // Deserialize argument e
       AliasEnum e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3965,7 +3965,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
 
       // Deserialize argument a
       AliasArray a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3973,7 +3973,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
 
       // Deserialize argument s
       AliasStruct s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4005,7 +4005,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
     case TYPEDASYNC_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4013,7 +4013,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4021,7 +4021,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4030,7 +4030,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4038,7 +4038,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4046,7 +4046,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4054,7 +4054,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4078,7 +4078,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
     case TYPEDASYNCASSERT_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4086,7 +4086,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4094,7 +4094,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4103,7 +4103,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4111,7 +4111,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4119,7 +4119,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4127,7 +4127,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4151,7 +4151,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
     case TYPEDASYNCBLOCKPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4159,7 +4159,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4167,7 +4167,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4176,7 +4176,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4184,7 +4184,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4192,7 +4192,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4200,7 +4200,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4224,7 +4224,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
     case TYPEDASYNCDROPPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4232,7 +4232,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4240,7 +4240,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4249,7 +4249,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4257,7 +4257,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4265,7 +4265,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4273,7 +4273,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveExternalParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveExternalParamsComponentAc.ref.cpp
@@ -2218,7 +2218,7 @@ void ActiveExternalParamsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
   );
   FW_ASSERT(
@@ -2227,56 +2227,56 @@ void ActiveExternalParamsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str2
-  _status = msg.serialize(str2);
+  _status = msg.serializeFrom(str2);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2324,7 +2324,7 @@ void ActiveExternalParamsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
   );
   FW_ASSERT(
@@ -2333,7 +2333,7 @@ void ActiveExternalParamsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2578,7 +2578,7 @@ void ActiveExternalParamsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
   );
   FW_ASSERT(
@@ -2587,56 +2587,56 @@ void ActiveExternalParamsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2685,7 +2685,7 @@ void ActiveExternalParamsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
   );
   FW_ASSERT(
@@ -2694,56 +2694,56 @@ void ActiveExternalParamsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2792,7 +2792,7 @@ void ActiveExternalParamsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -2801,56 +2801,56 @@ void ActiveExternalParamsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2899,7 +2899,7 @@ void ActiveExternalParamsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -2908,56 +2908,56 @@ void ActiveExternalParamsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3469,7 +3469,7 @@ I32 ActiveExternalParamsComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -3492,7 +3492,7 @@ F64 ActiveExternalParamsComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -3515,7 +3515,7 @@ Fw::ParamString ActiveExternalParamsComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -3538,7 +3538,7 @@ E ActiveExternalParamsComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -3561,7 +3561,7 @@ A ActiveExternalParamsComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -3584,7 +3584,7 @@ S ActiveExternalParamsComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -3664,7 +3664,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
   _msg.resetDeser();
 
   FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -3677,7 +3677,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
   }
 
   FwIndexType portNum = 0;
-  _deserStatus = _msg.deserialize(portNum);
+  _deserStatus = _msg.deserializeTo(portNum);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -3688,7 +3688,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
     case ALIASTYPEDASYNC_ALIASTYPED: {
       // Deserialize argument u32
       AliasPrim1 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3696,7 +3696,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
 
       // Deserialize argument f32
       AliasPrim2 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3704,7 +3704,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
 
       // Deserialize argument b
       AliasBool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3713,7 +3713,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
       // Deserialize argument str2
       char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
       Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserialize(str2);
+      _deserStatus = _msg.deserializeTo(str2);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3721,7 +3721,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
 
       // Deserialize argument e
       AliasEnum e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3729,7 +3729,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
 
       // Deserialize argument a
       AliasArray a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3737,7 +3737,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
 
       // Deserialize argument s
       AliasStruct s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3769,7 +3769,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
     case TYPEDASYNC_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3777,7 +3777,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3785,7 +3785,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3794,7 +3794,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3802,7 +3802,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3810,7 +3810,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3818,7 +3818,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3842,7 +3842,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
     case TYPEDASYNCASSERT_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3850,7 +3850,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3858,7 +3858,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3867,7 +3867,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3875,7 +3875,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3883,7 +3883,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3891,7 +3891,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3915,7 +3915,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
     case TYPEDASYNCBLOCKPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3923,7 +3923,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3931,7 +3931,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3940,7 +3940,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3948,7 +3948,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3956,7 +3956,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3964,7 +3964,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3988,7 +3988,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
     case TYPEDASYNCDROPPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3996,7 +3996,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4004,7 +4004,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4013,7 +4013,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4021,7 +4021,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4029,7 +4029,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4037,7 +4037,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveExternalParamsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveExternalStateMachinesComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveExternalStateMachinesComponentAc.ref.cpp
@@ -175,32 +175,32 @@ namespace ExternalSm {
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
-    _status = _msg.serialize(static_cast<FwEnumStoreType>(EXTERNAL_STATE_MACHINE_SIGNAL));
+    _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(EXTERNAL_STATE_MACHINE_SIGNAL));
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Fake port number to make message dequeue work
-    _status = _msg.serialize(static_cast<FwIndexType>(0));
+    _status = _msg.serializeFrom(static_cast<FwIndexType>(0));
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = _msg.serialize(static_cast<FwEnumStoreType>(SmId::sm1));
+    _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(SmId::sm1));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = _msg.serialize(static_cast<FwEnumStoreType>(signal));
+    _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(signal));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = _msg.serialize(data);
+    _status = _msg.serializeFrom(data);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -227,32 +227,32 @@ namespace ExternalSm {
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
-    _status = _msg.serialize(static_cast<FwEnumStoreType>(EXTERNAL_STATE_MACHINE_SIGNAL));
+    _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(EXTERNAL_STATE_MACHINE_SIGNAL));
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Fake port number to make message dequeue work
-    _status = _msg.serialize(static_cast<FwIndexType>(0));
+    _status = _msg.serializeFrom(static_cast<FwIndexType>(0));
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = _msg.serialize(static_cast<FwEnumStoreType>(SmId::sm2));
+    _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(SmId::sm2));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = _msg.serialize(static_cast<FwEnumStoreType>(signal));
+    _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(signal));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = _msg.serialize(data);
+    _status = _msg.serializeFrom(data);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -279,32 +279,32 @@ namespace ExternalSm {
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
-    _status = _msg.serialize(static_cast<FwEnumStoreType>(EXTERNAL_STATE_MACHINE_SIGNAL));
+    _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(EXTERNAL_STATE_MACHINE_SIGNAL));
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Fake port number to make message dequeue work
-    _status = _msg.serialize(static_cast<FwIndexType>(0));
+    _status = _msg.serializeFrom(static_cast<FwIndexType>(0));
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = _msg.serialize(static_cast<FwEnumStoreType>(SmId::sm3));
+    _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(SmId::sm3));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = _msg.serialize(static_cast<FwEnumStoreType>(signal));
+    _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(signal));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = _msg.serialize(data);
+    _status = _msg.serializeFrom(data);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -336,32 +336,32 @@ namespace ExternalSm {
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
-    _status = _msg.serialize(static_cast<FwEnumStoreType>(EXTERNAL_STATE_MACHINE_SIGNAL));
+    _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(EXTERNAL_STATE_MACHINE_SIGNAL));
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Fake port number to make message dequeue work
-    _status = _msg.serialize(static_cast<FwIndexType>(0));
+    _status = _msg.serializeFrom(static_cast<FwIndexType>(0));
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = _msg.serialize(static_cast<FwEnumStoreType>(SmId::sm4));
+    _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(SmId::sm4));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = _msg.serialize(static_cast<FwEnumStoreType>(signal));
+    _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(signal));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = _msg.serialize(data);
+    _status = _msg.serializeFrom(data);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -388,32 +388,32 @@ namespace ExternalSm {
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
-    _status = _msg.serialize(static_cast<FwEnumStoreType>(EXTERNAL_STATE_MACHINE_SIGNAL));
+    _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(EXTERNAL_STATE_MACHINE_SIGNAL));
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Fake port number to make message dequeue work
-    _status = _msg.serialize(static_cast<FwIndexType>(0));
+    _status = _msg.serializeFrom(static_cast<FwIndexType>(0));
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = _msg.serialize(static_cast<FwEnumStoreType>(SmId::sm5));
+    _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(SmId::sm5));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = _msg.serialize(static_cast<FwEnumStoreType>(signal));
+    _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(signal));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = _msg.serialize(data);
+    _status = _msg.serializeFrom(data);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -445,32 +445,32 @@ namespace ExternalSm {
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
-    _status = _msg.serialize(static_cast<FwEnumStoreType>(EXTERNAL_STATE_MACHINE_SIGNAL));
+    _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(EXTERNAL_STATE_MACHINE_SIGNAL));
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Fake port number to make message dequeue work
-    _status = _msg.serialize(static_cast<FwIndexType>(0));
+    _status = _msg.serializeFrom(static_cast<FwIndexType>(0));
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = _msg.serialize(static_cast<FwEnumStoreType>(SmId::sm6));
+    _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(SmId::sm6));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = _msg.serialize(static_cast<FwEnumStoreType>(signal));
+    _status = _msg.serializeFrom(static_cast<FwEnumStoreType>(signal));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = _msg.serialize(data);
+    _status = _msg.serializeFrom(data);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -510,7 +510,7 @@ namespace ExternalSm {
     _msg.resetDeser();
 
     FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
     FW_ASSERT(
       _deserStatus == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_deserStatus)
@@ -523,7 +523,7 @@ namespace ExternalSm {
     }
 
     FwIndexType portNum = 0;
-    _deserStatus = _msg.deserialize(portNum);
+    _deserStatus = _msg.deserializeTo(portNum);
     FW_ASSERT(
       _deserStatus == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_deserStatus)
@@ -536,7 +536,7 @@ namespace ExternalSm {
 
         // Deserialize the state machine ID to an FwEnumStoreType
         FwEnumStoreType enumStoreSmId = 0;
-        _deserStatus = _msg.deserialize(enumStoreSmId);
+        _deserStatus = _msg.deserializeTo(enumStoreSmId);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -548,7 +548,7 @@ namespace ExternalSm {
         // This value will be cast to the correct type in the
         // switch statement that calls the state machine update function.
         FwEnumStoreType enumStoreSmSignal = 0;
-        _deserStatus = _msg.deserialize(enumStoreSmSignal);
+        _deserStatus = _msg.deserializeTo(enumStoreSmSignal);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -556,7 +556,7 @@ namespace ExternalSm {
 
         // Deserialize the state machine data
         Fw::SmSignalBuffer data;
-        _deserStatus = _msg.deserialize(data);
+        _deserStatus = _msg.deserializeTo(data);
         FW_ASSERT(
           Fw::FW_SERIALIZE_OK == _deserStatus,
           static_cast<FwAssertArgType>(_deserStatus)

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveGetProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveGetProductsComponentAc.ref.cpp
@@ -109,12 +109,12 @@ Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serialize(array[i]);
+      status = this->m_dataBuffer.serializeFrom(array[i]);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -134,9 +134,9 @@ Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(elt);
+    status = this->m_dataBuffer.serializeFrom(elt);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -167,14 +167,14 @@ Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       const Fw::StringBase *const sbPtr = array[i];
       FW_ASSERT(sbPtr != nullptr);
-      status = sbPtr->serialize(this->m_dataBuffer, stringSize);
+      status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -195,9 +195,9 @@ Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = elt.serialize(this->m_dataBuffer, stringSize);
+    status = elt.serializeTo(this->m_dataBuffer, stringSize);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -223,12 +223,12 @@ Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serialize(array[i]);
+      status = this->m_dataBuffer.serializeFrom(array[i]);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -248,9 +248,9 @@ Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32Record;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(elt);
+    status = this->m_dataBuffer.serializeFrom(elt);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -276,11 +276,11 @@ Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
+    status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -2318,7 +2318,7 @@ void ActiveGetProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
   );
   FW_ASSERT(
@@ -2327,56 +2327,56 @@ void ActiveGetProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str2
-  _status = msg.serialize(str2);
+  _status = msg.serializeFrom(str2);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2424,7 +2424,7 @@ void ActiveGetProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
   );
   FW_ASSERT(
@@ -2433,7 +2433,7 @@ void ActiveGetProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2678,7 +2678,7 @@ void ActiveGetProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
   );
   FW_ASSERT(
@@ -2687,56 +2687,56 @@ void ActiveGetProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2785,7 +2785,7 @@ void ActiveGetProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
   );
   FW_ASSERT(
@@ -2794,56 +2794,56 @@ void ActiveGetProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2892,7 +2892,7 @@ void ActiveGetProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -2901,56 +2901,56 @@ void ActiveGetProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2999,7 +2999,7 @@ void ActiveGetProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -3008,56 +3008,56 @@ void ActiveGetProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3662,7 +3662,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
   _msg.resetDeser();
 
   FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -3675,7 +3675,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
   }
 
   FwIndexType portNum = 0;
-  _deserStatus = _msg.deserialize(portNum);
+  _deserStatus = _msg.deserializeTo(portNum);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -3686,7 +3686,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
     case ALIASTYPEDASYNC_ALIASTYPED: {
       // Deserialize argument u32
       AliasPrim1 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3694,7 +3694,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
 
       // Deserialize argument f32
       AliasPrim2 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3702,7 +3702,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
 
       // Deserialize argument b
       AliasBool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3711,7 +3711,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
       // Deserialize argument str2
       char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
       Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserialize(str2);
+      _deserStatus = _msg.deserializeTo(str2);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3719,7 +3719,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
 
       // Deserialize argument e
       AliasEnum e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3727,7 +3727,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
 
       // Deserialize argument a
       AliasArray a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3735,7 +3735,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
 
       // Deserialize argument s
       AliasStruct s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3767,7 +3767,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
     case TYPEDASYNC_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3775,7 +3775,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3783,7 +3783,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3792,7 +3792,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3800,7 +3800,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3808,7 +3808,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3816,7 +3816,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3840,7 +3840,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
     case TYPEDASYNCASSERT_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3848,7 +3848,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3856,7 +3856,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3865,7 +3865,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3873,7 +3873,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3881,7 +3881,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3889,7 +3889,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3913,7 +3913,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
     case TYPEDASYNCBLOCKPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3921,7 +3921,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3929,7 +3929,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3938,7 +3938,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3946,7 +3946,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3954,7 +3954,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3962,7 +3962,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3986,7 +3986,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
     case TYPEDASYNCDROPPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3994,7 +3994,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4002,7 +4002,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4011,7 +4011,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4019,7 +4019,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4027,7 +4027,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4035,7 +4035,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGetProductsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveGuardedProductsComponentAc.ref.cpp
@@ -109,12 +109,12 @@ Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serialize(array[i]);
+      status = this->m_dataBuffer.serializeFrom(array[i]);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -134,9 +134,9 @@ Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(elt);
+    status = this->m_dataBuffer.serializeFrom(elt);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -167,14 +167,14 @@ Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       const Fw::StringBase *const sbPtr = array[i];
       FW_ASSERT(sbPtr != nullptr);
-      status = sbPtr->serialize(this->m_dataBuffer, stringSize);
+      status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -195,9 +195,9 @@ Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = elt.serialize(this->m_dataBuffer, stringSize);
+    status = elt.serializeTo(this->m_dataBuffer, stringSize);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -223,12 +223,12 @@ Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serialize(array[i]);
+      status = this->m_dataBuffer.serializeFrom(array[i]);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -248,9 +248,9 @@ Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32Record;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(elt);
+    status = this->m_dataBuffer.serializeFrom(elt);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -276,11 +276,11 @@ Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
+    status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -2408,7 +2408,7 @@ void ActiveGuardedProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
   );
   FW_ASSERT(
@@ -2417,56 +2417,56 @@ void ActiveGuardedProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str2
-  _status = msg.serialize(str2);
+  _status = msg.serializeFrom(str2);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2514,7 +2514,7 @@ void ActiveGuardedProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
   );
   FW_ASSERT(
@@ -2523,7 +2523,7 @@ void ActiveGuardedProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2768,7 +2768,7 @@ void ActiveGuardedProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
   );
   FW_ASSERT(
@@ -2777,56 +2777,56 @@ void ActiveGuardedProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2875,7 +2875,7 @@ void ActiveGuardedProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
   );
   FW_ASSERT(
@@ -2884,56 +2884,56 @@ void ActiveGuardedProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2982,7 +2982,7 @@ void ActiveGuardedProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -2991,56 +2991,56 @@ void ActiveGuardedProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3089,7 +3089,7 @@ void ActiveGuardedProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -3098,56 +3098,56 @@ void ActiveGuardedProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3750,7 +3750,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
   _msg.resetDeser();
 
   FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -3763,7 +3763,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
   }
 
   FwIndexType portNum = 0;
-  _deserStatus = _msg.deserialize(portNum);
+  _deserStatus = _msg.deserializeTo(portNum);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -3774,7 +3774,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
     case ALIASTYPEDASYNC_ALIASTYPED: {
       // Deserialize argument u32
       AliasPrim1 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3782,7 +3782,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
 
       // Deserialize argument f32
       AliasPrim2 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3790,7 +3790,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
 
       // Deserialize argument b
       AliasBool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3799,7 +3799,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
       // Deserialize argument str2
       char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
       Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserialize(str2);
+      _deserStatus = _msg.deserializeTo(str2);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3807,7 +3807,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
 
       // Deserialize argument e
       AliasEnum e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3815,7 +3815,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
 
       // Deserialize argument a
       AliasArray a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3823,7 +3823,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
 
       // Deserialize argument s
       AliasStruct s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3855,7 +3855,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
     case TYPEDASYNC_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3863,7 +3863,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3871,7 +3871,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3880,7 +3880,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3888,7 +3888,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3896,7 +3896,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3904,7 +3904,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3928,7 +3928,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
     case TYPEDASYNCASSERT_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3936,7 +3936,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3944,7 +3944,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3953,7 +3953,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3961,7 +3961,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3969,7 +3969,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3977,7 +3977,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4001,7 +4001,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
     case TYPEDASYNCBLOCKPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4009,7 +4009,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4017,7 +4017,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4026,7 +4026,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4034,7 +4034,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4042,7 +4042,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4050,7 +4050,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4074,7 +4074,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
     case TYPEDASYNCDROPPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4082,7 +4082,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4090,7 +4090,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4099,7 +4099,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4107,7 +4107,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4115,7 +4115,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4123,7 +4123,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveGuardedProductsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveNoArgsPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveNoArgsPortsOnlyComponentAc.ref.cpp
@@ -421,7 +421,7 @@ void ActiveNoArgsPortsOnlyComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
   );
   FW_ASSERT(
@@ -430,7 +430,7 @@ void ActiveNoArgsPortsOnlyComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -596,7 +596,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveNoArgsPortsOnlyComponentBase ::
   _msg.resetDeser();
 
   FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -609,7 +609,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveNoArgsPortsOnlyComponentBase ::
   }
 
   FwIndexType portNum = 0;
-  _deserStatus = _msg.deserialize(portNum);
+  _deserStatus = _msg.deserializeTo(portNum);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveOverflowComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveOverflowComponentAc.ref.cpp
@@ -1015,7 +1015,7 @@ void ActiveOverflowComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(PRODUCTRECVINHOOK_DPRESPONSE)
   );
   FW_ASSERT(
@@ -1024,28 +1024,28 @@ void ActiveOverflowComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument id
-  _status = msg.serialize(id);
+  _status = msg.serializeFrom(id);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument buffer
-  _status = msg.serialize(buffer);
+  _status = msg.serializeFrom(buffer);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument status
-  _status = msg.serialize(status);
+  _status = msg.serializeFrom(status);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -1105,7 +1105,7 @@ void ActiveOverflowComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(ASSERTASYNC_TYPED)
   );
   FW_ASSERT(
@@ -1114,56 +1114,56 @@ void ActiveOverflowComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -1212,7 +1212,7 @@ void ActiveOverflowComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(BLOCKASYNC_TYPED)
   );
   FW_ASSERT(
@@ -1221,56 +1221,56 @@ void ActiveOverflowComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -1319,7 +1319,7 @@ void ActiveOverflowComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(DROPASYNC_TYPED)
   );
   FW_ASSERT(
@@ -1328,56 +1328,56 @@ void ActiveOverflowComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -1431,7 +1431,7 @@ void ActiveOverflowComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(HOOKASYNC_TYPED)
   );
   FW_ASSERT(
@@ -1440,56 +1440,56 @@ void ActiveOverflowComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -1537,7 +1537,7 @@ void ActiveOverflowComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msgSerBuff.serialize(
+  _status = msgSerBuff.serializeFrom(
     static_cast<FwEnumStoreType>(SERIALASYNCHOOK_SERIAL)
   );
   FW_ASSERT(
@@ -1546,14 +1546,14 @@ void ActiveOverflowComponentBase ::
   );
 
   // Serialize port number
-  _status = msgSerBuff.serialize(portNum);
+  _status = msgSerBuff.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument buffer
-  _status = msgSerBuff.serialize(buffer);
+  _status = msgSerBuff.serializeFrom(buffer);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -1697,14 +1697,14 @@ void ActiveOverflowComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize the message ID
-  _status = msg.serialize(static_cast<FwEnumStoreType>(INT_IF_INTERNALHOOKDROP));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALHOOKDROP));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Fake port number to make message dequeue work
-  _status = msg.serialize(static_cast<FwIndexType>(0));
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -1762,7 +1762,7 @@ void ActiveOverflowComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize for IPC
-  _status = msg.serialize(static_cast<FwEnumStoreType>(CMD_CMD_HOOK));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_HOOK));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -1771,25 +1771,25 @@ void ActiveOverflowComponentBase ::
   // Fake port number to make message dequeue work
   FwIndexType port = 0;
 
-  _status = msg.serialize(port);
+  _status = msg.serializeFrom(port);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(opCode);
+  _status = msg.serializeFrom(opCode);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(cmdSeq);
+  _status = msg.serializeFrom(cmdSeq);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(args);
+  _status = msg.serializeFrom(args);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -1826,7 +1826,7 @@ void ActiveOverflowComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize for IPC
-  _status = msg.serialize(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_HOOK));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_HOOK));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -1835,25 +1835,25 @@ void ActiveOverflowComponentBase ::
   // Fake port number to make message dequeue work
   FwIndexType port = 0;
 
-  _status = msg.serialize(port);
+  _status = msg.serializeFrom(port);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(opCode);
+  _status = msg.serializeFrom(opCode);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(cmdSeq);
+  _status = msg.serializeFrom(cmdSeq);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(args);
+  _status = msg.serializeFrom(args);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -1949,7 +1949,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
   _msg.resetDeser();
 
   FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -1962,7 +1962,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
   }
 
   FwIndexType portNum = 0;
-  _deserStatus = _msg.deserialize(portNum);
+  _deserStatus = _msg.deserializeTo(portNum);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -1973,7 +1973,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
     case PRODUCTRECVINHOOK_DPRESPONSE: {
       // Deserialize argument id
       FwDpIdType id;
-      _deserStatus = _msg.deserialize(id);
+      _deserStatus = _msg.deserializeTo(id);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -1981,7 +1981,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
 
       // Deserialize argument buffer
       Fw::Buffer buffer;
-      _deserStatus = _msg.deserialize(buffer);
+      _deserStatus = _msg.deserializeTo(buffer);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -1989,7 +1989,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
 
       // Deserialize argument status
       Fw::Success status;
-      _deserStatus = _msg.deserialize(status);
+      _deserStatus = _msg.deserializeTo(status);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2009,7 +2009,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
     case ASSERTASYNC_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2017,7 +2017,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2025,7 +2025,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2034,7 +2034,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2042,7 +2042,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2050,7 +2050,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2058,7 +2058,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2082,7 +2082,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
     case BLOCKASYNC_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2090,7 +2090,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2098,7 +2098,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2107,7 +2107,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2115,7 +2115,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2123,7 +2123,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2131,7 +2131,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2155,7 +2155,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
     case DROPASYNC_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2163,7 +2163,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2171,7 +2171,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2180,7 +2180,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2188,7 +2188,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2196,7 +2196,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2204,7 +2204,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2228,7 +2228,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
     case HOOKASYNC_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2236,7 +2236,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2244,7 +2244,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2253,7 +2253,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2261,7 +2261,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2269,7 +2269,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2277,7 +2277,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2305,7 +2305,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
         handBuff,
         static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
       );
-      _deserStatus = _msg.deserialize(serHandBuff);
+      _deserStatus = _msg.deserializeTo(serHandBuff);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2319,7 +2319,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
     case CMD_CMD_HOOK: {
       // Deserialize opcode
       FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserialize(_opCode);
+      _deserStatus = _msg.deserializeTo(_opCode);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2327,7 +2327,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
 
       // Deserialize command sequence
       U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserialize(_cmdSeq);
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2335,7 +2335,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
 
       // Deserialize command argument buffer
       Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserialize(args);
+      _deserStatus = _msg.deserializeTo(args);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2366,7 +2366,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
     case CMD_CMD_PARAMS_PRIORITY_HOOK: {
       // Deserialize opcode
       FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserialize(_opCode);
+      _deserStatus = _msg.deserializeTo(_opCode);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2374,7 +2374,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
 
       // Deserialize command sequence
       U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserialize(_cmdSeq);
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2382,7 +2382,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
 
       // Deserialize command argument buffer
       Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserialize(args);
+      _deserStatus = _msg.deserializeTo(args);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2393,7 +2393,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveOverflowComponentBase ::
 
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = args.deserialize(u32);
+      _deserStatus = args.deserializeTo(u32);
       if (_deserStatus != Fw::FW_SERIALIZE_OK) {
         if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
           this->cmdResponse_out(

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.cpp
@@ -1589,7 +1589,7 @@ void ActiveParamsComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamU32);
+    _stat = _buff.deserializeTo(this->m_ParamU32);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamU32_valid = Fw::ParamValid::INVALID;
     }
@@ -1614,7 +1614,7 @@ void ActiveParamsComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamF64);
+    _stat = _buff.deserializeTo(this->m_ParamF64);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamF64_valid = Fw::ParamValid::INVALID;
     }
@@ -1639,7 +1639,7 @@ void ActiveParamsComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamString);
+    _stat = _buff.deserializeTo(this->m_ParamString);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
       // Set default value
@@ -1668,7 +1668,7 @@ void ActiveParamsComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamEnum);
+    _stat = _buff.deserializeTo(this->m_ParamEnum);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamEnum_valid = Fw::ParamValid::INVALID;
     }
@@ -1693,7 +1693,7 @@ void ActiveParamsComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamArray);
+    _stat = _buff.deserializeTo(this->m_ParamArray);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
       // Set default value
@@ -1722,7 +1722,7 @@ void ActiveParamsComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamStruct);
+    _stat = _buff.deserializeTo(this->m_ParamStruct);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamStruct_valid = Fw::ParamValid::INVALID;
     }
@@ -2222,7 +2222,7 @@ void ActiveParamsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
   );
   FW_ASSERT(
@@ -2231,56 +2231,56 @@ void ActiveParamsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str2
-  _status = msg.serialize(str2);
+  _status = msg.serializeFrom(str2);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2328,7 +2328,7 @@ void ActiveParamsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
   );
   FW_ASSERT(
@@ -2337,7 +2337,7 @@ void ActiveParamsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2582,7 +2582,7 @@ void ActiveParamsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
   );
   FW_ASSERT(
@@ -2591,56 +2591,56 @@ void ActiveParamsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2689,7 +2689,7 @@ void ActiveParamsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
   );
   FW_ASSERT(
@@ -2698,56 +2698,56 @@ void ActiveParamsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2796,7 +2796,7 @@ void ActiveParamsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -2805,56 +2805,56 @@ void ActiveParamsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2903,7 +2903,7 @@ void ActiveParamsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -2912,56 +2912,56 @@ void ActiveParamsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3585,7 +3585,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
   _msg.resetDeser();
 
   FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -3598,7 +3598,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
   }
 
   FwIndexType portNum = 0;
-  _deserStatus = _msg.deserialize(portNum);
+  _deserStatus = _msg.deserializeTo(portNum);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -3609,7 +3609,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
     case ALIASTYPEDASYNC_ALIASTYPED: {
       // Deserialize argument u32
       AliasPrim1 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3617,7 +3617,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
 
       // Deserialize argument f32
       AliasPrim2 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3625,7 +3625,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
 
       // Deserialize argument b
       AliasBool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3634,7 +3634,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
       // Deserialize argument str2
       char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
       Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserialize(str2);
+      _deserStatus = _msg.deserializeTo(str2);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3642,7 +3642,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
 
       // Deserialize argument e
       AliasEnum e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3650,7 +3650,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
 
       // Deserialize argument a
       AliasArray a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3658,7 +3658,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
 
       // Deserialize argument s
       AliasStruct s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3690,7 +3690,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
     case TYPEDASYNC_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3698,7 +3698,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3706,7 +3706,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3715,7 +3715,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3723,7 +3723,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3731,7 +3731,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3739,7 +3739,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3763,7 +3763,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
     case TYPEDASYNCASSERT_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3771,7 +3771,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3779,7 +3779,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3788,7 +3788,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3796,7 +3796,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3804,7 +3804,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3812,7 +3812,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3836,7 +3836,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
     case TYPEDASYNCBLOCKPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3844,7 +3844,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3852,7 +3852,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3861,7 +3861,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3869,7 +3869,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3877,7 +3877,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3885,7 +3885,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3909,7 +3909,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
     case TYPEDASYNCDROPPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3917,7 +3917,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3925,7 +3925,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3934,7 +3934,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3942,7 +3942,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3950,7 +3950,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3958,7 +3958,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4541,7 +4541,7 @@ Fw::CmdResponse ActiveParamsComponentBase ::
   paramSet_ParamU32(Fw::SerializeBufferBase& val)
 {
   U32 _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -4561,7 +4561,7 @@ Fw::CmdResponse ActiveParamsComponentBase ::
   paramSet_ParamF64(Fw::SerializeBufferBase& val)
 {
   F64 _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -4581,7 +4581,7 @@ Fw::CmdResponse ActiveParamsComponentBase ::
   paramSet_ParamString(Fw::SerializeBufferBase& val)
 {
   Fw::ParamString _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -4601,7 +4601,7 @@ Fw::CmdResponse ActiveParamsComponentBase ::
   paramSet_ParamEnum(Fw::SerializeBufferBase& val)
 {
   E _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -4621,7 +4621,7 @@ Fw::CmdResponse ActiveParamsComponentBase ::
   paramSet_ParamArray(Fw::SerializeBufferBase& val)
 {
   A _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -4641,7 +4641,7 @@ Fw::CmdResponse ActiveParamsComponentBase ::
   paramSet_ParamStruct(Fw::SerializeBufferBase& val)
 {
   S _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -4670,7 +4670,7 @@ Fw::CmdResponse ActiveParamsComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamU32);
+    _stat = _saveBuff.serializeFrom(m_ParamU32);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -4700,7 +4700,7 @@ Fw::CmdResponse ActiveParamsComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamF64);
+    _stat = _saveBuff.serializeFrom(m_ParamF64);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -4730,7 +4730,7 @@ Fw::CmdResponse ActiveParamsComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamString);
+    _stat = _saveBuff.serializeFrom(m_ParamString);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -4760,7 +4760,7 @@ Fw::CmdResponse ActiveParamsComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamEnum);
+    _stat = _saveBuff.serializeFrom(m_ParamEnum);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -4790,7 +4790,7 @@ Fw::CmdResponse ActiveParamsComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamArray);
+    _stat = _saveBuff.serializeFrom(m_ParamArray);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -4820,7 +4820,7 @@ Fw::CmdResponse ActiveParamsComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamStruct);
+    _stat = _saveBuff.serializeFrom(m_ParamStruct);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
@@ -2006,7 +2006,7 @@ void ActiveSerialComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamU32);
+    _stat = _buff.deserializeTo(this->m_ParamU32);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamU32_valid = Fw::ParamValid::INVALID;
     }
@@ -2031,7 +2031,7 @@ void ActiveSerialComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamF64);
+    _stat = _buff.deserializeTo(this->m_ParamF64);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamF64_valid = Fw::ParamValid::INVALID;
     }
@@ -2056,7 +2056,7 @@ void ActiveSerialComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamString);
+    _stat = _buff.deserializeTo(this->m_ParamString);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
       // Set default value
@@ -2085,7 +2085,7 @@ void ActiveSerialComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamEnum);
+    _stat = _buff.deserializeTo(this->m_ParamEnum);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamEnum_valid = Fw::ParamValid::INVALID;
     }
@@ -2110,7 +2110,7 @@ void ActiveSerialComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamArray);
+    _stat = _buff.deserializeTo(this->m_ParamArray);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
       // Set default value
@@ -2139,7 +2139,7 @@ void ActiveSerialComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamStruct);
+    _stat = _buff.deserializeTo(this->m_ParamStruct);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamStruct_valid = Fw::ParamValid::INVALID;
     }
@@ -2872,7 +2872,7 @@ void ActiveSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
   );
   FW_ASSERT(
@@ -2881,56 +2881,56 @@ void ActiveSerialComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str2
-  _status = msg.serialize(str2);
+  _status = msg.serializeFrom(str2);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2978,7 +2978,7 @@ void ActiveSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
   );
   FW_ASSERT(
@@ -2987,7 +2987,7 @@ void ActiveSerialComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3232,7 +3232,7 @@ void ActiveSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
   );
   FW_ASSERT(
@@ -3241,56 +3241,56 @@ void ActiveSerialComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3339,7 +3339,7 @@ void ActiveSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
   );
   FW_ASSERT(
@@ -3348,56 +3348,56 @@ void ActiveSerialComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3446,7 +3446,7 @@ void ActiveSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -3455,56 +3455,56 @@ void ActiveSerialComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3553,7 +3553,7 @@ void ActiveSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -3562,56 +3562,56 @@ void ActiveSerialComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3803,7 +3803,7 @@ void ActiveSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msgSerBuff.serialize(
+  _status = msgSerBuff.serializeFrom(
     static_cast<FwEnumStoreType>(SERIALASYNC_SERIAL)
   );
   FW_ASSERT(
@@ -3812,14 +3812,14 @@ void ActiveSerialComponentBase ::
   );
 
   // Serialize port number
-  _status = msgSerBuff.serialize(portNum);
+  _status = msgSerBuff.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument buffer
-  _status = msgSerBuff.serialize(buffer);
+  _status = msgSerBuff.serializeFrom(buffer);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3856,7 +3856,7 @@ void ActiveSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msgSerBuff.serialize(
+  _status = msgSerBuff.serializeFrom(
     static_cast<FwEnumStoreType>(SERIALASYNCASSERT_SERIAL)
   );
   FW_ASSERT(
@@ -3865,14 +3865,14 @@ void ActiveSerialComponentBase ::
   );
 
   // Serialize port number
-  _status = msgSerBuff.serialize(portNum);
+  _status = msgSerBuff.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument buffer
-  _status = msgSerBuff.serialize(buffer);
+  _status = msgSerBuff.serializeFrom(buffer);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3909,7 +3909,7 @@ void ActiveSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msgSerBuff.serialize(
+  _status = msgSerBuff.serializeFrom(
     static_cast<FwEnumStoreType>(SERIALASYNCBLOCKPRIORITY_SERIAL)
   );
   FW_ASSERT(
@@ -3918,14 +3918,14 @@ void ActiveSerialComponentBase ::
   );
 
   // Serialize port number
-  _status = msgSerBuff.serialize(portNum);
+  _status = msgSerBuff.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument buffer
-  _status = msgSerBuff.serialize(buffer);
+  _status = msgSerBuff.serializeFrom(buffer);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3962,7 +3962,7 @@ void ActiveSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msgSerBuff.serialize(
+  _status = msgSerBuff.serializeFrom(
     static_cast<FwEnumStoreType>(SERIALASYNCDROPPRIORITY_SERIAL)
   );
   FW_ASSERT(
@@ -3971,14 +3971,14 @@ void ActiveSerialComponentBase ::
   );
 
   // Serialize port number
-  _status = msgSerBuff.serialize(portNum);
+  _status = msgSerBuff.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument buffer
-  _status = msgSerBuff.serialize(buffer);
+  _status = msgSerBuff.serializeFrom(buffer);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4420,20 +4420,20 @@ void ActiveSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize the message ID
-  _status = msg.serialize(static_cast<FwEnumStoreType>(INT_IF_INTERNALARRAY));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALARRAY));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Fake port number to make message dequeue work
-  _status = msg.serialize(static_cast<FwIndexType>(0));
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4456,20 +4456,20 @@ void ActiveSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize the message ID
-  _status = msg.serialize(static_cast<FwEnumStoreType>(INT_IF_INTERNALENUM));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALENUM));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Fake port number to make message dequeue work
-  _status = msg.serialize(static_cast<FwIndexType>(0));
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4496,32 +4496,32 @@ void ActiveSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize the message ID
-  _status = msg.serialize(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIMITIVE));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIMITIVE));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Fake port number to make message dequeue work
-  _status = msg.serialize(static_cast<FwIndexType>(0));
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4544,14 +4544,14 @@ void ActiveSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize the message ID
-  _status = msg.serialize(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIORITYDROP));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIORITYDROP));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Fake port number to make message dequeue work
-  _status = msg.serialize(static_cast<FwIndexType>(0));
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4582,26 +4582,26 @@ void ActiveSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize the message ID
-  _status = msg.serialize(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRING));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRING));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Fake port number to make message dequeue work
-  _status = msg.serialize(static_cast<FwIndexType>(0));
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(str1);
+  _status = msg.serializeFrom(str1);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(str2);
+  _status = msg.serializeFrom(str2);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4624,20 +4624,20 @@ void ActiveSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize the message ID
-  _status = msg.serialize(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRUCT));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRUCT));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Fake port number to make message dequeue work
-  _status = msg.serialize(static_cast<FwIndexType>(0));
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4718,7 +4718,7 @@ void ActiveSerialComponentBase ::
   args.resetDeser();
 
   U32 u32;
-  _status = args.deserialize(u32);
+  _status = args.deserializeTo(u32);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4731,7 +4731,7 @@ void ActiveSerialComponentBase ::
   }
 
   F32 f32;
-  _status = args.deserialize(f32);
+  _status = args.deserializeTo(f32);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4744,7 +4744,7 @@ void ActiveSerialComponentBase ::
   }
 
   bool b;
-  _status = args.deserialize(b);
+  _status = args.deserializeTo(b);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4793,7 +4793,7 @@ void ActiveSerialComponentBase ::
   args.resetDeser();
 
   Fw::CmdStringArg str1;
-  _status = args.deserialize(str1);
+  _status = args.deserializeTo(str1);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4806,7 +4806,7 @@ void ActiveSerialComponentBase ::
   }
 
   Fw::CmdStringArg str2;
-  _status = args.deserialize(str2);
+  _status = args.deserializeTo(str2);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4854,7 +4854,7 @@ void ActiveSerialComponentBase ::
   args.resetDeser();
 
   E e;
-  _status = args.deserialize(e);
+  _status = args.deserializeTo(e);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4901,7 +4901,7 @@ void ActiveSerialComponentBase ::
   args.resetDeser();
 
   A a;
-  _status = args.deserialize(a);
+  _status = args.deserializeTo(a);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4948,7 +4948,7 @@ void ActiveSerialComponentBase ::
   args.resetDeser();
 
   S s;
-  _status = args.deserialize(s);
+  _status = args.deserializeTo(s);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -5024,7 +5024,7 @@ void ActiveSerialComponentBase ::
   args.resetDeser();
 
   U32 u32;
-  _status = args.deserialize(u32);
+  _status = args.deserializeTo(u32);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -5037,7 +5037,7 @@ void ActiveSerialComponentBase ::
   }
 
   F32 f32;
-  _status = args.deserialize(f32);
+  _status = args.deserializeTo(f32);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -5050,7 +5050,7 @@ void ActiveSerialComponentBase ::
   }
 
   bool b;
-  _status = args.deserialize(b);
+  _status = args.deserializeTo(b);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -5103,7 +5103,7 @@ void ActiveSerialComponentBase ::
   args.resetDeser();
 
   Fw::CmdStringArg str1;
-  _status = args.deserialize(str1);
+  _status = args.deserializeTo(str1);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -5116,7 +5116,7 @@ void ActiveSerialComponentBase ::
   }
 
   Fw::CmdStringArg str2;
-  _status = args.deserialize(str2);
+  _status = args.deserializeTo(str2);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -5168,7 +5168,7 @@ void ActiveSerialComponentBase ::
   args.resetDeser();
 
   E e;
-  _status = args.deserialize(e);
+  _status = args.deserializeTo(e);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -5219,7 +5219,7 @@ void ActiveSerialComponentBase ::
   args.resetDeser();
 
   A a;
-  _status = args.deserialize(a);
+  _status = args.deserializeTo(a);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -5270,7 +5270,7 @@ void ActiveSerialComponentBase ::
   args.resetDeser();
 
   S s;
-  _status = args.deserialize(s);
+  _status = args.deserializeTo(s);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -5323,7 +5323,7 @@ void ActiveSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize for IPC
-  _status = msg.serialize(static_cast<FwEnumStoreType>(CMD_CMD_ASYNC));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_ASYNC));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -5332,25 +5332,25 @@ void ActiveSerialComponentBase ::
   // Fake port number to make message dequeue work
   FwIndexType port = 0;
 
-  _status = msg.serialize(port);
+  _status = msg.serializeFrom(port);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(opCode);
+  _status = msg.serializeFrom(opCode);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(cmdSeq);
+  _status = msg.serializeFrom(cmdSeq);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(args);
+  _status = msg.serializeFrom(args);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -5382,7 +5382,7 @@ void ActiveSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize for IPC
-  _status = msg.serialize(static_cast<FwEnumStoreType>(CMD_CMD_PRIORITY));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PRIORITY));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -5391,25 +5391,25 @@ void ActiveSerialComponentBase ::
   // Fake port number to make message dequeue work
   FwIndexType port = 0;
 
-  _status = msg.serialize(port);
+  _status = msg.serializeFrom(port);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(opCode);
+  _status = msg.serializeFrom(opCode);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(cmdSeq);
+  _status = msg.serializeFrom(cmdSeq);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(args);
+  _status = msg.serializeFrom(args);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -5441,7 +5441,7 @@ void ActiveSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize for IPC
-  _status = msg.serialize(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -5450,25 +5450,25 @@ void ActiveSerialComponentBase ::
   // Fake port number to make message dequeue work
   FwIndexType port = 0;
 
-  _status = msg.serialize(port);
+  _status = msg.serializeFrom(port);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(opCode);
+  _status = msg.serializeFrom(opCode);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(cmdSeq);
+  _status = msg.serializeFrom(cmdSeq);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(args);
+  _status = msg.serializeFrom(args);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -5500,7 +5500,7 @@ void ActiveSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize for IPC
-  _status = msg.serialize(static_cast<FwEnumStoreType>(CMD_CMD_DROP));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_DROP));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -5509,25 +5509,25 @@ void ActiveSerialComponentBase ::
   // Fake port number to make message dequeue work
   FwIndexType port = 0;
 
-  _status = msg.serialize(port);
+  _status = msg.serializeFrom(port);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(opCode);
+  _status = msg.serializeFrom(opCode);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(cmdSeq);
+  _status = msg.serializeFrom(cmdSeq);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(args);
+  _status = msg.serializeFrom(args);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -5564,7 +5564,7 @@ void ActiveSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize for IPC
-  _status = msg.serialize(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_DROP));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_DROP));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -5573,25 +5573,25 @@ void ActiveSerialComponentBase ::
   // Fake port number to make message dequeue work
   FwIndexType port = 0;
 
-  _status = msg.serialize(port);
+  _status = msg.serializeFrom(port);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(opCode);
+  _status = msg.serializeFrom(opCode);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(cmdSeq);
+  _status = msg.serializeFrom(cmdSeq);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(args);
+  _status = msg.serializeFrom(args);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -5699,7 +5699,7 @@ void ActiveSerialComponentBase ::
 #if FW_AMPCS_COMPATIBLE
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(0));
+    _status = _logBuff.serializeFrom(static_cast<U8>(0));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -5776,7 +5776,7 @@ void ActiveSerialComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(3));
+    _status = _logBuff.serializeFrom(static_cast<U8>(3));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -5785,7 +5785,7 @@ void ActiveSerialComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(sizeof(U32))
     );
     FW_ASSERT(
@@ -5793,7 +5793,7 @@ void ActiveSerialComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(u32);
+    _status = _logBuff.serializeFrom(u32);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -5801,7 +5801,7 @@ void ActiveSerialComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(sizeof(F32))
     );
     FW_ASSERT(
@@ -5809,7 +5809,7 @@ void ActiveSerialComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(f32);
+    _status = _logBuff.serializeFrom(f32);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -5817,7 +5817,7 @@ void ActiveSerialComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(sizeof(U8))
     );
     FW_ASSERT(
@@ -5825,7 +5825,7 @@ void ActiveSerialComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(b);
+    _status = _logBuff.serializeFrom(b);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -5895,20 +5895,20 @@ void ActiveSerialComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(2));
+    _status = _logBuff.serializeFrom(static_cast<U8>(2));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 #endif
 
-    _status = str1.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 80));
+    _status = str1.serializeTo(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 80));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = str2.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 100));
+    _status = str2.serializeTo(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 100));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -5974,7 +5974,7 @@ void ActiveSerialComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(1));
+    _status = _logBuff.serializeFrom(static_cast<U8>(1));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -5983,7 +5983,7 @@ void ActiveSerialComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(E::SERIALIZED_SIZE)
     );
     FW_ASSERT(
@@ -5991,7 +5991,7 @@ void ActiveSerialComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(e);
+    _status = _logBuff.serializeFrom(e);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -6067,20 +6067,20 @@ void ActiveSerialComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(1 + 1));
+    _status = _logBuff.serializeFrom(static_cast<U8>(1 + 1));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // For FATAL, add stack size of 4 and a dummy entry. No support for stacks yet.
-    _status = _logBuff.serialize(static_cast<U8>(4));
+    _status = _logBuff.serializeFrom(static_cast<U8>(4));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = _logBuff.serialize(static_cast<U32>(0));
+    _status = _logBuff.serializeFrom(static_cast<U32>(0));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -6089,7 +6089,7 @@ void ActiveSerialComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(A::SERIALIZED_SIZE)
     );
     FW_ASSERT(
@@ -6097,7 +6097,7 @@ void ActiveSerialComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(a);
+    _status = _logBuff.serializeFrom(a);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -6165,7 +6165,7 @@ void ActiveSerialComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(1));
+    _status = _logBuff.serializeFrom(static_cast<U8>(1));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -6174,7 +6174,7 @@ void ActiveSerialComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(S::SERIALIZED_SIZE)
     );
     FW_ASSERT(
@@ -6182,7 +6182,7 @@ void ActiveSerialComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(s);
+    _status = _logBuff.serializeFrom(s);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -6258,7 +6258,7 @@ void ActiveSerialComponentBase ::
 #if FW_AMPCS_COMPATIBLE
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(0));
+    _status = _logBuff.serializeFrom(static_cast<U8>(0));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -6347,7 +6347,7 @@ void ActiveSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -6380,7 +6380,7 @@ void ActiveSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -6413,7 +6413,7 @@ void ActiveSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = arg.serialize(_tlmBuff, FW_MIN(FW_TLM_STRING_MAX_SIZE, 80));
+    Fw::SerializeStatus _stat = arg.serializeTo(_tlmBuff, FW_MIN(FW_TLM_STRING_MAX_SIZE, 80));
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -6446,7 +6446,7 @@ void ActiveSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -6479,7 +6479,7 @@ void ActiveSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -6512,7 +6512,7 @@ void ActiveSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -6545,7 +6545,7 @@ void ActiveSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -6578,7 +6578,7 @@ void ActiveSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -6611,7 +6611,7 @@ void ActiveSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -6659,7 +6659,7 @@ void ActiveSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -6707,7 +6707,7 @@ void ActiveSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -6825,7 +6825,7 @@ I32 ActiveSerialComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -6848,7 +6848,7 @@ F64 ActiveSerialComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -6871,7 +6871,7 @@ Fw::ParamString ActiveSerialComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -6894,7 +6894,7 @@ E ActiveSerialComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -6917,7 +6917,7 @@ A ActiveSerialComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -6940,7 +6940,7 @@ S ActiveSerialComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -7024,7 +7024,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
   _msg.resetDeser();
 
   FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -7037,7 +7037,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
   }
 
   FwIndexType portNum = 0;
-  _deserStatus = _msg.deserialize(portNum);
+  _deserStatus = _msg.deserializeTo(portNum);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -7048,7 +7048,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
     case ALIASTYPEDASYNC_ALIASTYPED: {
       // Deserialize argument u32
       AliasPrim1 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7056,7 +7056,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize argument f32
       AliasPrim2 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7064,7 +7064,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize argument b
       AliasBool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7073,7 +7073,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
       // Deserialize argument str2
       char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
       Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserialize(str2);
+      _deserStatus = _msg.deserializeTo(str2);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7081,7 +7081,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize argument e
       AliasEnum e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7089,7 +7089,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize argument a
       AliasArray a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7097,7 +7097,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize argument s
       AliasStruct s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7129,7 +7129,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
     case TYPEDASYNC_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7137,7 +7137,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7145,7 +7145,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7154,7 +7154,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7162,7 +7162,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7170,7 +7170,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7178,7 +7178,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7202,7 +7202,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
     case TYPEDASYNCASSERT_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7210,7 +7210,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7218,7 +7218,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7227,7 +7227,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7235,7 +7235,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7243,7 +7243,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7251,7 +7251,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7275,7 +7275,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
     case TYPEDASYNCBLOCKPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7283,7 +7283,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7291,7 +7291,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7300,7 +7300,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7308,7 +7308,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7316,7 +7316,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7324,7 +7324,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7348,7 +7348,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
     case TYPEDASYNCDROPPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7356,7 +7356,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7364,7 +7364,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7373,7 +7373,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7381,7 +7381,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7389,7 +7389,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7397,7 +7397,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7425,7 +7425,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
         handBuff,
         static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
       );
-      _deserStatus = _msg.deserialize(serHandBuff);
+      _deserStatus = _msg.deserializeTo(serHandBuff);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7443,7 +7443,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
         handBuff,
         static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
       );
-      _deserStatus = _msg.deserialize(serHandBuff);
+      _deserStatus = _msg.deserializeTo(serHandBuff);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7461,7 +7461,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
         handBuff,
         static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
       );
-      _deserStatus = _msg.deserialize(serHandBuff);
+      _deserStatus = _msg.deserializeTo(serHandBuff);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7479,7 +7479,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
         handBuff,
         static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
       );
-      _deserStatus = _msg.deserialize(serHandBuff);
+      _deserStatus = _msg.deserializeTo(serHandBuff);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7493,7 +7493,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
     case CMD_CMD_ASYNC: {
       // Deserialize opcode
       FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserialize(_opCode);
+      _deserStatus = _msg.deserializeTo(_opCode);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7501,7 +7501,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize command sequence
       U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserialize(_cmdSeq);
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7509,7 +7509,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize command argument buffer
       Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserialize(args);
+      _deserStatus = _msg.deserializeTo(args);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7540,7 +7540,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
     case CMD_CMD_PRIORITY: {
       // Deserialize opcode
       FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserialize(_opCode);
+      _deserStatus = _msg.deserializeTo(_opCode);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7548,7 +7548,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize command sequence
       U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserialize(_cmdSeq);
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7556,7 +7556,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize command argument buffer
       Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserialize(args);
+      _deserStatus = _msg.deserializeTo(args);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7587,7 +7587,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
     case CMD_CMD_PARAMS_PRIORITY: {
       // Deserialize opcode
       FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserialize(_opCode);
+      _deserStatus = _msg.deserializeTo(_opCode);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7595,7 +7595,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize command sequence
       U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserialize(_cmdSeq);
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7603,7 +7603,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize command argument buffer
       Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserialize(args);
+      _deserStatus = _msg.deserializeTo(args);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7614,7 +7614,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = args.deserialize(u32);
+      _deserStatus = args.deserializeTo(u32);
       if (_deserStatus != Fw::FW_SERIALIZE_OK) {
         if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
           this->cmdResponse_out(
@@ -7652,7 +7652,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
     case CMD_CMD_DROP: {
       // Deserialize opcode
       FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserialize(_opCode);
+      _deserStatus = _msg.deserializeTo(_opCode);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7660,7 +7660,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize command sequence
       U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserialize(_cmdSeq);
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7668,7 +7668,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize command argument buffer
       Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserialize(args);
+      _deserStatus = _msg.deserializeTo(args);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7699,7 +7699,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
     case CMD_CMD_PARAMS_PRIORITY_DROP: {
       // Deserialize opcode
       FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserialize(_opCode);
+      _deserStatus = _msg.deserializeTo(_opCode);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7707,7 +7707,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize command sequence
       U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserialize(_cmdSeq);
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7715,7 +7715,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize command argument buffer
       Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserialize(args);
+      _deserStatus = _msg.deserializeTo(args);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7726,7 +7726,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
 
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = args.deserialize(u32);
+      _deserStatus = args.deserializeTo(u32);
       if (_deserStatus != Fw::FW_SERIALIZE_OK) {
         if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
           this->cmdResponse_out(
@@ -7763,7 +7763,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
     // Handle internal interface internalArray
     case INT_IF_INTERNALARRAY: {
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
 
       // Internal interface should always deserialize
       FW_ASSERT(
@@ -7789,7 +7789,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
     // Handle internal interface internalEnum
     case INT_IF_INTERNALENUM: {
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
 
       // Internal interface should always deserialize
       FW_ASSERT(
@@ -7815,7 +7815,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
     // Handle internal interface internalPrimitive
     case INT_IF_INTERNALPRIMITIVE: {
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
 
       // Internal interface should always deserialize
       FW_ASSERT(
@@ -7824,7 +7824,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
       );
 
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
 
       // Internal interface should always deserialize
       FW_ASSERT(
@@ -7833,7 +7833,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
       );
 
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
 
       // Internal interface should always deserialize
       FW_ASSERT(
@@ -7876,7 +7876,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
     // Handle internal interface internalString
     case INT_IF_INTERNALSTRING: {
       Fw::InternalInterfaceString str1;
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
 
       // Internal interface should always deserialize
       FW_ASSERT(
@@ -7885,7 +7885,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
       );
 
       Fw::InternalInterfaceString str2;
-      _deserStatus = _msg.deserialize(str2);
+      _deserStatus = _msg.deserializeTo(str2);
 
       // Internal interface should always deserialize
       FW_ASSERT(
@@ -7912,7 +7912,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
     // Handle internal interface internalStruct
     case INT_IF_INTERNALSTRUCT: {
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
 
       // Internal interface should always deserialize
       FW_ASSERT(
@@ -8869,7 +8869,7 @@ Fw::CmdResponse ActiveSerialComponentBase ::
   paramSet_ParamU32(Fw::SerializeBufferBase& val)
 {
   U32 _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -8889,7 +8889,7 @@ Fw::CmdResponse ActiveSerialComponentBase ::
   paramSet_ParamF64(Fw::SerializeBufferBase& val)
 {
   F64 _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -8909,7 +8909,7 @@ Fw::CmdResponse ActiveSerialComponentBase ::
   paramSet_ParamString(Fw::SerializeBufferBase& val)
 {
   Fw::ParamString _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -8929,7 +8929,7 @@ Fw::CmdResponse ActiveSerialComponentBase ::
   paramSet_ParamEnum(Fw::SerializeBufferBase& val)
 {
   E _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -8949,7 +8949,7 @@ Fw::CmdResponse ActiveSerialComponentBase ::
   paramSet_ParamArray(Fw::SerializeBufferBase& val)
 {
   A _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -8969,7 +8969,7 @@ Fw::CmdResponse ActiveSerialComponentBase ::
   paramSet_ParamStruct(Fw::SerializeBufferBase& val)
 {
   S _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -9136,7 +9136,7 @@ Fw::CmdResponse ActiveSerialComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamU32);
+    _stat = _saveBuff.serializeFrom(m_ParamU32);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -9166,7 +9166,7 @@ Fw::CmdResponse ActiveSerialComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamF64);
+    _stat = _saveBuff.serializeFrom(m_ParamF64);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -9196,7 +9196,7 @@ Fw::CmdResponse ActiveSerialComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamString);
+    _stat = _saveBuff.serializeFrom(m_ParamString);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -9226,7 +9226,7 @@ Fw::CmdResponse ActiveSerialComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamEnum);
+    _stat = _saveBuff.serializeFrom(m_ParamEnum);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -9256,7 +9256,7 @@ Fw::CmdResponse ActiveSerialComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamArray);
+    _stat = _saveBuff.serializeFrom(m_ParamArray);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -9286,7 +9286,7 @@ Fw::CmdResponse ActiveSerialComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamStruct);
+    _stat = _saveBuff.serializeFrom(m_ParamStruct);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSyncProductsComponentAc.ref.cpp
@@ -109,12 +109,12 @@ Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serialize(array[i]);
+      status = this->m_dataBuffer.serializeFrom(array[i]);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -134,9 +134,9 @@ Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(elt);
+    status = this->m_dataBuffer.serializeFrom(elt);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -167,14 +167,14 @@ Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       const Fw::StringBase *const sbPtr = array[i];
       FW_ASSERT(sbPtr != nullptr);
-      status = sbPtr->serialize(this->m_dataBuffer, stringSize);
+      status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -195,9 +195,9 @@ Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = elt.serialize(this->m_dataBuffer, stringSize);
+    status = elt.serializeTo(this->m_dataBuffer, stringSize);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -223,12 +223,12 @@ Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serialize(array[i]);
+      status = this->m_dataBuffer.serializeFrom(array[i]);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -248,9 +248,9 @@ Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32Record;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(elt);
+    status = this->m_dataBuffer.serializeFrom(elt);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -276,11 +276,11 @@ Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
+    status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -2402,7 +2402,7 @@ void ActiveSyncProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
   );
   FW_ASSERT(
@@ -2411,56 +2411,56 @@ void ActiveSyncProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str2
-  _status = msg.serialize(str2);
+  _status = msg.serializeFrom(str2);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2508,7 +2508,7 @@ void ActiveSyncProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
   );
   FW_ASSERT(
@@ -2517,7 +2517,7 @@ void ActiveSyncProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2762,7 +2762,7 @@ void ActiveSyncProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
   );
   FW_ASSERT(
@@ -2771,56 +2771,56 @@ void ActiveSyncProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2869,7 +2869,7 @@ void ActiveSyncProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
   );
   FW_ASSERT(
@@ -2878,56 +2878,56 @@ void ActiveSyncProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2976,7 +2976,7 @@ void ActiveSyncProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -2985,56 +2985,56 @@ void ActiveSyncProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3083,7 +3083,7 @@ void ActiveSyncProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -3092,56 +3092,56 @@ void ActiveSyncProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3744,7 +3744,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
   _msg.resetDeser();
 
   FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -3757,7 +3757,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
   }
 
   FwIndexType portNum = 0;
-  _deserStatus = _msg.deserialize(portNum);
+  _deserStatus = _msg.deserializeTo(portNum);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -3768,7 +3768,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
     case ALIASTYPEDASYNC_ALIASTYPED: {
       // Deserialize argument u32
       AliasPrim1 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3776,7 +3776,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
 
       // Deserialize argument f32
       AliasPrim2 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3784,7 +3784,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
 
       // Deserialize argument b
       AliasBool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3793,7 +3793,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
       // Deserialize argument str2
       char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
       Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserialize(str2);
+      _deserStatus = _msg.deserializeTo(str2);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3801,7 +3801,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
 
       // Deserialize argument e
       AliasEnum e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3809,7 +3809,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
 
       // Deserialize argument a
       AliasArray a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3817,7 +3817,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
 
       // Deserialize argument s
       AliasStruct s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3849,7 +3849,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
     case TYPEDASYNC_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3857,7 +3857,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3865,7 +3865,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3874,7 +3874,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3882,7 +3882,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3890,7 +3890,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3898,7 +3898,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3922,7 +3922,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
     case TYPEDASYNCASSERT_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3930,7 +3930,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3938,7 +3938,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3947,7 +3947,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3955,7 +3955,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3963,7 +3963,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3971,7 +3971,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3995,7 +3995,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
     case TYPEDASYNCBLOCKPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4003,7 +4003,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4011,7 +4011,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4020,7 +4020,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4028,7 +4028,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4036,7 +4036,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4044,7 +4044,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4068,7 +4068,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
     case TYPEDASYNCDROPPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4076,7 +4076,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4084,7 +4084,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4093,7 +4093,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4101,7 +4101,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4109,7 +4109,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4117,7 +4117,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSyncProductsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.cpp
@@ -1988,7 +1988,7 @@ void ActiveTelemetryComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
   );
   FW_ASSERT(
@@ -1997,56 +1997,56 @@ void ActiveTelemetryComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str2
-  _status = msg.serialize(str2);
+  _status = msg.serializeFrom(str2);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2094,7 +2094,7 @@ void ActiveTelemetryComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
   );
   FW_ASSERT(
@@ -2103,7 +2103,7 @@ void ActiveTelemetryComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2348,7 +2348,7 @@ void ActiveTelemetryComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
   );
   FW_ASSERT(
@@ -2357,56 +2357,56 @@ void ActiveTelemetryComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2455,7 +2455,7 @@ void ActiveTelemetryComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
   );
   FW_ASSERT(
@@ -2464,56 +2464,56 @@ void ActiveTelemetryComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2562,7 +2562,7 @@ void ActiveTelemetryComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -2571,56 +2571,56 @@ void ActiveTelemetryComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2669,7 +2669,7 @@ void ActiveTelemetryComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -2678,56 +2678,56 @@ void ActiveTelemetryComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3209,7 +3209,7 @@ void ActiveTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -3242,7 +3242,7 @@ void ActiveTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -3275,7 +3275,7 @@ void ActiveTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = arg.serialize(_tlmBuff, FW_MIN(FW_TLM_STRING_MAX_SIZE, 80));
+    Fw::SerializeStatus _stat = arg.serializeTo(_tlmBuff, FW_MIN(FW_TLM_STRING_MAX_SIZE, 80));
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -3308,7 +3308,7 @@ void ActiveTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -3341,7 +3341,7 @@ void ActiveTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -3374,7 +3374,7 @@ void ActiveTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -3407,7 +3407,7 @@ void ActiveTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -3440,7 +3440,7 @@ void ActiveTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -3473,7 +3473,7 @@ void ActiveTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -3521,7 +3521,7 @@ void ActiveTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -3569,7 +3569,7 @@ void ActiveTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -3647,7 +3647,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
   _msg.resetDeser();
 
   FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -3660,7 +3660,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
   }
 
   FwIndexType portNum = 0;
-  _deserStatus = _msg.deserialize(portNum);
+  _deserStatus = _msg.deserializeTo(portNum);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -3671,7 +3671,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
     case ALIASTYPEDASYNC_ALIASTYPED: {
       // Deserialize argument u32
       AliasPrim1 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3679,7 +3679,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
 
       // Deserialize argument f32
       AliasPrim2 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3687,7 +3687,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
 
       // Deserialize argument b
       AliasBool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3696,7 +3696,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
       // Deserialize argument str2
       char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
       Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserialize(str2);
+      _deserStatus = _msg.deserializeTo(str2);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3704,7 +3704,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
 
       // Deserialize argument e
       AliasEnum e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3712,7 +3712,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
 
       // Deserialize argument a
       AliasArray a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3720,7 +3720,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
 
       // Deserialize argument s
       AliasStruct s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3752,7 +3752,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
     case TYPEDASYNC_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3760,7 +3760,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3768,7 +3768,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3777,7 +3777,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3785,7 +3785,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3793,7 +3793,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3801,7 +3801,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3825,7 +3825,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
     case TYPEDASYNCASSERT_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3833,7 +3833,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3841,7 +3841,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3850,7 +3850,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3858,7 +3858,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3866,7 +3866,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3874,7 +3874,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3898,7 +3898,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
     case TYPEDASYNCBLOCKPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3906,7 +3906,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3914,7 +3914,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3923,7 +3923,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3931,7 +3931,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3939,7 +3939,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3947,7 +3947,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3971,7 +3971,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
     case TYPEDASYNCDROPPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3979,7 +3979,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3987,7 +3987,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3996,7 +3996,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4004,7 +4004,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4012,7 +4012,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4020,7 +4020,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
@@ -147,12 +147,12 @@ namespace M {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
       const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
-      status = this->m_dataBuffer.serialize(id);
+      status = this->m_dataBuffer.serializeFrom(id);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
       status = this->m_dataBuffer.serializeSize(size);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
       for (FwSizeType i = 0; i < size; i++) {
-        status = this->m_dataBuffer.serialize(array[i]);
+        status = this->m_dataBuffer.serializeFrom(array[i]);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
       }
       this->m_dataSize += sizeDelta;
@@ -172,9 +172,9 @@ namespace M {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
       const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
-      status = this->m_dataBuffer.serialize(id);
+      status = this->m_dataBuffer.serializeFrom(id);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-      status = this->m_dataBuffer.serialize(elt);
+      status = this->m_dataBuffer.serializeFrom(elt);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
       this->m_dataSize += sizeDelta;
     }
@@ -205,14 +205,14 @@ namespace M {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
       const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
-      status = this->m_dataBuffer.serialize(id);
+      status = this->m_dataBuffer.serializeFrom(id);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
       status = this->m_dataBuffer.serializeSize(size);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
       for (FwSizeType i = 0; i < size; i++) {
         const Fw::StringBase *const sbPtr = array[i];
         FW_ASSERT(sbPtr != nullptr);
-        status = sbPtr->serialize(this->m_dataBuffer, stringSize);
+        status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
       }
       this->m_dataSize += sizeDelta;
@@ -233,9 +233,9 @@ namespace M {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
       const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
-      status = this->m_dataBuffer.serialize(id);
+      status = this->m_dataBuffer.serializeFrom(id);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-      status = elt.serialize(this->m_dataBuffer, stringSize);
+      status = elt.serializeTo(this->m_dataBuffer, stringSize);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
       this->m_dataSize += sizeDelta;
     }
@@ -261,12 +261,12 @@ namespace M {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
       const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
-      status = this->m_dataBuffer.serialize(id);
+      status = this->m_dataBuffer.serializeFrom(id);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
       status = this->m_dataBuffer.serializeSize(size);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
       for (FwSizeType i = 0; i < size; i++) {
-        status = this->m_dataBuffer.serialize(array[i]);
+        status = this->m_dataBuffer.serializeFrom(array[i]);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
       }
       this->m_dataSize += sizeDelta;
@@ -286,9 +286,9 @@ namespace M {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
       const FwDpIdType id = this->m_baseId + RecordId::U32Record;
-      status = this->m_dataBuffer.serialize(id);
+      status = this->m_dataBuffer.serializeFrom(id);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-      status = this->m_dataBuffer.serialize(elt);
+      status = this->m_dataBuffer.serializeFrom(elt);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
       this->m_dataSize += sizeDelta;
     }
@@ -314,11 +314,11 @@ namespace M {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
       const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
-      status = this->m_dataBuffer.serialize(id);
+      status = this->m_dataBuffer.serializeFrom(id);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
       status = this->m_dataBuffer.serializeSize(size);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-      status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
+      status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
       this->m_dataSize += sizeDelta;
     }
@@ -2095,7 +2095,7 @@ namespace M {
 
     // If there was a deserialization issue, mark it invalid
     if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
-      _stat = _buff.deserialize(this->m_ParamU32);
+      _stat = _buff.deserializeTo(this->m_ParamU32);
       if (_stat != Fw::FW_SERIALIZE_OK) {
         this->m_param_ParamU32_valid = Fw::ParamValid::INVALID;
       }
@@ -2120,7 +2120,7 @@ namespace M {
 
     // If there was a deserialization issue, mark it invalid
     if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
-      _stat = _buff.deserialize(this->m_ParamF64);
+      _stat = _buff.deserializeTo(this->m_ParamF64);
       if (_stat != Fw::FW_SERIALIZE_OK) {
         this->m_param_ParamF64_valid = Fw::ParamValid::INVALID;
       }
@@ -2145,7 +2145,7 @@ namespace M {
 
     // If there was a deserialization issue, mark it invalid
     if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
-      _stat = _buff.deserialize(this->m_ParamString);
+      _stat = _buff.deserializeTo(this->m_ParamString);
       if (_stat != Fw::FW_SERIALIZE_OK) {
         this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
         // Set default value
@@ -2174,7 +2174,7 @@ namespace M {
 
     // If there was a deserialization issue, mark it invalid
     if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
-      _stat = _buff.deserialize(this->m_ParamEnum);
+      _stat = _buff.deserializeTo(this->m_ParamEnum);
       if (_stat != Fw::FW_SERIALIZE_OK) {
         this->m_param_ParamEnum_valid = Fw::ParamValid::INVALID;
       }
@@ -2199,7 +2199,7 @@ namespace M {
 
     // If there was a deserialization issue, mark it invalid
     if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
-      _stat = _buff.deserialize(this->m_ParamArray);
+      _stat = _buff.deserializeTo(this->m_ParamArray);
       if (_stat != Fw::FW_SERIALIZE_OK) {
         this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
         // Set default value
@@ -2228,7 +2228,7 @@ namespace M {
 
     // If there was a deserialization issue, mark it invalid
     if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
-      _stat = _buff.deserialize(this->m_ParamStruct);
+      _stat = _buff.deserializeTo(this->m_ParamStruct);
       if (_stat != Fw::FW_SERIALIZE_OK) {
         this->m_param_ParamStruct_valid = Fw::ParamValid::INVALID;
       }
@@ -2928,7 +2928,7 @@ namespace M {
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize message ID
-    _status = msg.serialize(
+    _status = msg.serializeFrom(
       static_cast<FwEnumStoreType>(PRODUCTRECVIN_DPRESPONSE)
     );
     FW_ASSERT(
@@ -2937,28 +2937,28 @@ namespace M {
     );
 
     // Serialize port number
-    _status = msg.serialize(portNum);
+    _status = msg.serializeFrom(portNum);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument id
-    _status = msg.serialize(id);
+    _status = msg.serializeFrom(id);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument buffer
-    _status = msg.serialize(buffer);
+    _status = msg.serializeFrom(buffer);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument status
-    _status = msg.serialize(status);
+    _status = msg.serializeFrom(status);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3013,7 +3013,7 @@ namespace M {
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize message ID
-    _status = msg.serialize(
+    _status = msg.serializeFrom(
       static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
     );
     FW_ASSERT(
@@ -3022,56 +3022,56 @@ namespace M {
     );
 
     // Serialize port number
-    _status = msg.serialize(portNum);
+    _status = msg.serializeFrom(portNum);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument u32
-    _status = msg.serialize(u32);
+    _status = msg.serializeFrom(u32);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument f32
-    _status = msg.serialize(f32);
+    _status = msg.serializeFrom(f32);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument b
-    _status = msg.serialize(b);
+    _status = msg.serializeFrom(b);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument str2
-    _status = msg.serialize(str2);
+    _status = msg.serializeFrom(str2);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument e
-    _status = msg.serialize(e);
+    _status = msg.serializeFrom(e);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument a
-    _status = msg.serialize(a);
+    _status = msg.serializeFrom(a);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument s
-    _status = msg.serialize(s);
+    _status = msg.serializeFrom(s);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3119,7 +3119,7 @@ namespace M {
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize message ID
-    _status = msg.serialize(
+    _status = msg.serializeFrom(
       static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
     );
     FW_ASSERT(
@@ -3128,7 +3128,7 @@ namespace M {
     );
 
     // Serialize port number
-    _status = msg.serialize(portNum);
+    _status = msg.serializeFrom(portNum);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3373,7 +3373,7 @@ namespace M {
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize message ID
-    _status = msg.serialize(
+    _status = msg.serializeFrom(
       static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
     );
     FW_ASSERT(
@@ -3382,56 +3382,56 @@ namespace M {
     );
 
     // Serialize port number
-    _status = msg.serialize(portNum);
+    _status = msg.serializeFrom(portNum);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument u32
-    _status = msg.serialize(u32);
+    _status = msg.serializeFrom(u32);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument f32
-    _status = msg.serialize(f32);
+    _status = msg.serializeFrom(f32);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument b
-    _status = msg.serialize(b);
+    _status = msg.serializeFrom(b);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument str1
-    _status = str1.serialize(msg, 80);
+    _status = str1.serializeTo(msg, 80);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument e
-    _status = msg.serialize(e);
+    _status = msg.serializeFrom(e);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument a
-    _status = msg.serialize(a);
+    _status = msg.serializeFrom(a);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument s
-    _status = msg.serialize(s);
+    _status = msg.serializeFrom(s);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3480,7 +3480,7 @@ namespace M {
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize message ID
-    _status = msg.serialize(
+    _status = msg.serializeFrom(
       static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
     );
     FW_ASSERT(
@@ -3489,56 +3489,56 @@ namespace M {
     );
 
     // Serialize port number
-    _status = msg.serialize(portNum);
+    _status = msg.serializeFrom(portNum);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument u32
-    _status = msg.serialize(u32);
+    _status = msg.serializeFrom(u32);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument f32
-    _status = msg.serialize(f32);
+    _status = msg.serializeFrom(f32);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument b
-    _status = msg.serialize(b);
+    _status = msg.serializeFrom(b);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument str1
-    _status = str1.serialize(msg, 80);
+    _status = str1.serializeTo(msg, 80);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument e
-    _status = msg.serialize(e);
+    _status = msg.serializeFrom(e);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument a
-    _status = msg.serialize(a);
+    _status = msg.serializeFrom(a);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument s
-    _status = msg.serialize(s);
+    _status = msg.serializeFrom(s);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3587,7 +3587,7 @@ namespace M {
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize message ID
-    _status = msg.serialize(
+    _status = msg.serializeFrom(
       static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
     );
     FW_ASSERT(
@@ -3596,56 +3596,56 @@ namespace M {
     );
 
     // Serialize port number
-    _status = msg.serialize(portNum);
+    _status = msg.serializeFrom(portNum);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument u32
-    _status = msg.serialize(u32);
+    _status = msg.serializeFrom(u32);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument f32
-    _status = msg.serialize(f32);
+    _status = msg.serializeFrom(f32);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument b
-    _status = msg.serialize(b);
+    _status = msg.serializeFrom(b);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument str1
-    _status = str1.serialize(msg, 80);
+    _status = str1.serializeTo(msg, 80);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument e
-    _status = msg.serialize(e);
+    _status = msg.serializeFrom(e);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument a
-    _status = msg.serialize(a);
+    _status = msg.serializeFrom(a);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument s
-    _status = msg.serialize(s);
+    _status = msg.serializeFrom(s);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3694,7 +3694,7 @@ namespace M {
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize message ID
-    _status = msg.serialize(
+    _status = msg.serializeFrom(
       static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
     );
     FW_ASSERT(
@@ -3703,56 +3703,56 @@ namespace M {
     );
 
     // Serialize port number
-    _status = msg.serialize(portNum);
+    _status = msg.serializeFrom(portNum);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument u32
-    _status = msg.serialize(u32);
+    _status = msg.serializeFrom(u32);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument f32
-    _status = msg.serialize(f32);
+    _status = msg.serializeFrom(f32);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument b
-    _status = msg.serialize(b);
+    _status = msg.serializeFrom(b);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument str1
-    _status = str1.serialize(msg, 80);
+    _status = str1.serializeTo(msg, 80);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument e
-    _status = msg.serialize(e);
+    _status = msg.serializeFrom(e);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument a
-    _status = msg.serialize(a);
+    _status = msg.serializeFrom(a);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Serialize argument s
-    _status = msg.serialize(s);
+    _status = msg.serializeFrom(s);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -4293,20 +4293,20 @@ namespace M {
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
-    _status = msg.serialize(static_cast<FwEnumStoreType>(INT_IF_INTERNALARRAY));
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALARRAY));
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Fake port number to make message dequeue work
-    _status = msg.serialize(static_cast<FwIndexType>(0));
+    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = msg.serialize(a);
+    _status = msg.serializeFrom(a);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -4329,20 +4329,20 @@ namespace M {
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
-    _status = msg.serialize(static_cast<FwEnumStoreType>(INT_IF_INTERNALENUM));
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALENUM));
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Fake port number to make message dequeue work
-    _status = msg.serialize(static_cast<FwIndexType>(0));
+    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = msg.serialize(e);
+    _status = msg.serializeFrom(e);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -4369,32 +4369,32 @@ namespace M {
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
-    _status = msg.serialize(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIMITIVE));
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIMITIVE));
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Fake port number to make message dequeue work
-    _status = msg.serialize(static_cast<FwIndexType>(0));
+    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = msg.serialize(u32);
+    _status = msg.serializeFrom(u32);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = msg.serialize(f32);
+    _status = msg.serializeFrom(f32);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = msg.serialize(b);
+    _status = msg.serializeFrom(b);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -4417,14 +4417,14 @@ namespace M {
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
-    _status = msg.serialize(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIORITYDROP));
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIORITYDROP));
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Fake port number to make message dequeue work
-    _status = msg.serialize(static_cast<FwIndexType>(0));
+    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -4455,26 +4455,26 @@ namespace M {
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
-    _status = msg.serialize(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRING));
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRING));
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Fake port number to make message dequeue work
-    _status = msg.serialize(static_cast<FwIndexType>(0));
+    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = msg.serialize(str1);
+    _status = msg.serializeFrom(str1);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = msg.serialize(str2);
+    _status = msg.serializeFrom(str2);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -4497,20 +4497,20 @@ namespace M {
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message ID
-    _status = msg.serialize(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRUCT));
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRUCT));
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // Fake port number to make message dequeue work
-    _status = msg.serialize(static_cast<FwIndexType>(0));
+    _status = msg.serializeFrom(static_cast<FwIndexType>(0));
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = msg.serialize(s);
+    _status = msg.serializeFrom(s);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -4591,7 +4591,7 @@ namespace M {
     args.resetDeser();
 
     U32 u32;
-    _status = args.deserialize(u32);
+    _status = args.deserializeTo(u32);
     if (_status != Fw::FW_SERIALIZE_OK) {
       if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
         this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4604,7 +4604,7 @@ namespace M {
     }
 
     F32 f32;
-    _status = args.deserialize(f32);
+    _status = args.deserializeTo(f32);
     if (_status != Fw::FW_SERIALIZE_OK) {
       if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
         this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4617,7 +4617,7 @@ namespace M {
     }
 
     bool b;
-    _status = args.deserialize(b);
+    _status = args.deserializeTo(b);
     if (_status != Fw::FW_SERIALIZE_OK) {
       if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
         this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4666,7 +4666,7 @@ namespace M {
     args.resetDeser();
 
     Fw::CmdStringArg str1;
-    _status = args.deserialize(str1);
+    _status = args.deserializeTo(str1);
     if (_status != Fw::FW_SERIALIZE_OK) {
       if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
         this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4679,7 +4679,7 @@ namespace M {
     }
 
     Fw::CmdStringArg str2;
-    _status = args.deserialize(str2);
+    _status = args.deserializeTo(str2);
     if (_status != Fw::FW_SERIALIZE_OK) {
       if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
         this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4727,7 +4727,7 @@ namespace M {
     args.resetDeser();
 
     E e;
-    _status = args.deserialize(e);
+    _status = args.deserializeTo(e);
     if (_status != Fw::FW_SERIALIZE_OK) {
       if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
         this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4774,7 +4774,7 @@ namespace M {
     args.resetDeser();
 
     A a;
-    _status = args.deserialize(a);
+    _status = args.deserializeTo(a);
     if (_status != Fw::FW_SERIALIZE_OK) {
       if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
         this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4821,7 +4821,7 @@ namespace M {
     args.resetDeser();
 
     S s;
-    _status = args.deserialize(s);
+    _status = args.deserializeTo(s);
     if (_status != Fw::FW_SERIALIZE_OK) {
       if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
         this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4897,7 +4897,7 @@ namespace M {
     args.resetDeser();
 
     U32 u32;
-    _status = args.deserialize(u32);
+    _status = args.deserializeTo(u32);
     if (_status != Fw::FW_SERIALIZE_OK) {
       if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
         this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4910,7 +4910,7 @@ namespace M {
     }
 
     F32 f32;
-    _status = args.deserialize(f32);
+    _status = args.deserializeTo(f32);
     if (_status != Fw::FW_SERIALIZE_OK) {
       if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
         this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4923,7 +4923,7 @@ namespace M {
     }
 
     bool b;
-    _status = args.deserialize(b);
+    _status = args.deserializeTo(b);
     if (_status != Fw::FW_SERIALIZE_OK) {
       if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
         this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4976,7 +4976,7 @@ namespace M {
     args.resetDeser();
 
     Fw::CmdStringArg str1;
-    _status = args.deserialize(str1);
+    _status = args.deserializeTo(str1);
     if (_status != Fw::FW_SERIALIZE_OK) {
       if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
         this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4989,7 +4989,7 @@ namespace M {
     }
 
     Fw::CmdStringArg str2;
-    _status = args.deserialize(str2);
+    _status = args.deserializeTo(str2);
     if (_status != Fw::FW_SERIALIZE_OK) {
       if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
         this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -5041,7 +5041,7 @@ namespace M {
     args.resetDeser();
 
     E e;
-    _status = args.deserialize(e);
+    _status = args.deserializeTo(e);
     if (_status != Fw::FW_SERIALIZE_OK) {
       if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
         this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -5092,7 +5092,7 @@ namespace M {
     args.resetDeser();
 
     A a;
-    _status = args.deserialize(a);
+    _status = args.deserializeTo(a);
     if (_status != Fw::FW_SERIALIZE_OK) {
       if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
         this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -5143,7 +5143,7 @@ namespace M {
     args.resetDeser();
 
     S s;
-    _status = args.deserialize(s);
+    _status = args.deserializeTo(s);
     if (_status != Fw::FW_SERIALIZE_OK) {
       if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
         this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -5196,7 +5196,7 @@ namespace M {
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize for IPC
-    _status = msg.serialize(static_cast<FwEnumStoreType>(CMD_CMD_ASYNC));
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_ASYNC));
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -5205,25 +5205,25 @@ namespace M {
     // Fake port number to make message dequeue work
     FwIndexType port = 0;
 
-    _status = msg.serialize(port);
+    _status = msg.serializeFrom(port);
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = msg.serialize(opCode);
+    _status = msg.serializeFrom(opCode);
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = msg.serialize(cmdSeq);
+    _status = msg.serializeFrom(cmdSeq);
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = msg.serialize(args);
+    _status = msg.serializeFrom(args);
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -5255,7 +5255,7 @@ namespace M {
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize for IPC
-    _status = msg.serialize(static_cast<FwEnumStoreType>(CMD_CMD_PRIORITY));
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PRIORITY));
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -5264,25 +5264,25 @@ namespace M {
     // Fake port number to make message dequeue work
     FwIndexType port = 0;
 
-    _status = msg.serialize(port);
+    _status = msg.serializeFrom(port);
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = msg.serialize(opCode);
+    _status = msg.serializeFrom(opCode);
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = msg.serialize(cmdSeq);
+    _status = msg.serializeFrom(cmdSeq);
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = msg.serialize(args);
+    _status = msg.serializeFrom(args);
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -5314,7 +5314,7 @@ namespace M {
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize for IPC
-    _status = msg.serialize(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY));
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY));
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -5323,25 +5323,25 @@ namespace M {
     // Fake port number to make message dequeue work
     FwIndexType port = 0;
 
-    _status = msg.serialize(port);
+    _status = msg.serializeFrom(port);
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = msg.serialize(opCode);
+    _status = msg.serializeFrom(opCode);
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = msg.serialize(cmdSeq);
+    _status = msg.serializeFrom(cmdSeq);
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = msg.serialize(args);
+    _status = msg.serializeFrom(args);
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -5373,7 +5373,7 @@ namespace M {
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize for IPC
-    _status = msg.serialize(static_cast<FwEnumStoreType>(CMD_CMD_DROP));
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_DROP));
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -5382,25 +5382,25 @@ namespace M {
     // Fake port number to make message dequeue work
     FwIndexType port = 0;
 
-    _status = msg.serialize(port);
+    _status = msg.serializeFrom(port);
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = msg.serialize(opCode);
+    _status = msg.serializeFrom(opCode);
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = msg.serialize(cmdSeq);
+    _status = msg.serializeFrom(cmdSeq);
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = msg.serialize(args);
+    _status = msg.serializeFrom(args);
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -5437,7 +5437,7 @@ namespace M {
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
     // Serialize for IPC
-    _status = msg.serialize(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_DROP));
+    _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_DROP));
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -5446,25 +5446,25 @@ namespace M {
     // Fake port number to make message dequeue work
     FwIndexType port = 0;
 
-    _status = msg.serialize(port);
+    _status = msg.serializeFrom(port);
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = msg.serialize(opCode);
+    _status = msg.serializeFrom(opCode);
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = msg.serialize(cmdSeq);
+    _status = msg.serializeFrom(cmdSeq);
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = msg.serialize(args);
+    _status = msg.serializeFrom(args);
     FW_ASSERT (
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -5572,7 +5572,7 @@ namespace M {
 #if FW_AMPCS_COMPATIBLE
       Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
       // Serialize the number of arguments
-      _status = _logBuff.serialize(static_cast<U8>(0));
+      _status = _logBuff.serializeFrom(static_cast<U8>(0));
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5649,7 +5649,7 @@ namespace M {
 
 #if FW_AMPCS_COMPATIBLE
       // Serialize the number of arguments
-      _status = _logBuff.serialize(static_cast<U8>(3));
+      _status = _logBuff.serializeFrom(static_cast<U8>(3));
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5658,7 +5658,7 @@ namespace M {
 
 #if FW_AMPCS_COMPATIBLE
       // Serialize the argument size
-      _status = _logBuff.serialize(
+      _status = _logBuff.serializeFrom(
         static_cast<U8>(sizeof(U32))
       );
       FW_ASSERT(
@@ -5666,7 +5666,7 @@ namespace M {
         static_cast<FwAssertArgType>(_status)
       );
 #endif
-      _status = _logBuff.serialize(u32);
+      _status = _logBuff.serializeFrom(u32);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5674,7 +5674,7 @@ namespace M {
 
 #if FW_AMPCS_COMPATIBLE
       // Serialize the argument size
-      _status = _logBuff.serialize(
+      _status = _logBuff.serializeFrom(
         static_cast<U8>(sizeof(F32))
       );
       FW_ASSERT(
@@ -5682,7 +5682,7 @@ namespace M {
         static_cast<FwAssertArgType>(_status)
       );
 #endif
-      _status = _logBuff.serialize(f32);
+      _status = _logBuff.serializeFrom(f32);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5690,7 +5690,7 @@ namespace M {
 
 #if FW_AMPCS_COMPATIBLE
       // Serialize the argument size
-      _status = _logBuff.serialize(
+      _status = _logBuff.serializeFrom(
         static_cast<U8>(sizeof(U8))
       );
       FW_ASSERT(
@@ -5698,7 +5698,7 @@ namespace M {
         static_cast<FwAssertArgType>(_status)
       );
 #endif
-      _status = _logBuff.serialize(b);
+      _status = _logBuff.serializeFrom(b);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5768,20 +5768,20 @@ namespace M {
 
 #if FW_AMPCS_COMPATIBLE
       // Serialize the number of arguments
-      _status = _logBuff.serialize(static_cast<U8>(2));
+      _status = _logBuff.serializeFrom(static_cast<U8>(2));
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
 #endif
 
-      _status = str1.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 80));
+      _status = str1.serializeTo(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 80));
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
 
-      _status = str2.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 100));
+      _status = str2.serializeTo(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 100));
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5847,7 +5847,7 @@ namespace M {
 
 #if FW_AMPCS_COMPATIBLE
       // Serialize the number of arguments
-      _status = _logBuff.serialize(static_cast<U8>(1));
+      _status = _logBuff.serializeFrom(static_cast<U8>(1));
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5856,7 +5856,7 @@ namespace M {
 
 #if FW_AMPCS_COMPATIBLE
       // Serialize the argument size
-      _status = _logBuff.serialize(
+      _status = _logBuff.serializeFrom(
         static_cast<U8>(E::SERIALIZED_SIZE)
       );
       FW_ASSERT(
@@ -5864,7 +5864,7 @@ namespace M {
         static_cast<FwAssertArgType>(_status)
       );
 #endif
-      _status = _logBuff.serialize(e);
+      _status = _logBuff.serializeFrom(e);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5940,20 +5940,20 @@ namespace M {
 
 #if FW_AMPCS_COMPATIBLE
       // Serialize the number of arguments
-      _status = _logBuff.serialize(static_cast<U8>(1 + 1));
+      _status = _logBuff.serializeFrom(static_cast<U8>(1 + 1));
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
 
       // For FATAL, add stack size of 4 and a dummy entry. No support for stacks yet.
-      _status = _logBuff.serialize(static_cast<U8>(4));
+      _status = _logBuff.serializeFrom(static_cast<U8>(4));
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
       );
 
-      _status = _logBuff.serialize(static_cast<U32>(0));
+      _status = _logBuff.serializeFrom(static_cast<U32>(0));
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5962,7 +5962,7 @@ namespace M {
 
 #if FW_AMPCS_COMPATIBLE
       // Serialize the argument size
-      _status = _logBuff.serialize(
+      _status = _logBuff.serializeFrom(
         static_cast<U8>(A::SERIALIZED_SIZE)
       );
       FW_ASSERT(
@@ -5970,7 +5970,7 @@ namespace M {
         static_cast<FwAssertArgType>(_status)
       );
 #endif
-      _status = _logBuff.serialize(a);
+      _status = _logBuff.serializeFrom(a);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -6038,7 +6038,7 @@ namespace M {
 
 #if FW_AMPCS_COMPATIBLE
       // Serialize the number of arguments
-      _status = _logBuff.serialize(static_cast<U8>(1));
+      _status = _logBuff.serializeFrom(static_cast<U8>(1));
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -6047,7 +6047,7 @@ namespace M {
 
 #if FW_AMPCS_COMPATIBLE
       // Serialize the argument size
-      _status = _logBuff.serialize(
+      _status = _logBuff.serializeFrom(
         static_cast<U8>(S::SERIALIZED_SIZE)
       );
       FW_ASSERT(
@@ -6055,7 +6055,7 @@ namespace M {
         static_cast<FwAssertArgType>(_status)
       );
 #endif
-      _status = _logBuff.serialize(s);
+      _status = _logBuff.serializeFrom(s);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -6131,7 +6131,7 @@ namespace M {
 #if FW_AMPCS_COMPATIBLE
       Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
       // Serialize the number of arguments
-      _status = _logBuff.serialize(static_cast<U8>(0));
+      _status = _logBuff.serializeFrom(static_cast<U8>(0));
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -6220,7 +6220,7 @@ namespace M {
       }
 
       Fw::TlmBuffer _tlmBuff;
-      Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+      Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
       FW_ASSERT(
         _stat == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_stat)
@@ -6253,7 +6253,7 @@ namespace M {
       }
 
       Fw::TlmBuffer _tlmBuff;
-      Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+      Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
       FW_ASSERT(
         _stat == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_stat)
@@ -6286,7 +6286,7 @@ namespace M {
       }
 
       Fw::TlmBuffer _tlmBuff;
-      Fw::SerializeStatus _stat = arg.serialize(_tlmBuff, FW_MIN(FW_TLM_STRING_MAX_SIZE, 80));
+      Fw::SerializeStatus _stat = arg.serializeTo(_tlmBuff, FW_MIN(FW_TLM_STRING_MAX_SIZE, 80));
       FW_ASSERT(
         _stat == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_stat)
@@ -6319,7 +6319,7 @@ namespace M {
       }
 
       Fw::TlmBuffer _tlmBuff;
-      Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+      Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
       FW_ASSERT(
         _stat == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_stat)
@@ -6352,7 +6352,7 @@ namespace M {
       }
 
       Fw::TlmBuffer _tlmBuff;
-      Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+      Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
       FW_ASSERT(
         _stat == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_stat)
@@ -6385,7 +6385,7 @@ namespace M {
       }
 
       Fw::TlmBuffer _tlmBuff;
-      Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+      Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
       FW_ASSERT(
         _stat == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_stat)
@@ -6418,7 +6418,7 @@ namespace M {
       }
 
       Fw::TlmBuffer _tlmBuff;
-      Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+      Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
       FW_ASSERT(
         _stat == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_stat)
@@ -6451,7 +6451,7 @@ namespace M {
       }
 
       Fw::TlmBuffer _tlmBuff;
-      Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+      Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
       FW_ASSERT(
         _stat == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_stat)
@@ -6484,7 +6484,7 @@ namespace M {
       }
 
       Fw::TlmBuffer _tlmBuff;
-      Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+      Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
       FW_ASSERT(
         _stat == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_stat)
@@ -6532,7 +6532,7 @@ namespace M {
       }
 
       Fw::TlmBuffer _tlmBuff;
-      Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+      Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
       FW_ASSERT(
         _stat == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_stat)
@@ -6580,7 +6580,7 @@ namespace M {
       }
 
       Fw::TlmBuffer _tlmBuff;
-      Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+      Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
       FW_ASSERT(
         _stat == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_stat)
@@ -6698,7 +6698,7 @@ namespace M {
     // Get the external parameter from the delegate
     Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
     if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _getBuff.deserialize(_local);
+      _stat = _getBuff.deserializeTo(_local);
       FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
       valid = Fw::ParamValid::VALID;
     } else {
@@ -6721,7 +6721,7 @@ namespace M {
     // Get the external parameter from the delegate
     Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
     if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _getBuff.deserialize(_local);
+      _stat = _getBuff.deserializeTo(_local);
       FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
       valid = Fw::ParamValid::VALID;
     } else {
@@ -6744,7 +6744,7 @@ namespace M {
     // Get the external parameter from the delegate
     Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
     if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _getBuff.deserialize(_local);
+      _stat = _getBuff.deserializeTo(_local);
       FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
       valid = Fw::ParamValid::VALID;
     } else {
@@ -6767,7 +6767,7 @@ namespace M {
     // Get the external parameter from the delegate
     Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
     if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _getBuff.deserialize(_local);
+      _stat = _getBuff.deserializeTo(_local);
       FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
       valid = Fw::ParamValid::VALID;
     } else {
@@ -6790,7 +6790,7 @@ namespace M {
     // Get the external parameter from the delegate
     Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
     if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _getBuff.deserialize(_local);
+      _stat = _getBuff.deserializeTo(_local);
       FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
       valid = Fw::ParamValid::VALID;
     } else {
@@ -6813,7 +6813,7 @@ namespace M {
     // Get the external parameter from the delegate
     Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
     if(_stat == Fw::FW_SERIALIZE_OK) {
-      _stat = _getBuff.deserialize(_local);
+      _stat = _getBuff.deserializeTo(_local);
       FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
       valid = Fw::ParamValid::VALID;
     } else {
@@ -6925,7 +6925,7 @@ namespace M {
     _msg.resetDeser();
 
     FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
     FW_ASSERT(
       _deserStatus == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_deserStatus)
@@ -6938,7 +6938,7 @@ namespace M {
     }
 
     FwIndexType portNum = 0;
-    _deserStatus = _msg.deserialize(portNum);
+    _deserStatus = _msg.deserializeTo(portNum);
     FW_ASSERT(
       _deserStatus == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_deserStatus)
@@ -6949,7 +6949,7 @@ namespace M {
       case PRODUCTRECVIN_DPRESPONSE: {
         // Deserialize argument id
         FwDpIdType id;
-        _deserStatus = _msg.deserialize(id);
+        _deserStatus = _msg.deserializeTo(id);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -6957,7 +6957,7 @@ namespace M {
 
         // Deserialize argument buffer
         Fw::Buffer buffer;
-        _deserStatus = _msg.deserialize(buffer);
+        _deserStatus = _msg.deserializeTo(buffer);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -6965,7 +6965,7 @@ namespace M {
 
         // Deserialize argument status
         Fw::Success status;
-        _deserStatus = _msg.deserialize(status);
+        _deserStatus = _msg.deserializeTo(status);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -6985,7 +6985,7 @@ namespace M {
       case ALIASTYPEDASYNC_ALIASTYPED: {
         // Deserialize argument u32
         AliasPrim1 u32;
-        _deserStatus = _msg.deserialize(u32);
+        _deserStatus = _msg.deserializeTo(u32);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -6993,7 +6993,7 @@ namespace M {
 
         // Deserialize argument f32
         AliasPrim2 f32;
-        _deserStatus = _msg.deserialize(f32);
+        _deserStatus = _msg.deserializeTo(f32);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7001,7 +7001,7 @@ namespace M {
 
         // Deserialize argument b
         AliasBool b;
-        _deserStatus = _msg.deserialize(b);
+        _deserStatus = _msg.deserializeTo(b);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7010,7 +7010,7 @@ namespace M {
         // Deserialize argument str2
         char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
         Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-        _deserStatus = _msg.deserialize(str2);
+        _deserStatus = _msg.deserializeTo(str2);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7018,7 +7018,7 @@ namespace M {
 
         // Deserialize argument e
         AliasEnum e;
-        _deserStatus = _msg.deserialize(e);
+        _deserStatus = _msg.deserializeTo(e);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7026,7 +7026,7 @@ namespace M {
 
         // Deserialize argument a
         AliasArray a;
-        _deserStatus = _msg.deserialize(a);
+        _deserStatus = _msg.deserializeTo(a);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7034,7 +7034,7 @@ namespace M {
 
         // Deserialize argument s
         AliasStruct s;
-        _deserStatus = _msg.deserialize(s);
+        _deserStatus = _msg.deserializeTo(s);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7066,7 +7066,7 @@ namespace M {
       case TYPEDASYNC_TYPED: {
         // Deserialize argument u32
         U32 u32;
-        _deserStatus = _msg.deserialize(u32);
+        _deserStatus = _msg.deserializeTo(u32);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7074,7 +7074,7 @@ namespace M {
 
         // Deserialize argument f32
         F32 f32;
-        _deserStatus = _msg.deserialize(f32);
+        _deserStatus = _msg.deserializeTo(f32);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7082,7 +7082,7 @@ namespace M {
 
         // Deserialize argument b
         bool b;
-        _deserStatus = _msg.deserialize(b);
+        _deserStatus = _msg.deserializeTo(b);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7091,7 +7091,7 @@ namespace M {
         // Deserialize argument str1
         char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
         Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-        _deserStatus = _msg.deserialize(str1);
+        _deserStatus = _msg.deserializeTo(str1);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7099,7 +7099,7 @@ namespace M {
 
         // Deserialize argument e
         E e;
-        _deserStatus = _msg.deserialize(e);
+        _deserStatus = _msg.deserializeTo(e);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7107,7 +7107,7 @@ namespace M {
 
         // Deserialize argument a
         A a;
-        _deserStatus = _msg.deserialize(a);
+        _deserStatus = _msg.deserializeTo(a);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7115,7 +7115,7 @@ namespace M {
 
         // Deserialize argument s
         S s;
-        _deserStatus = _msg.deserialize(s);
+        _deserStatus = _msg.deserializeTo(s);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7139,7 +7139,7 @@ namespace M {
       case TYPEDASYNCASSERT_TYPED: {
         // Deserialize argument u32
         U32 u32;
-        _deserStatus = _msg.deserialize(u32);
+        _deserStatus = _msg.deserializeTo(u32);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7147,7 +7147,7 @@ namespace M {
 
         // Deserialize argument f32
         F32 f32;
-        _deserStatus = _msg.deserialize(f32);
+        _deserStatus = _msg.deserializeTo(f32);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7155,7 +7155,7 @@ namespace M {
 
         // Deserialize argument b
         bool b;
-        _deserStatus = _msg.deserialize(b);
+        _deserStatus = _msg.deserializeTo(b);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7164,7 +7164,7 @@ namespace M {
         // Deserialize argument str1
         char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
         Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-        _deserStatus = _msg.deserialize(str1);
+        _deserStatus = _msg.deserializeTo(str1);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7172,7 +7172,7 @@ namespace M {
 
         // Deserialize argument e
         E e;
-        _deserStatus = _msg.deserialize(e);
+        _deserStatus = _msg.deserializeTo(e);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7180,7 +7180,7 @@ namespace M {
 
         // Deserialize argument a
         A a;
-        _deserStatus = _msg.deserialize(a);
+        _deserStatus = _msg.deserializeTo(a);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7188,7 +7188,7 @@ namespace M {
 
         // Deserialize argument s
         S s;
-        _deserStatus = _msg.deserialize(s);
+        _deserStatus = _msg.deserializeTo(s);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7212,7 +7212,7 @@ namespace M {
       case TYPEDASYNCBLOCKPRIORITY_TYPED: {
         // Deserialize argument u32
         U32 u32;
-        _deserStatus = _msg.deserialize(u32);
+        _deserStatus = _msg.deserializeTo(u32);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7220,7 +7220,7 @@ namespace M {
 
         // Deserialize argument f32
         F32 f32;
-        _deserStatus = _msg.deserialize(f32);
+        _deserStatus = _msg.deserializeTo(f32);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7228,7 +7228,7 @@ namespace M {
 
         // Deserialize argument b
         bool b;
-        _deserStatus = _msg.deserialize(b);
+        _deserStatus = _msg.deserializeTo(b);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7237,7 +7237,7 @@ namespace M {
         // Deserialize argument str1
         char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
         Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-        _deserStatus = _msg.deserialize(str1);
+        _deserStatus = _msg.deserializeTo(str1);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7245,7 +7245,7 @@ namespace M {
 
         // Deserialize argument e
         E e;
-        _deserStatus = _msg.deserialize(e);
+        _deserStatus = _msg.deserializeTo(e);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7253,7 +7253,7 @@ namespace M {
 
         // Deserialize argument a
         A a;
-        _deserStatus = _msg.deserialize(a);
+        _deserStatus = _msg.deserializeTo(a);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7261,7 +7261,7 @@ namespace M {
 
         // Deserialize argument s
         S s;
-        _deserStatus = _msg.deserialize(s);
+        _deserStatus = _msg.deserializeTo(s);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7285,7 +7285,7 @@ namespace M {
       case TYPEDASYNCDROPPRIORITY_TYPED: {
         // Deserialize argument u32
         U32 u32;
-        _deserStatus = _msg.deserialize(u32);
+        _deserStatus = _msg.deserializeTo(u32);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7293,7 +7293,7 @@ namespace M {
 
         // Deserialize argument f32
         F32 f32;
-        _deserStatus = _msg.deserialize(f32);
+        _deserStatus = _msg.deserializeTo(f32);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7301,7 +7301,7 @@ namespace M {
 
         // Deserialize argument b
         bool b;
-        _deserStatus = _msg.deserialize(b);
+        _deserStatus = _msg.deserializeTo(b);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7310,7 +7310,7 @@ namespace M {
         // Deserialize argument str1
         char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
         Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-        _deserStatus = _msg.deserialize(str1);
+        _deserStatus = _msg.deserializeTo(str1);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7318,7 +7318,7 @@ namespace M {
 
         // Deserialize argument e
         E e;
-        _deserStatus = _msg.deserialize(e);
+        _deserStatus = _msg.deserializeTo(e);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7326,7 +7326,7 @@ namespace M {
 
         // Deserialize argument a
         A a;
-        _deserStatus = _msg.deserialize(a);
+        _deserStatus = _msg.deserializeTo(a);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7334,7 +7334,7 @@ namespace M {
 
         // Deserialize argument s
         S s;
-        _deserStatus = _msg.deserialize(s);
+        _deserStatus = _msg.deserializeTo(s);
         FW_ASSERT(
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7358,7 +7358,7 @@ namespace M {
       case CMD_CMD_ASYNC: {
         // Deserialize opcode
         FwOpcodeType _opCode = 0;
-        _deserStatus = _msg.deserialize(_opCode);
+        _deserStatus = _msg.deserializeTo(_opCode);
         FW_ASSERT (
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7366,7 +7366,7 @@ namespace M {
 
         // Deserialize command sequence
         U32 _cmdSeq = 0;
-        _deserStatus = _msg.deserialize(_cmdSeq);
+        _deserStatus = _msg.deserializeTo(_cmdSeq);
         FW_ASSERT (
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7374,7 +7374,7 @@ namespace M {
 
         // Deserialize command argument buffer
         Fw::CmdArgBuffer args;
-        _deserStatus = _msg.deserialize(args);
+        _deserStatus = _msg.deserializeTo(args);
         FW_ASSERT (
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7405,7 +7405,7 @@ namespace M {
       case CMD_CMD_PRIORITY: {
         // Deserialize opcode
         FwOpcodeType _opCode = 0;
-        _deserStatus = _msg.deserialize(_opCode);
+        _deserStatus = _msg.deserializeTo(_opCode);
         FW_ASSERT (
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7413,7 +7413,7 @@ namespace M {
 
         // Deserialize command sequence
         U32 _cmdSeq = 0;
-        _deserStatus = _msg.deserialize(_cmdSeq);
+        _deserStatus = _msg.deserializeTo(_cmdSeq);
         FW_ASSERT (
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7421,7 +7421,7 @@ namespace M {
 
         // Deserialize command argument buffer
         Fw::CmdArgBuffer args;
-        _deserStatus = _msg.deserialize(args);
+        _deserStatus = _msg.deserializeTo(args);
         FW_ASSERT (
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7452,7 +7452,7 @@ namespace M {
       case CMD_CMD_PARAMS_PRIORITY: {
         // Deserialize opcode
         FwOpcodeType _opCode = 0;
-        _deserStatus = _msg.deserialize(_opCode);
+        _deserStatus = _msg.deserializeTo(_opCode);
         FW_ASSERT (
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7460,7 +7460,7 @@ namespace M {
 
         // Deserialize command sequence
         U32 _cmdSeq = 0;
-        _deserStatus = _msg.deserialize(_cmdSeq);
+        _deserStatus = _msg.deserializeTo(_cmdSeq);
         FW_ASSERT (
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7468,7 +7468,7 @@ namespace M {
 
         // Deserialize command argument buffer
         Fw::CmdArgBuffer args;
-        _deserStatus = _msg.deserialize(args);
+        _deserStatus = _msg.deserializeTo(args);
         FW_ASSERT (
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7479,7 +7479,7 @@ namespace M {
 
         // Deserialize argument u32
         U32 u32;
-        _deserStatus = args.deserialize(u32);
+        _deserStatus = args.deserializeTo(u32);
         if (_deserStatus != Fw::FW_SERIALIZE_OK) {
           if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
             this->cmdResponse_out(
@@ -7517,7 +7517,7 @@ namespace M {
       case CMD_CMD_DROP: {
         // Deserialize opcode
         FwOpcodeType _opCode = 0;
-        _deserStatus = _msg.deserialize(_opCode);
+        _deserStatus = _msg.deserializeTo(_opCode);
         FW_ASSERT (
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7525,7 +7525,7 @@ namespace M {
 
         // Deserialize command sequence
         U32 _cmdSeq = 0;
-        _deserStatus = _msg.deserialize(_cmdSeq);
+        _deserStatus = _msg.deserializeTo(_cmdSeq);
         FW_ASSERT (
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7533,7 +7533,7 @@ namespace M {
 
         // Deserialize command argument buffer
         Fw::CmdArgBuffer args;
-        _deserStatus = _msg.deserialize(args);
+        _deserStatus = _msg.deserializeTo(args);
         FW_ASSERT (
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7564,7 +7564,7 @@ namespace M {
       case CMD_CMD_PARAMS_PRIORITY_DROP: {
         // Deserialize opcode
         FwOpcodeType _opCode = 0;
-        _deserStatus = _msg.deserialize(_opCode);
+        _deserStatus = _msg.deserializeTo(_opCode);
         FW_ASSERT (
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7572,7 +7572,7 @@ namespace M {
 
         // Deserialize command sequence
         U32 _cmdSeq = 0;
-        _deserStatus = _msg.deserialize(_cmdSeq);
+        _deserStatus = _msg.deserializeTo(_cmdSeq);
         FW_ASSERT (
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7580,7 +7580,7 @@ namespace M {
 
         // Deserialize command argument buffer
         Fw::CmdArgBuffer args;
-        _deserStatus = _msg.deserialize(args);
+        _deserStatus = _msg.deserializeTo(args);
         FW_ASSERT (
           _deserStatus == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_deserStatus)
@@ -7591,7 +7591,7 @@ namespace M {
 
         // Deserialize argument u32
         U32 u32;
-        _deserStatus = args.deserialize(u32);
+        _deserStatus = args.deserializeTo(u32);
         if (_deserStatus != Fw::FW_SERIALIZE_OK) {
           if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
             this->cmdResponse_out(
@@ -7628,7 +7628,7 @@ namespace M {
       // Handle internal interface internalArray
       case INT_IF_INTERNALARRAY: {
         A a;
-        _deserStatus = _msg.deserialize(a);
+        _deserStatus = _msg.deserializeTo(a);
 
         // Internal interface should always deserialize
         FW_ASSERT(
@@ -7654,7 +7654,7 @@ namespace M {
       // Handle internal interface internalEnum
       case INT_IF_INTERNALENUM: {
         E e;
-        _deserStatus = _msg.deserialize(e);
+        _deserStatus = _msg.deserializeTo(e);
 
         // Internal interface should always deserialize
         FW_ASSERT(
@@ -7680,7 +7680,7 @@ namespace M {
       // Handle internal interface internalPrimitive
       case INT_IF_INTERNALPRIMITIVE: {
         U32 u32;
-        _deserStatus = _msg.deserialize(u32);
+        _deserStatus = _msg.deserializeTo(u32);
 
         // Internal interface should always deserialize
         FW_ASSERT(
@@ -7689,7 +7689,7 @@ namespace M {
         );
 
         F32 f32;
-        _deserStatus = _msg.deserialize(f32);
+        _deserStatus = _msg.deserializeTo(f32);
 
         // Internal interface should always deserialize
         FW_ASSERT(
@@ -7698,7 +7698,7 @@ namespace M {
         );
 
         bool b;
-        _deserStatus = _msg.deserialize(b);
+        _deserStatus = _msg.deserializeTo(b);
 
         // Internal interface should always deserialize
         FW_ASSERT(
@@ -7741,7 +7741,7 @@ namespace M {
       // Handle internal interface internalString
       case INT_IF_INTERNALSTRING: {
         Fw::InternalInterfaceString str1;
-        _deserStatus = _msg.deserialize(str1);
+        _deserStatus = _msg.deserializeTo(str1);
 
         // Internal interface should always deserialize
         FW_ASSERT(
@@ -7750,7 +7750,7 @@ namespace M {
         );
 
         Fw::InternalInterfaceString str2;
-        _deserStatus = _msg.deserialize(str2);
+        _deserStatus = _msg.deserializeTo(str2);
 
         // Internal interface should always deserialize
         FW_ASSERT(
@@ -7777,7 +7777,7 @@ namespace M {
       // Handle internal interface internalStruct
       case INT_IF_INTERNALSTRUCT: {
         S s;
-        _deserStatus = _msg.deserialize(s);
+        _deserStatus = _msg.deserializeTo(s);
 
         // Internal interface should always deserialize
         FW_ASSERT(
@@ -8655,7 +8655,7 @@ namespace M {
     paramSet_ParamU32(Fw::SerializeBufferBase& val)
   {
     U32 _localVal{};
-    const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
     }
@@ -8675,7 +8675,7 @@ namespace M {
     paramSet_ParamF64(Fw::SerializeBufferBase& val)
   {
     F64 _localVal{};
-    const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
     }
@@ -8695,7 +8695,7 @@ namespace M {
     paramSet_ParamString(Fw::SerializeBufferBase& val)
   {
     Fw::ParamString _localVal{};
-    const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
     }
@@ -8715,7 +8715,7 @@ namespace M {
     paramSet_ParamEnum(Fw::SerializeBufferBase& val)
   {
     E _localVal{};
-    const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
     }
@@ -8735,7 +8735,7 @@ namespace M {
     paramSet_ParamArray(Fw::SerializeBufferBase& val)
   {
     A _localVal{};
-    const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
     }
@@ -8755,7 +8755,7 @@ namespace M {
     paramSet_ParamStruct(Fw::SerializeBufferBase& val)
   {
     S _localVal{};
-    const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+    const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
     }
@@ -8922,7 +8922,7 @@ namespace M {
     if (this->m_prmSetOut_OutputPort[0].isConnected()) {
       this->m_paramLock.lock();
 
-      _stat = _saveBuff.serialize(m_ParamU32);
+      _stat = _saveBuff.serializeFrom(m_ParamU32);
 
       this->m_paramLock.unLock();
       if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -8952,7 +8952,7 @@ namespace M {
     if (this->m_prmSetOut_OutputPort[0].isConnected()) {
       this->m_paramLock.lock();
 
-      _stat = _saveBuff.serialize(m_ParamF64);
+      _stat = _saveBuff.serializeFrom(m_ParamF64);
 
       this->m_paramLock.unLock();
       if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -8982,7 +8982,7 @@ namespace M {
     if (this->m_prmSetOut_OutputPort[0].isConnected()) {
       this->m_paramLock.lock();
 
-      _stat = _saveBuff.serialize(m_ParamString);
+      _stat = _saveBuff.serializeFrom(m_ParamString);
 
       this->m_paramLock.unLock();
       if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -9012,7 +9012,7 @@ namespace M {
     if (this->m_prmSetOut_OutputPort[0].isConnected()) {
       this->m_paramLock.lock();
 
-      _stat = _saveBuff.serialize(m_ParamEnum);
+      _stat = _saveBuff.serializeFrom(m_ParamEnum);
 
       this->m_paramLock.unLock();
       if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -9042,7 +9042,7 @@ namespace M {
     if (this->m_prmSetOut_OutputPort[0].isConnected()) {
       this->m_paramLock.lock();
 
-      _stat = _saveBuff.serialize(m_ParamArray);
+      _stat = _saveBuff.serializeFrom(m_ParamArray);
 
       this->m_paramLock.unLock();
       if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -9072,7 +9072,7 @@ namespace M {
     if (this->m_prmSetOut_OutputPort[0].isConnected()) {
       this->m_paramLock.lock();
 
-      _stat = _saveBuff.serialize(m_ParamStruct);
+      _stat = _saveBuff.serializeFrom(m_ParamStruct);
 
       this->m_paramLock.unLock();
       if (_stat != Fw::FW_SERIALIZE_OK) {

--- a/compiler/tools/fpp-to-cpp/test/component/base/ArrayAliasArrayArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ArrayAliasArrayArrayAc.ref.cpp
@@ -145,11 +145,11 @@ std::ostream& operator<<(std::ostream& os, const ArrayAliasArray& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus ArrayAliasArray ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   for (U32 index = 0; index < SIZE; index++) {
-    status = buffer.serialize((*this)[index]);
+    status = buffer.serializeFrom((*this)[index]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
@@ -158,11 +158,11 @@ Fw::SerializeStatus ArrayAliasArray ::
 }
 
 Fw::SerializeStatus ArrayAliasArray ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   for (U32 index = 0; index < SIZE; index++) {
-    status = buffer.deserialize((*this)[index]);
+    status = buffer.deserializeTo((*this)[index]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }

--- a/compiler/tools/fpp-to-cpp/test/component/base/ArrayAliasArrayArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ArrayAliasArrayArrayAc.ref.hpp
@@ -130,12 +130,12 @@ class ArrayAliasArray :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/EEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/EEnumAc.ref.cpp
@@ -50,19 +50,19 @@ bool E ::
 }
 
 Fw::SerializeStatus E ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
-  const Fw::SerializeStatus status = buffer.serialize(
+  const Fw::SerializeStatus status = buffer.serializeFrom(
       static_cast<SerialType>(this->e)
   );
   return status;
 }
 
 Fw::SerializeStatus E ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   SerialType es;
-  Fw::SerializeStatus status = buffer.deserialize(es);
+  Fw::SerializeStatus status = buffer.deserializeTo(es);
   if (status == Fw::FW_SERIALIZE_OK) {
     this->e = static_cast<T>(es);
     if (!this->isValid()) {

--- a/compiler/tools/fpp-to-cpp/test/component/base/EEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/EEnumAc.ref.hpp
@@ -130,12 +130,12 @@ class E :
     bool isValid() const;
 
     //! Serialize raw enum value to SerialType
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialize raw enum value from SerialType
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveCommandsComponentAc.ref.cpp
@@ -2317,7 +2317,7 @@ void PassiveCommandsComponentBase ::
   args.resetDeser();
 
   U32 u32;
-  _status = args.deserialize(u32);
+  _status = args.deserializeTo(u32);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -2330,7 +2330,7 @@ void PassiveCommandsComponentBase ::
   }
 
   F32 f32;
-  _status = args.deserialize(f32);
+  _status = args.deserializeTo(f32);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -2343,7 +2343,7 @@ void PassiveCommandsComponentBase ::
   }
 
   bool b;
-  _status = args.deserialize(b);
+  _status = args.deserializeTo(b);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -2392,7 +2392,7 @@ void PassiveCommandsComponentBase ::
   args.resetDeser();
 
   Fw::CmdStringArg str1;
-  _status = args.deserialize(str1);
+  _status = args.deserializeTo(str1);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -2405,7 +2405,7 @@ void PassiveCommandsComponentBase ::
   }
 
   Fw::CmdStringArg str2;
-  _status = args.deserialize(str2);
+  _status = args.deserializeTo(str2);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -2453,7 +2453,7 @@ void PassiveCommandsComponentBase ::
   args.resetDeser();
 
   E e;
-  _status = args.deserialize(e);
+  _status = args.deserializeTo(e);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -2500,7 +2500,7 @@ void PassiveCommandsComponentBase ::
   args.resetDeser();
 
   A a;
-  _status = args.deserialize(a);
+  _status = args.deserializeTo(a);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -2547,7 +2547,7 @@ void PassiveCommandsComponentBase ::
   args.resetDeser();
 
   S s;
-  _status = args.deserialize(s);
+  _status = args.deserializeTo(s);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -2623,7 +2623,7 @@ void PassiveCommandsComponentBase ::
   args.resetDeser();
 
   U32 u32;
-  _status = args.deserialize(u32);
+  _status = args.deserializeTo(u32);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -2636,7 +2636,7 @@ void PassiveCommandsComponentBase ::
   }
 
   F32 f32;
-  _status = args.deserialize(f32);
+  _status = args.deserializeTo(f32);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -2649,7 +2649,7 @@ void PassiveCommandsComponentBase ::
   }
 
   bool b;
-  _status = args.deserialize(b);
+  _status = args.deserializeTo(b);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -2702,7 +2702,7 @@ void PassiveCommandsComponentBase ::
   args.resetDeser();
 
   Fw::CmdStringArg str1;
-  _status = args.deserialize(str1);
+  _status = args.deserializeTo(str1);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -2715,7 +2715,7 @@ void PassiveCommandsComponentBase ::
   }
 
   Fw::CmdStringArg str2;
-  _status = args.deserialize(str2);
+  _status = args.deserializeTo(str2);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -2767,7 +2767,7 @@ void PassiveCommandsComponentBase ::
   args.resetDeser();
 
   E e;
-  _status = args.deserialize(e);
+  _status = args.deserializeTo(e);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -2818,7 +2818,7 @@ void PassiveCommandsComponentBase ::
   args.resetDeser();
 
   A a;
-  _status = args.deserialize(a);
+  _status = args.deserializeTo(a);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -2869,7 +2869,7 @@ void PassiveCommandsComponentBase ::
   args.resetDeser();
 
   S s;
-  _status = args.deserialize(s);
+  _status = args.deserializeTo(s);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveEventsComponentAc.ref.cpp
@@ -2225,7 +2225,7 @@ void PassiveEventsComponentBase ::
 #if FW_AMPCS_COMPATIBLE
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(0));
+    _status = _logBuff.serializeFrom(static_cast<U8>(0));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -2302,7 +2302,7 @@ void PassiveEventsComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(3));
+    _status = _logBuff.serializeFrom(static_cast<U8>(3));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -2311,7 +2311,7 @@ void PassiveEventsComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(sizeof(U32))
     );
     FW_ASSERT(
@@ -2319,7 +2319,7 @@ void PassiveEventsComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(u32);
+    _status = _logBuff.serializeFrom(u32);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -2327,7 +2327,7 @@ void PassiveEventsComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(sizeof(F32))
     );
     FW_ASSERT(
@@ -2335,7 +2335,7 @@ void PassiveEventsComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(f32);
+    _status = _logBuff.serializeFrom(f32);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -2343,7 +2343,7 @@ void PassiveEventsComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(sizeof(U8))
     );
     FW_ASSERT(
@@ -2351,7 +2351,7 @@ void PassiveEventsComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(b);
+    _status = _logBuff.serializeFrom(b);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -2421,20 +2421,20 @@ void PassiveEventsComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(2));
+    _status = _logBuff.serializeFrom(static_cast<U8>(2));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 #endif
 
-    _status = str1.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 80));
+    _status = str1.serializeTo(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 80));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = str2.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 100));
+    _status = str2.serializeTo(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 100));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -2500,7 +2500,7 @@ void PassiveEventsComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(1));
+    _status = _logBuff.serializeFrom(static_cast<U8>(1));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -2509,7 +2509,7 @@ void PassiveEventsComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(E::SERIALIZED_SIZE)
     );
     FW_ASSERT(
@@ -2517,7 +2517,7 @@ void PassiveEventsComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(e);
+    _status = _logBuff.serializeFrom(e);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -2593,20 +2593,20 @@ void PassiveEventsComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(1 + 1));
+    _status = _logBuff.serializeFrom(static_cast<U8>(1 + 1));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // For FATAL, add stack size of 4 and a dummy entry. No support for stacks yet.
-    _status = _logBuff.serialize(static_cast<U8>(4));
+    _status = _logBuff.serializeFrom(static_cast<U8>(4));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = _logBuff.serialize(static_cast<U32>(0));
+    _status = _logBuff.serializeFrom(static_cast<U32>(0));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -2615,7 +2615,7 @@ void PassiveEventsComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(A::SERIALIZED_SIZE)
     );
     FW_ASSERT(
@@ -2623,7 +2623,7 @@ void PassiveEventsComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(a);
+    _status = _logBuff.serializeFrom(a);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -2691,7 +2691,7 @@ void PassiveEventsComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(1));
+    _status = _logBuff.serializeFrom(static_cast<U8>(1));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -2700,7 +2700,7 @@ void PassiveEventsComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(S::SERIALIZED_SIZE)
     );
     FW_ASSERT(
@@ -2708,7 +2708,7 @@ void PassiveEventsComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(s);
+    _status = _logBuff.serializeFrom(s);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -2784,7 +2784,7 @@ void PassiveEventsComponentBase ::
 #if FW_AMPCS_COMPATIBLE
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(0));
+    _status = _logBuff.serializeFrom(static_cast<U8>(0));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveExternalParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveExternalParamsComponentAc.ref.cpp
@@ -2483,7 +2483,7 @@ I32 PassiveExternalParamsComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -2506,7 +2506,7 @@ F64 PassiveExternalParamsComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -2529,7 +2529,7 @@ Fw::ParamString PassiveExternalParamsComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -2552,7 +2552,7 @@ E PassiveExternalParamsComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -2575,7 +2575,7 @@ A PassiveExternalParamsComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -2598,7 +2598,7 @@ S PassiveExternalParamsComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveGetProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveGetProductsComponentAc.ref.cpp
@@ -51,12 +51,12 @@ Fw::SerializeStatus PassiveGetProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serialize(array[i]);
+      status = this->m_dataBuffer.serializeFrom(array[i]);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -76,9 +76,9 @@ Fw::SerializeStatus PassiveGetProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(elt);
+    status = this->m_dataBuffer.serializeFrom(elt);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -109,14 +109,14 @@ Fw::SerializeStatus PassiveGetProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       const Fw::StringBase *const sbPtr = array[i];
       FW_ASSERT(sbPtr != nullptr);
-      status = sbPtr->serialize(this->m_dataBuffer, stringSize);
+      status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -137,9 +137,9 @@ Fw::SerializeStatus PassiveGetProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = elt.serialize(this->m_dataBuffer, stringSize);
+    status = elt.serializeTo(this->m_dataBuffer, stringSize);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -165,12 +165,12 @@ Fw::SerializeStatus PassiveGetProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serialize(array[i]);
+      status = this->m_dataBuffer.serializeFrom(array[i]);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -190,9 +190,9 @@ Fw::SerializeStatus PassiveGetProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32Record;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(elt);
+    status = this->m_dataBuffer.serializeFrom(elt);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -218,11 +218,11 @@ Fw::SerializeStatus PassiveGetProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
+    status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveGuardedProductsComponentAc.ref.cpp
@@ -51,12 +51,12 @@ Fw::SerializeStatus PassiveGuardedProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serialize(array[i]);
+      status = this->m_dataBuffer.serializeFrom(array[i]);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -76,9 +76,9 @@ Fw::SerializeStatus PassiveGuardedProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(elt);
+    status = this->m_dataBuffer.serializeFrom(elt);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -109,14 +109,14 @@ Fw::SerializeStatus PassiveGuardedProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       const Fw::StringBase *const sbPtr = array[i];
       FW_ASSERT(sbPtr != nullptr);
-      status = sbPtr->serialize(this->m_dataBuffer, stringSize);
+      status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -137,9 +137,9 @@ Fw::SerializeStatus PassiveGuardedProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = elt.serialize(this->m_dataBuffer, stringSize);
+    status = elt.serializeTo(this->m_dataBuffer, stringSize);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -165,12 +165,12 @@ Fw::SerializeStatus PassiveGuardedProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serialize(array[i]);
+      status = this->m_dataBuffer.serializeFrom(array[i]);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -190,9 +190,9 @@ Fw::SerializeStatus PassiveGuardedProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32Record;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(elt);
+    status = this->m_dataBuffer.serializeFrom(elt);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -218,11 +218,11 @@ Fw::SerializeStatus PassiveGuardedProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
+    status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveParamsComponentAc.ref.cpp
@@ -1308,7 +1308,7 @@ void PassiveParamsComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamU32);
+    _stat = _buff.deserializeTo(this->m_ParamU32);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamU32_valid = Fw::ParamValid::INVALID;
     }
@@ -1333,7 +1333,7 @@ void PassiveParamsComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamF64);
+    _stat = _buff.deserializeTo(this->m_ParamF64);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamF64_valid = Fw::ParamValid::INVALID;
     }
@@ -1358,7 +1358,7 @@ void PassiveParamsComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamString);
+    _stat = _buff.deserializeTo(this->m_ParamString);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
       // Set default value
@@ -1387,7 +1387,7 @@ void PassiveParamsComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamEnum);
+    _stat = _buff.deserializeTo(this->m_ParamEnum);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamEnum_valid = Fw::ParamValid::INVALID;
     }
@@ -1412,7 +1412,7 @@ void PassiveParamsComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamArray);
+    _stat = _buff.deserializeTo(this->m_ParamArray);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
       // Set default value
@@ -1441,7 +1441,7 @@ void PassiveParamsComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamStruct);
+    _stat = _buff.deserializeTo(this->m_ParamStruct);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamStruct_valid = Fw::ParamValid::INVALID;
     }
@@ -2985,7 +2985,7 @@ Fw::CmdResponse PassiveParamsComponentBase ::
   paramSet_ParamU32(Fw::SerializeBufferBase& val)
 {
   U32 _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -3005,7 +3005,7 @@ Fw::CmdResponse PassiveParamsComponentBase ::
   paramSet_ParamF64(Fw::SerializeBufferBase& val)
 {
   F64 _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -3025,7 +3025,7 @@ Fw::CmdResponse PassiveParamsComponentBase ::
   paramSet_ParamString(Fw::SerializeBufferBase& val)
 {
   Fw::ParamString _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -3045,7 +3045,7 @@ Fw::CmdResponse PassiveParamsComponentBase ::
   paramSet_ParamEnum(Fw::SerializeBufferBase& val)
 {
   E _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -3065,7 +3065,7 @@ Fw::CmdResponse PassiveParamsComponentBase ::
   paramSet_ParamArray(Fw::SerializeBufferBase& val)
 {
   A _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -3085,7 +3085,7 @@ Fw::CmdResponse PassiveParamsComponentBase ::
   paramSet_ParamStruct(Fw::SerializeBufferBase& val)
 {
   S _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -3114,7 +3114,7 @@ Fw::CmdResponse PassiveParamsComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamU32);
+    _stat = _saveBuff.serializeFrom(m_ParamU32);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -3144,7 +3144,7 @@ Fw::CmdResponse PassiveParamsComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamF64);
+    _stat = _saveBuff.serializeFrom(m_ParamF64);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -3174,7 +3174,7 @@ Fw::CmdResponse PassiveParamsComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamString);
+    _stat = _saveBuff.serializeFrom(m_ParamString);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -3204,7 +3204,7 @@ Fw::CmdResponse PassiveParamsComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamEnum);
+    _stat = _saveBuff.serializeFrom(m_ParamEnum);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -3234,7 +3234,7 @@ Fw::CmdResponse PassiveParamsComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamArray);
+    _stat = _saveBuff.serializeFrom(m_ParamArray);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -3264,7 +3264,7 @@ Fw::CmdResponse PassiveParamsComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamStruct);
+    _stat = _saveBuff.serializeFrom(m_ParamStruct);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
@@ -1521,7 +1521,7 @@ void PassiveSerialComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamU32);
+    _stat = _buff.deserializeTo(this->m_ParamU32);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamU32_valid = Fw::ParamValid::INVALID;
     }
@@ -1546,7 +1546,7 @@ void PassiveSerialComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamF64);
+    _stat = _buff.deserializeTo(this->m_ParamF64);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamF64_valid = Fw::ParamValid::INVALID;
     }
@@ -1571,7 +1571,7 @@ void PassiveSerialComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamString);
+    _stat = _buff.deserializeTo(this->m_ParamString);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
       // Set default value
@@ -1600,7 +1600,7 @@ void PassiveSerialComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamEnum);
+    _stat = _buff.deserializeTo(this->m_ParamEnum);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamEnum_valid = Fw::ParamValid::INVALID;
     }
@@ -1625,7 +1625,7 @@ void PassiveSerialComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamArray);
+    _stat = _buff.deserializeTo(this->m_ParamArray);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
       // Set default value
@@ -1654,7 +1654,7 @@ void PassiveSerialComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamStruct);
+    _stat = _buff.deserializeTo(this->m_ParamStruct);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamStruct_valid = Fw::ParamValid::INVALID;
     }
@@ -2994,7 +2994,7 @@ void PassiveSerialComponentBase ::
   args.resetDeser();
 
   U32 u32;
-  _status = args.deserialize(u32);
+  _status = args.deserializeTo(u32);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3007,7 +3007,7 @@ void PassiveSerialComponentBase ::
   }
 
   F32 f32;
-  _status = args.deserialize(f32);
+  _status = args.deserializeTo(f32);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3020,7 +3020,7 @@ void PassiveSerialComponentBase ::
   }
 
   bool b;
-  _status = args.deserialize(b);
+  _status = args.deserializeTo(b);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3069,7 +3069,7 @@ void PassiveSerialComponentBase ::
   args.resetDeser();
 
   Fw::CmdStringArg str1;
-  _status = args.deserialize(str1);
+  _status = args.deserializeTo(str1);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3082,7 +3082,7 @@ void PassiveSerialComponentBase ::
   }
 
   Fw::CmdStringArg str2;
-  _status = args.deserialize(str2);
+  _status = args.deserializeTo(str2);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3130,7 +3130,7 @@ void PassiveSerialComponentBase ::
   args.resetDeser();
 
   E e;
-  _status = args.deserialize(e);
+  _status = args.deserializeTo(e);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3177,7 +3177,7 @@ void PassiveSerialComponentBase ::
   args.resetDeser();
 
   A a;
-  _status = args.deserialize(a);
+  _status = args.deserializeTo(a);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3224,7 +3224,7 @@ void PassiveSerialComponentBase ::
   args.resetDeser();
 
   S s;
-  _status = args.deserialize(s);
+  _status = args.deserializeTo(s);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3300,7 +3300,7 @@ void PassiveSerialComponentBase ::
   args.resetDeser();
 
   U32 u32;
-  _status = args.deserialize(u32);
+  _status = args.deserializeTo(u32);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3313,7 +3313,7 @@ void PassiveSerialComponentBase ::
   }
 
   F32 f32;
-  _status = args.deserialize(f32);
+  _status = args.deserializeTo(f32);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3326,7 +3326,7 @@ void PassiveSerialComponentBase ::
   }
 
   bool b;
-  _status = args.deserialize(b);
+  _status = args.deserializeTo(b);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3379,7 +3379,7 @@ void PassiveSerialComponentBase ::
   args.resetDeser();
 
   Fw::CmdStringArg str1;
-  _status = args.deserialize(str1);
+  _status = args.deserializeTo(str1);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3392,7 +3392,7 @@ void PassiveSerialComponentBase ::
   }
 
   Fw::CmdStringArg str2;
-  _status = args.deserialize(str2);
+  _status = args.deserializeTo(str2);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3444,7 +3444,7 @@ void PassiveSerialComponentBase ::
   args.resetDeser();
 
   E e;
-  _status = args.deserialize(e);
+  _status = args.deserializeTo(e);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3495,7 +3495,7 @@ void PassiveSerialComponentBase ::
   args.resetDeser();
 
   A a;
-  _status = args.deserialize(a);
+  _status = args.deserializeTo(a);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3546,7 +3546,7 @@ void PassiveSerialComponentBase ::
   args.resetDeser();
 
   S s;
-  _status = args.deserialize(s);
+  _status = args.deserializeTo(s);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3607,7 +3607,7 @@ void PassiveSerialComponentBase ::
 #if FW_AMPCS_COMPATIBLE
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(0));
+    _status = _logBuff.serializeFrom(static_cast<U8>(0));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3684,7 +3684,7 @@ void PassiveSerialComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(3));
+    _status = _logBuff.serializeFrom(static_cast<U8>(3));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3693,7 +3693,7 @@ void PassiveSerialComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(sizeof(U32))
     );
     FW_ASSERT(
@@ -3701,7 +3701,7 @@ void PassiveSerialComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(u32);
+    _status = _logBuff.serializeFrom(u32);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3709,7 +3709,7 @@ void PassiveSerialComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(sizeof(F32))
     );
     FW_ASSERT(
@@ -3717,7 +3717,7 @@ void PassiveSerialComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(f32);
+    _status = _logBuff.serializeFrom(f32);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3725,7 +3725,7 @@ void PassiveSerialComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(sizeof(U8))
     );
     FW_ASSERT(
@@ -3733,7 +3733,7 @@ void PassiveSerialComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(b);
+    _status = _logBuff.serializeFrom(b);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3803,20 +3803,20 @@ void PassiveSerialComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(2));
+    _status = _logBuff.serializeFrom(static_cast<U8>(2));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 #endif
 
-    _status = str1.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 80));
+    _status = str1.serializeTo(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 80));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = str2.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 100));
+    _status = str2.serializeTo(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 100));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3882,7 +3882,7 @@ void PassiveSerialComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(1));
+    _status = _logBuff.serializeFrom(static_cast<U8>(1));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3891,7 +3891,7 @@ void PassiveSerialComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(E::SERIALIZED_SIZE)
     );
     FW_ASSERT(
@@ -3899,7 +3899,7 @@ void PassiveSerialComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(e);
+    _status = _logBuff.serializeFrom(e);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3975,20 +3975,20 @@ void PassiveSerialComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(1 + 1));
+    _status = _logBuff.serializeFrom(static_cast<U8>(1 + 1));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // For FATAL, add stack size of 4 and a dummy entry. No support for stacks yet.
-    _status = _logBuff.serialize(static_cast<U8>(4));
+    _status = _logBuff.serializeFrom(static_cast<U8>(4));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = _logBuff.serialize(static_cast<U32>(0));
+    _status = _logBuff.serializeFrom(static_cast<U32>(0));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3997,7 +3997,7 @@ void PassiveSerialComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(A::SERIALIZED_SIZE)
     );
     FW_ASSERT(
@@ -4005,7 +4005,7 @@ void PassiveSerialComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(a);
+    _status = _logBuff.serializeFrom(a);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -4073,7 +4073,7 @@ void PassiveSerialComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(1));
+    _status = _logBuff.serializeFrom(static_cast<U8>(1));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -4082,7 +4082,7 @@ void PassiveSerialComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(S::SERIALIZED_SIZE)
     );
     FW_ASSERT(
@@ -4090,7 +4090,7 @@ void PassiveSerialComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(s);
+    _status = _logBuff.serializeFrom(s);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -4166,7 +4166,7 @@ void PassiveSerialComponentBase ::
 #if FW_AMPCS_COMPATIBLE
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(0));
+    _status = _logBuff.serializeFrom(static_cast<U8>(0));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -4255,7 +4255,7 @@ void PassiveSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -4288,7 +4288,7 @@ void PassiveSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -4321,7 +4321,7 @@ void PassiveSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = arg.serialize(_tlmBuff, FW_MIN(FW_TLM_STRING_MAX_SIZE, 80));
+    Fw::SerializeStatus _stat = arg.serializeTo(_tlmBuff, FW_MIN(FW_TLM_STRING_MAX_SIZE, 80));
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -4354,7 +4354,7 @@ void PassiveSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -4387,7 +4387,7 @@ void PassiveSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -4420,7 +4420,7 @@ void PassiveSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -4453,7 +4453,7 @@ void PassiveSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -4486,7 +4486,7 @@ void PassiveSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -4519,7 +4519,7 @@ void PassiveSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -4567,7 +4567,7 @@ void PassiveSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -4615,7 +4615,7 @@ void PassiveSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -4733,7 +4733,7 @@ I32 PassiveSerialComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -4756,7 +4756,7 @@ F64 PassiveSerialComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -4779,7 +4779,7 @@ Fw::ParamString PassiveSerialComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -4802,7 +4802,7 @@ E PassiveSerialComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -4825,7 +4825,7 @@ A PassiveSerialComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -4848,7 +4848,7 @@ S PassiveSerialComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -5580,7 +5580,7 @@ Fw::CmdResponse PassiveSerialComponentBase ::
   paramSet_ParamU32(Fw::SerializeBufferBase& val)
 {
   U32 _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -5600,7 +5600,7 @@ Fw::CmdResponse PassiveSerialComponentBase ::
   paramSet_ParamF64(Fw::SerializeBufferBase& val)
 {
   F64 _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -5620,7 +5620,7 @@ Fw::CmdResponse PassiveSerialComponentBase ::
   paramSet_ParamString(Fw::SerializeBufferBase& val)
 {
   Fw::ParamString _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -5640,7 +5640,7 @@ Fw::CmdResponse PassiveSerialComponentBase ::
   paramSet_ParamEnum(Fw::SerializeBufferBase& val)
 {
   E _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -5660,7 +5660,7 @@ Fw::CmdResponse PassiveSerialComponentBase ::
   paramSet_ParamArray(Fw::SerializeBufferBase& val)
 {
   A _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -5680,7 +5680,7 @@ Fw::CmdResponse PassiveSerialComponentBase ::
   paramSet_ParamStruct(Fw::SerializeBufferBase& val)
 {
   S _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -5847,7 +5847,7 @@ Fw::CmdResponse PassiveSerialComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamU32);
+    _stat = _saveBuff.serializeFrom(m_ParamU32);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -5877,7 +5877,7 @@ Fw::CmdResponse PassiveSerialComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamF64);
+    _stat = _saveBuff.serializeFrom(m_ParamF64);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -5907,7 +5907,7 @@ Fw::CmdResponse PassiveSerialComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamString);
+    _stat = _saveBuff.serializeFrom(m_ParamString);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -5937,7 +5937,7 @@ Fw::CmdResponse PassiveSerialComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamEnum);
+    _stat = _saveBuff.serializeFrom(m_ParamEnum);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -5967,7 +5967,7 @@ Fw::CmdResponse PassiveSerialComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamArray);
+    _stat = _saveBuff.serializeFrom(m_ParamArray);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -5997,7 +5997,7 @@ Fw::CmdResponse PassiveSerialComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamStruct);
+    _stat = _saveBuff.serializeFrom(m_ParamStruct);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductsComponentAc.ref.cpp
@@ -51,12 +51,12 @@ Fw::SerializeStatus PassiveSyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serialize(array[i]);
+      status = this->m_dataBuffer.serializeFrom(array[i]);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -76,9 +76,9 @@ Fw::SerializeStatus PassiveSyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(elt);
+    status = this->m_dataBuffer.serializeFrom(elt);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -109,14 +109,14 @@ Fw::SerializeStatus PassiveSyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       const Fw::StringBase *const sbPtr = array[i];
       FW_ASSERT(sbPtr != nullptr);
-      status = sbPtr->serialize(this->m_dataBuffer, stringSize);
+      status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -137,9 +137,9 @@ Fw::SerializeStatus PassiveSyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = elt.serialize(this->m_dataBuffer, stringSize);
+    status = elt.serializeTo(this->m_dataBuffer, stringSize);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -165,12 +165,12 @@ Fw::SerializeStatus PassiveSyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serialize(array[i]);
+      status = this->m_dataBuffer.serializeFrom(array[i]);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -190,9 +190,9 @@ Fw::SerializeStatus PassiveSyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32Record;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(elt);
+    status = this->m_dataBuffer.serializeFrom(elt);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -218,11 +218,11 @@ Fw::SerializeStatus PassiveSyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
+    status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTelemetryComponentAc.ref.cpp
@@ -2223,7 +2223,7 @@ void PassiveTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -2256,7 +2256,7 @@ void PassiveTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -2289,7 +2289,7 @@ void PassiveTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = arg.serialize(_tlmBuff, FW_MIN(FW_TLM_STRING_MAX_SIZE, 80));
+    Fw::SerializeStatus _stat = arg.serializeTo(_tlmBuff, FW_MIN(FW_TLM_STRING_MAX_SIZE, 80));
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -2322,7 +2322,7 @@ void PassiveTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -2355,7 +2355,7 @@ void PassiveTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -2388,7 +2388,7 @@ void PassiveTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -2421,7 +2421,7 @@ void PassiveTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -2454,7 +2454,7 @@ void PassiveTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -2487,7 +2487,7 @@ void PassiveTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -2535,7 +2535,7 @@ void PassiveTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -2583,7 +2583,7 @@ void PassiveTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
@@ -51,12 +51,12 @@ Fw::SerializeStatus PassiveTestComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serialize(array[i]);
+      status = this->m_dataBuffer.serializeFrom(array[i]);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -76,9 +76,9 @@ Fw::SerializeStatus PassiveTestComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(elt);
+    status = this->m_dataBuffer.serializeFrom(elt);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -109,14 +109,14 @@ Fw::SerializeStatus PassiveTestComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       const Fw::StringBase *const sbPtr = array[i];
       FW_ASSERT(sbPtr != nullptr);
-      status = sbPtr->serialize(this->m_dataBuffer, stringSize);
+      status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -137,9 +137,9 @@ Fw::SerializeStatus PassiveTestComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = elt.serialize(this->m_dataBuffer, stringSize);
+    status = elt.serializeTo(this->m_dataBuffer, stringSize);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -165,12 +165,12 @@ Fw::SerializeStatus PassiveTestComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serialize(array[i]);
+      status = this->m_dataBuffer.serializeFrom(array[i]);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -190,9 +190,9 @@ Fw::SerializeStatus PassiveTestComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32Record;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(elt);
+    status = this->m_dataBuffer.serializeFrom(elt);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -218,11 +218,11 @@ Fw::SerializeStatus PassiveTestComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
+    status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -1756,7 +1756,7 @@ void PassiveTestComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamU32);
+    _stat = _buff.deserializeTo(this->m_ParamU32);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamU32_valid = Fw::ParamValid::INVALID;
     }
@@ -1781,7 +1781,7 @@ void PassiveTestComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamF64);
+    _stat = _buff.deserializeTo(this->m_ParamF64);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamF64_valid = Fw::ParamValid::INVALID;
     }
@@ -1806,7 +1806,7 @@ void PassiveTestComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamString);
+    _stat = _buff.deserializeTo(this->m_ParamString);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
       // Set default value
@@ -1835,7 +1835,7 @@ void PassiveTestComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamEnum);
+    _stat = _buff.deserializeTo(this->m_ParamEnum);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamEnum_valid = Fw::ParamValid::INVALID;
     }
@@ -1860,7 +1860,7 @@ void PassiveTestComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamArray);
+    _stat = _buff.deserializeTo(this->m_ParamArray);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
       // Set default value
@@ -1889,7 +1889,7 @@ void PassiveTestComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamStruct);
+    _stat = _buff.deserializeTo(this->m_ParamStruct);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamStruct_valid = Fw::ParamValid::INVALID;
     }
@@ -3231,7 +3231,7 @@ void PassiveTestComponentBase ::
   args.resetDeser();
 
   U32 u32;
-  _status = args.deserialize(u32);
+  _status = args.deserializeTo(u32);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3244,7 +3244,7 @@ void PassiveTestComponentBase ::
   }
 
   F32 f32;
-  _status = args.deserialize(f32);
+  _status = args.deserializeTo(f32);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3257,7 +3257,7 @@ void PassiveTestComponentBase ::
   }
 
   bool b;
-  _status = args.deserialize(b);
+  _status = args.deserializeTo(b);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3306,7 +3306,7 @@ void PassiveTestComponentBase ::
   args.resetDeser();
 
   Fw::CmdStringArg str1;
-  _status = args.deserialize(str1);
+  _status = args.deserializeTo(str1);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3319,7 +3319,7 @@ void PassiveTestComponentBase ::
   }
 
   Fw::CmdStringArg str2;
-  _status = args.deserialize(str2);
+  _status = args.deserializeTo(str2);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3367,7 +3367,7 @@ void PassiveTestComponentBase ::
   args.resetDeser();
 
   E e;
-  _status = args.deserialize(e);
+  _status = args.deserializeTo(e);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3414,7 +3414,7 @@ void PassiveTestComponentBase ::
   args.resetDeser();
 
   A a;
-  _status = args.deserialize(a);
+  _status = args.deserializeTo(a);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3461,7 +3461,7 @@ void PassiveTestComponentBase ::
   args.resetDeser();
 
   S s;
-  _status = args.deserialize(s);
+  _status = args.deserializeTo(s);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3537,7 +3537,7 @@ void PassiveTestComponentBase ::
   args.resetDeser();
 
   U32 u32;
-  _status = args.deserialize(u32);
+  _status = args.deserializeTo(u32);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3550,7 +3550,7 @@ void PassiveTestComponentBase ::
   }
 
   F32 f32;
-  _status = args.deserialize(f32);
+  _status = args.deserializeTo(f32);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3563,7 +3563,7 @@ void PassiveTestComponentBase ::
   }
 
   bool b;
-  _status = args.deserialize(b);
+  _status = args.deserializeTo(b);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3616,7 +3616,7 @@ void PassiveTestComponentBase ::
   args.resetDeser();
 
   Fw::CmdStringArg str1;
-  _status = args.deserialize(str1);
+  _status = args.deserializeTo(str1);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3629,7 +3629,7 @@ void PassiveTestComponentBase ::
   }
 
   Fw::CmdStringArg str2;
-  _status = args.deserialize(str2);
+  _status = args.deserializeTo(str2);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3681,7 +3681,7 @@ void PassiveTestComponentBase ::
   args.resetDeser();
 
   E e;
-  _status = args.deserialize(e);
+  _status = args.deserializeTo(e);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3732,7 +3732,7 @@ void PassiveTestComponentBase ::
   args.resetDeser();
 
   A a;
-  _status = args.deserialize(a);
+  _status = args.deserializeTo(a);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3783,7 +3783,7 @@ void PassiveTestComponentBase ::
   args.resetDeser();
 
   S s;
-  _status = args.deserialize(s);
+  _status = args.deserializeTo(s);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3844,7 +3844,7 @@ void PassiveTestComponentBase ::
 #if FW_AMPCS_COMPATIBLE
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(0));
+    _status = _logBuff.serializeFrom(static_cast<U8>(0));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3921,7 +3921,7 @@ void PassiveTestComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(3));
+    _status = _logBuff.serializeFrom(static_cast<U8>(3));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3930,7 +3930,7 @@ void PassiveTestComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(sizeof(U32))
     );
     FW_ASSERT(
@@ -3938,7 +3938,7 @@ void PassiveTestComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(u32);
+    _status = _logBuff.serializeFrom(u32);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3946,7 +3946,7 @@ void PassiveTestComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(sizeof(F32))
     );
     FW_ASSERT(
@@ -3954,7 +3954,7 @@ void PassiveTestComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(f32);
+    _status = _logBuff.serializeFrom(f32);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3962,7 +3962,7 @@ void PassiveTestComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(sizeof(U8))
     );
     FW_ASSERT(
@@ -3970,7 +3970,7 @@ void PassiveTestComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(b);
+    _status = _logBuff.serializeFrom(b);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -4040,20 +4040,20 @@ void PassiveTestComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(2));
+    _status = _logBuff.serializeFrom(static_cast<U8>(2));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 #endif
 
-    _status = str1.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 80));
+    _status = str1.serializeTo(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 80));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = str2.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 100));
+    _status = str2.serializeTo(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 100));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -4119,7 +4119,7 @@ void PassiveTestComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(1));
+    _status = _logBuff.serializeFrom(static_cast<U8>(1));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -4128,7 +4128,7 @@ void PassiveTestComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(E::SERIALIZED_SIZE)
     );
     FW_ASSERT(
@@ -4136,7 +4136,7 @@ void PassiveTestComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(e);
+    _status = _logBuff.serializeFrom(e);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -4212,20 +4212,20 @@ void PassiveTestComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(1 + 1));
+    _status = _logBuff.serializeFrom(static_cast<U8>(1 + 1));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // For FATAL, add stack size of 4 and a dummy entry. No support for stacks yet.
-    _status = _logBuff.serialize(static_cast<U8>(4));
+    _status = _logBuff.serializeFrom(static_cast<U8>(4));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = _logBuff.serialize(static_cast<U32>(0));
+    _status = _logBuff.serializeFrom(static_cast<U32>(0));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -4234,7 +4234,7 @@ void PassiveTestComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(A::SERIALIZED_SIZE)
     );
     FW_ASSERT(
@@ -4242,7 +4242,7 @@ void PassiveTestComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(a);
+    _status = _logBuff.serializeFrom(a);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -4310,7 +4310,7 @@ void PassiveTestComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(1));
+    _status = _logBuff.serializeFrom(static_cast<U8>(1));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -4319,7 +4319,7 @@ void PassiveTestComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(S::SERIALIZED_SIZE)
     );
     FW_ASSERT(
@@ -4327,7 +4327,7 @@ void PassiveTestComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(s);
+    _status = _logBuff.serializeFrom(s);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -4403,7 +4403,7 @@ void PassiveTestComponentBase ::
 #if FW_AMPCS_COMPATIBLE
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(0));
+    _status = _logBuff.serializeFrom(static_cast<U8>(0));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -4492,7 +4492,7 @@ void PassiveTestComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -4525,7 +4525,7 @@ void PassiveTestComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -4558,7 +4558,7 @@ void PassiveTestComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = arg.serialize(_tlmBuff, FW_MIN(FW_TLM_STRING_MAX_SIZE, 80));
+    Fw::SerializeStatus _stat = arg.serializeTo(_tlmBuff, FW_MIN(FW_TLM_STRING_MAX_SIZE, 80));
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -4591,7 +4591,7 @@ void PassiveTestComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -4624,7 +4624,7 @@ void PassiveTestComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -4657,7 +4657,7 @@ void PassiveTestComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -4690,7 +4690,7 @@ void PassiveTestComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -4723,7 +4723,7 @@ void PassiveTestComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -4756,7 +4756,7 @@ void PassiveTestComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -4804,7 +4804,7 @@ void PassiveTestComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -4852,7 +4852,7 @@ void PassiveTestComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -4970,7 +4970,7 @@ I32 PassiveTestComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -4993,7 +4993,7 @@ F64 PassiveTestComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -5016,7 +5016,7 @@ Fw::ParamString PassiveTestComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -5039,7 +5039,7 @@ E PassiveTestComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -5062,7 +5062,7 @@ A PassiveTestComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -5085,7 +5085,7 @@ S PassiveTestComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -5830,7 +5830,7 @@ Fw::CmdResponse PassiveTestComponentBase ::
   paramSet_ParamU32(Fw::SerializeBufferBase& val)
 {
   U32 _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -5850,7 +5850,7 @@ Fw::CmdResponse PassiveTestComponentBase ::
   paramSet_ParamF64(Fw::SerializeBufferBase& val)
 {
   F64 _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -5870,7 +5870,7 @@ Fw::CmdResponse PassiveTestComponentBase ::
   paramSet_ParamString(Fw::SerializeBufferBase& val)
 {
   Fw::ParamString _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -5890,7 +5890,7 @@ Fw::CmdResponse PassiveTestComponentBase ::
   paramSet_ParamEnum(Fw::SerializeBufferBase& val)
 {
   E _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -5910,7 +5910,7 @@ Fw::CmdResponse PassiveTestComponentBase ::
   paramSet_ParamArray(Fw::SerializeBufferBase& val)
 {
   A _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -5930,7 +5930,7 @@ Fw::CmdResponse PassiveTestComponentBase ::
   paramSet_ParamStruct(Fw::SerializeBufferBase& val)
 {
   S _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -6097,7 +6097,7 @@ Fw::CmdResponse PassiveTestComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamU32);
+    _stat = _saveBuff.serializeFrom(m_ParamU32);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -6127,7 +6127,7 @@ Fw::CmdResponse PassiveTestComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamF64);
+    _stat = _saveBuff.serializeFrom(m_ParamF64);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -6157,7 +6157,7 @@ Fw::CmdResponse PassiveTestComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamString);
+    _stat = _saveBuff.serializeFrom(m_ParamString);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -6187,7 +6187,7 @@ Fw::CmdResponse PassiveTestComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamEnum);
+    _stat = _saveBuff.serializeFrom(m_ParamEnum);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -6217,7 +6217,7 @@ Fw::CmdResponse PassiveTestComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamArray);
+    _stat = _saveBuff.serializeFrom(m_ParamArray);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -6247,7 +6247,7 @@ Fw::CmdResponse PassiveTestComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamStruct);
+    _stat = _saveBuff.serializeFrom(m_ParamStruct);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductPortsOnlyComponentAc.ref.cpp
@@ -328,7 +328,7 @@ void QueuedAsyncProductPortsOnlyComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(PRODUCTRECVIN_DPRESPONSE)
   );
   FW_ASSERT(
@@ -337,28 +337,28 @@ void QueuedAsyncProductPortsOnlyComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument id
-  _status = msg.serialize(id);
+  _status = msg.serializeFrom(id);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument buffer
-  _status = msg.serialize(buffer);
+  _status = msg.serializeFrom(buffer);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument status
-  _status = msg.serialize(status);
+  _status = msg.serializeFrom(status);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -470,7 +470,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductPortsOnlyComponentB
   _msg.resetDeser();
 
   FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -483,7 +483,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductPortsOnlyComponentB
   }
 
   FwIndexType portNum = 0;
-  _deserStatus = _msg.deserialize(portNum);
+  _deserStatus = _msg.deserializeTo(portNum);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -494,7 +494,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductPortsOnlyComponentB
     case PRODUCTRECVIN_DPRESPONSE: {
       // Deserialize argument id
       FwDpIdType id;
-      _deserStatus = _msg.deserialize(id);
+      _deserStatus = _msg.deserializeTo(id);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -502,7 +502,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductPortsOnlyComponentB
 
       // Deserialize argument buffer
       Fw::Buffer buffer;
-      _deserStatus = _msg.deserialize(buffer);
+      _deserStatus = _msg.deserializeTo(buffer);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -510,7 +510,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductPortsOnlyComponentB
 
       // Deserialize argument status
       Fw::Success status;
-      _deserStatus = _msg.deserialize(status);
+      _deserStatus = _msg.deserializeTo(status);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductsComponentAc.ref.cpp
@@ -111,12 +111,12 @@ Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serialize(array[i]);
+      status = this->m_dataBuffer.serializeFrom(array[i]);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -136,9 +136,9 @@ Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(elt);
+    status = this->m_dataBuffer.serializeFrom(elt);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -169,14 +169,14 @@ Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       const Fw::StringBase *const sbPtr = array[i];
       FW_ASSERT(sbPtr != nullptr);
-      status = sbPtr->serialize(this->m_dataBuffer, stringSize);
+      status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -197,9 +197,9 @@ Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = elt.serialize(this->m_dataBuffer, stringSize);
+    status = elt.serializeTo(this->m_dataBuffer, stringSize);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -225,12 +225,12 @@ Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serialize(array[i]);
+      status = this->m_dataBuffer.serializeFrom(array[i]);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -250,9 +250,9 @@ Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32Record;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(elt);
+    status = this->m_dataBuffer.serializeFrom(elt);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -278,11 +278,11 @@ Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
+    status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -2367,7 +2367,7 @@ void QueuedAsyncProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(PRODUCTRECVIN_DPRESPONSE)
   );
   FW_ASSERT(
@@ -2376,28 +2376,28 @@ void QueuedAsyncProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument id
-  _status = msg.serialize(id);
+  _status = msg.serializeFrom(id);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument buffer
-  _status = msg.serialize(buffer);
+  _status = msg.serializeFrom(buffer);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument status
-  _status = msg.serialize(status);
+  _status = msg.serializeFrom(status);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2452,7 +2452,7 @@ void QueuedAsyncProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
   );
   FW_ASSERT(
@@ -2461,56 +2461,56 @@ void QueuedAsyncProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str2
-  _status = msg.serialize(str2);
+  _status = msg.serializeFrom(str2);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2558,7 +2558,7 @@ void QueuedAsyncProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
   );
   FW_ASSERT(
@@ -2567,7 +2567,7 @@ void QueuedAsyncProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2812,7 +2812,7 @@ void QueuedAsyncProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
   );
   FW_ASSERT(
@@ -2821,56 +2821,56 @@ void QueuedAsyncProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2919,7 +2919,7 @@ void QueuedAsyncProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
   );
   FW_ASSERT(
@@ -2928,56 +2928,56 @@ void QueuedAsyncProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3026,7 +3026,7 @@ void QueuedAsyncProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -3035,56 +3035,56 @@ void QueuedAsyncProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3133,7 +3133,7 @@ void QueuedAsyncProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -3142,56 +3142,56 @@ void QueuedAsyncProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3813,7 +3813,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
   _msg.resetDeser();
 
   FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -3826,7 +3826,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
   }
 
   FwIndexType portNum = 0;
-  _deserStatus = _msg.deserialize(portNum);
+  _deserStatus = _msg.deserializeTo(portNum);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -3837,7 +3837,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
     case PRODUCTRECVIN_DPRESPONSE: {
       // Deserialize argument id
       FwDpIdType id;
-      _deserStatus = _msg.deserialize(id);
+      _deserStatus = _msg.deserializeTo(id);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3845,7 +3845,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
 
       // Deserialize argument buffer
       Fw::Buffer buffer;
-      _deserStatus = _msg.deserialize(buffer);
+      _deserStatus = _msg.deserializeTo(buffer);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3853,7 +3853,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
 
       // Deserialize argument status
       Fw::Success status;
-      _deserStatus = _msg.deserialize(status);
+      _deserStatus = _msg.deserializeTo(status);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3873,7 +3873,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
     case ALIASTYPEDASYNC_ALIASTYPED: {
       // Deserialize argument u32
       AliasPrim1 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3881,7 +3881,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
 
       // Deserialize argument f32
       AliasPrim2 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3889,7 +3889,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
 
       // Deserialize argument b
       AliasBool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3898,7 +3898,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
       // Deserialize argument str2
       char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
       Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserialize(str2);
+      _deserStatus = _msg.deserializeTo(str2);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3906,7 +3906,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
 
       // Deserialize argument e
       AliasEnum e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3914,7 +3914,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
 
       // Deserialize argument a
       AliasArray a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3922,7 +3922,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
 
       // Deserialize argument s
       AliasStruct s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3954,7 +3954,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
     case TYPEDASYNC_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3962,7 +3962,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3970,7 +3970,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3979,7 +3979,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3987,7 +3987,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3995,7 +3995,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4003,7 +4003,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4027,7 +4027,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
     case TYPEDASYNCASSERT_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4035,7 +4035,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4043,7 +4043,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4052,7 +4052,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4060,7 +4060,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4068,7 +4068,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4076,7 +4076,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4100,7 +4100,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
     case TYPEDASYNCBLOCKPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4108,7 +4108,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4116,7 +4116,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4125,7 +4125,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4133,7 +4133,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4141,7 +4141,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4149,7 +4149,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4173,7 +4173,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
     case TYPEDASYNCDROPPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4181,7 +4181,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4189,7 +4189,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4198,7 +4198,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4206,7 +4206,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4214,7 +4214,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4222,7 +4222,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedAsyncProductsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedCommandsComponentAc.ref.cpp
@@ -2066,7 +2066,7 @@ void QueuedCommandsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
   );
   FW_ASSERT(
@@ -2075,56 +2075,56 @@ void QueuedCommandsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str2
-  _status = msg.serialize(str2);
+  _status = msg.serializeFrom(str2);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2172,7 +2172,7 @@ void QueuedCommandsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
   );
   FW_ASSERT(
@@ -2181,7 +2181,7 @@ void QueuedCommandsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2426,7 +2426,7 @@ void QueuedCommandsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
   );
   FW_ASSERT(
@@ -2435,56 +2435,56 @@ void QueuedCommandsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2533,7 +2533,7 @@ void QueuedCommandsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
   );
   FW_ASSERT(
@@ -2542,56 +2542,56 @@ void QueuedCommandsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2640,7 +2640,7 @@ void QueuedCommandsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -2649,56 +2649,56 @@ void QueuedCommandsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2747,7 +2747,7 @@ void QueuedCommandsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -2756,56 +2756,56 @@ void QueuedCommandsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3328,7 +3328,7 @@ void QueuedCommandsComponentBase ::
   args.resetDeser();
 
   U32 u32;
-  _status = args.deserialize(u32);
+  _status = args.deserializeTo(u32);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3341,7 +3341,7 @@ void QueuedCommandsComponentBase ::
   }
 
   F32 f32;
-  _status = args.deserialize(f32);
+  _status = args.deserializeTo(f32);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3354,7 +3354,7 @@ void QueuedCommandsComponentBase ::
   }
 
   bool b;
-  _status = args.deserialize(b);
+  _status = args.deserializeTo(b);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3403,7 +3403,7 @@ void QueuedCommandsComponentBase ::
   args.resetDeser();
 
   Fw::CmdStringArg str1;
-  _status = args.deserialize(str1);
+  _status = args.deserializeTo(str1);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3416,7 +3416,7 @@ void QueuedCommandsComponentBase ::
   }
 
   Fw::CmdStringArg str2;
-  _status = args.deserialize(str2);
+  _status = args.deserializeTo(str2);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3464,7 +3464,7 @@ void QueuedCommandsComponentBase ::
   args.resetDeser();
 
   E e;
-  _status = args.deserialize(e);
+  _status = args.deserializeTo(e);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3511,7 +3511,7 @@ void QueuedCommandsComponentBase ::
   args.resetDeser();
 
   A a;
-  _status = args.deserialize(a);
+  _status = args.deserializeTo(a);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3558,7 +3558,7 @@ void QueuedCommandsComponentBase ::
   args.resetDeser();
 
   S s;
-  _status = args.deserialize(s);
+  _status = args.deserializeTo(s);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3634,7 +3634,7 @@ void QueuedCommandsComponentBase ::
   args.resetDeser();
 
   U32 u32;
-  _status = args.deserialize(u32);
+  _status = args.deserializeTo(u32);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3647,7 +3647,7 @@ void QueuedCommandsComponentBase ::
   }
 
   F32 f32;
-  _status = args.deserialize(f32);
+  _status = args.deserializeTo(f32);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3660,7 +3660,7 @@ void QueuedCommandsComponentBase ::
   }
 
   bool b;
-  _status = args.deserialize(b);
+  _status = args.deserializeTo(b);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3713,7 +3713,7 @@ void QueuedCommandsComponentBase ::
   args.resetDeser();
 
   Fw::CmdStringArg str1;
-  _status = args.deserialize(str1);
+  _status = args.deserializeTo(str1);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3726,7 +3726,7 @@ void QueuedCommandsComponentBase ::
   }
 
   Fw::CmdStringArg str2;
-  _status = args.deserialize(str2);
+  _status = args.deserializeTo(str2);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3778,7 +3778,7 @@ void QueuedCommandsComponentBase ::
   args.resetDeser();
 
   E e;
-  _status = args.deserialize(e);
+  _status = args.deserializeTo(e);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3829,7 +3829,7 @@ void QueuedCommandsComponentBase ::
   args.resetDeser();
 
   A a;
-  _status = args.deserialize(a);
+  _status = args.deserializeTo(a);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3880,7 +3880,7 @@ void QueuedCommandsComponentBase ::
   args.resetDeser();
 
   S s;
-  _status = args.deserialize(s);
+  _status = args.deserializeTo(s);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -3933,7 +3933,7 @@ void QueuedCommandsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize for IPC
-  _status = msg.serialize(static_cast<FwEnumStoreType>(CMD_CMD_ASYNC));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_ASYNC));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3942,25 +3942,25 @@ void QueuedCommandsComponentBase ::
   // Fake port number to make message dequeue work
   FwIndexType port = 0;
 
-  _status = msg.serialize(port);
+  _status = msg.serializeFrom(port);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(opCode);
+  _status = msg.serializeFrom(opCode);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(cmdSeq);
+  _status = msg.serializeFrom(cmdSeq);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(args);
+  _status = msg.serializeFrom(args);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3992,7 +3992,7 @@ void QueuedCommandsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize for IPC
-  _status = msg.serialize(static_cast<FwEnumStoreType>(CMD_CMD_PRIORITY));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PRIORITY));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4001,25 +4001,25 @@ void QueuedCommandsComponentBase ::
   // Fake port number to make message dequeue work
   FwIndexType port = 0;
 
-  _status = msg.serialize(port);
+  _status = msg.serializeFrom(port);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(opCode);
+  _status = msg.serializeFrom(opCode);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(cmdSeq);
+  _status = msg.serializeFrom(cmdSeq);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(args);
+  _status = msg.serializeFrom(args);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4051,7 +4051,7 @@ void QueuedCommandsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize for IPC
-  _status = msg.serialize(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4060,25 +4060,25 @@ void QueuedCommandsComponentBase ::
   // Fake port number to make message dequeue work
   FwIndexType port = 0;
 
-  _status = msg.serialize(port);
+  _status = msg.serializeFrom(port);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(opCode);
+  _status = msg.serializeFrom(opCode);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(cmdSeq);
+  _status = msg.serializeFrom(cmdSeq);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(args);
+  _status = msg.serializeFrom(args);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4110,7 +4110,7 @@ void QueuedCommandsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize for IPC
-  _status = msg.serialize(static_cast<FwEnumStoreType>(CMD_CMD_DROP));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_DROP));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4119,25 +4119,25 @@ void QueuedCommandsComponentBase ::
   // Fake port number to make message dequeue work
   FwIndexType port = 0;
 
-  _status = msg.serialize(port);
+  _status = msg.serializeFrom(port);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(opCode);
+  _status = msg.serializeFrom(opCode);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(cmdSeq);
+  _status = msg.serializeFrom(cmdSeq);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(args);
+  _status = msg.serializeFrom(args);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4174,7 +4174,7 @@ void QueuedCommandsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize for IPC
-  _status = msg.serialize(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_DROP));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_DROP));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4183,25 +4183,25 @@ void QueuedCommandsComponentBase ::
   // Fake port number to make message dequeue work
   FwIndexType port = 0;
 
-  _status = msg.serialize(port);
+  _status = msg.serializeFrom(port);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(opCode);
+  _status = msg.serializeFrom(opCode);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(cmdSeq);
+  _status = msg.serializeFrom(cmdSeq);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(args);
+  _status = msg.serializeFrom(args);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4350,7 +4350,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
   _msg.resetDeser();
 
   FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -4363,7 +4363,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
   }
 
   FwIndexType portNum = 0;
-  _deserStatus = _msg.deserialize(portNum);
+  _deserStatus = _msg.deserializeTo(portNum);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -4374,7 +4374,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
     case ALIASTYPEDASYNC_ALIASTYPED: {
       // Deserialize argument u32
       AliasPrim1 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4382,7 +4382,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize argument f32
       AliasPrim2 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4390,7 +4390,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize argument b
       AliasBool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4399,7 +4399,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
       // Deserialize argument str2
       char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
       Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserialize(str2);
+      _deserStatus = _msg.deserializeTo(str2);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4407,7 +4407,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize argument e
       AliasEnum e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4415,7 +4415,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize argument a
       AliasArray a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4423,7 +4423,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize argument s
       AliasStruct s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4455,7 +4455,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
     case TYPEDASYNC_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4463,7 +4463,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4471,7 +4471,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4480,7 +4480,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4488,7 +4488,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4496,7 +4496,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4504,7 +4504,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4528,7 +4528,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
     case TYPEDASYNCASSERT_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4536,7 +4536,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4544,7 +4544,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4553,7 +4553,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4561,7 +4561,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4569,7 +4569,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4577,7 +4577,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4601,7 +4601,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
     case TYPEDASYNCBLOCKPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4609,7 +4609,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4617,7 +4617,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4626,7 +4626,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4634,7 +4634,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4642,7 +4642,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4650,7 +4650,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4674,7 +4674,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
     case TYPEDASYNCDROPPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4682,7 +4682,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4690,7 +4690,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4699,7 +4699,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4707,7 +4707,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4715,7 +4715,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4723,7 +4723,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4747,7 +4747,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
     case CMD_CMD_ASYNC: {
       // Deserialize opcode
       FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserialize(_opCode);
+      _deserStatus = _msg.deserializeTo(_opCode);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4755,7 +4755,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize command sequence
       U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserialize(_cmdSeq);
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4763,7 +4763,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize command argument buffer
       Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserialize(args);
+      _deserStatus = _msg.deserializeTo(args);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4794,7 +4794,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
     case CMD_CMD_PRIORITY: {
       // Deserialize opcode
       FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserialize(_opCode);
+      _deserStatus = _msg.deserializeTo(_opCode);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4802,7 +4802,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize command sequence
       U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserialize(_cmdSeq);
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4810,7 +4810,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize command argument buffer
       Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserialize(args);
+      _deserStatus = _msg.deserializeTo(args);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4841,7 +4841,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
     case CMD_CMD_PARAMS_PRIORITY: {
       // Deserialize opcode
       FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserialize(_opCode);
+      _deserStatus = _msg.deserializeTo(_opCode);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4849,7 +4849,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize command sequence
       U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserialize(_cmdSeq);
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4857,7 +4857,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize command argument buffer
       Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserialize(args);
+      _deserStatus = _msg.deserializeTo(args);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4868,7 +4868,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = args.deserialize(u32);
+      _deserStatus = args.deserializeTo(u32);
       if (_deserStatus != Fw::FW_SERIALIZE_OK) {
         if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
           this->cmdResponse_out(
@@ -4906,7 +4906,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
     case CMD_CMD_DROP: {
       // Deserialize opcode
       FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserialize(_opCode);
+      _deserStatus = _msg.deserializeTo(_opCode);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4914,7 +4914,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize command sequence
       U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserialize(_cmdSeq);
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4922,7 +4922,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize command argument buffer
       Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserialize(args);
+      _deserStatus = _msg.deserializeTo(args);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4953,7 +4953,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
     case CMD_CMD_PARAMS_PRIORITY_DROP: {
       // Deserialize opcode
       FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserialize(_opCode);
+      _deserStatus = _msg.deserializeTo(_opCode);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4961,7 +4961,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize command sequence
       U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserialize(_cmdSeq);
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4969,7 +4969,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize command argument buffer
       Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserialize(args);
+      _deserStatus = _msg.deserializeTo(args);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4980,7 +4980,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
 
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = args.deserialize(u32);
+      _deserStatus = args.deserializeTo(u32);
       if (_deserStatus != Fw::FW_SERIALIZE_OK) {
         if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
           this->cmdResponse_out(

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.cpp
@@ -1985,7 +1985,7 @@ void QueuedEventsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
   );
   FW_ASSERT(
@@ -1994,56 +1994,56 @@ void QueuedEventsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str2
-  _status = msg.serialize(str2);
+  _status = msg.serializeFrom(str2);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2091,7 +2091,7 @@ void QueuedEventsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
   );
   FW_ASSERT(
@@ -2100,7 +2100,7 @@ void QueuedEventsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2345,7 +2345,7 @@ void QueuedEventsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
   );
   FW_ASSERT(
@@ -2354,56 +2354,56 @@ void QueuedEventsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2452,7 +2452,7 @@ void QueuedEventsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
   );
   FW_ASSERT(
@@ -2461,56 +2461,56 @@ void QueuedEventsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2559,7 +2559,7 @@ void QueuedEventsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -2568,56 +2568,56 @@ void QueuedEventsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2666,7 +2666,7 @@ void QueuedEventsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -2675,56 +2675,56 @@ void QueuedEventsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3211,7 +3211,7 @@ void QueuedEventsComponentBase ::
 #if FW_AMPCS_COMPATIBLE
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(0));
+    _status = _logBuff.serializeFrom(static_cast<U8>(0));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3288,7 +3288,7 @@ void QueuedEventsComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(3));
+    _status = _logBuff.serializeFrom(static_cast<U8>(3));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3297,7 +3297,7 @@ void QueuedEventsComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(sizeof(U32))
     );
     FW_ASSERT(
@@ -3305,7 +3305,7 @@ void QueuedEventsComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(u32);
+    _status = _logBuff.serializeFrom(u32);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3313,7 +3313,7 @@ void QueuedEventsComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(sizeof(F32))
     );
     FW_ASSERT(
@@ -3321,7 +3321,7 @@ void QueuedEventsComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(f32);
+    _status = _logBuff.serializeFrom(f32);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3329,7 +3329,7 @@ void QueuedEventsComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(sizeof(U8))
     );
     FW_ASSERT(
@@ -3337,7 +3337,7 @@ void QueuedEventsComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(b);
+    _status = _logBuff.serializeFrom(b);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3407,20 +3407,20 @@ void QueuedEventsComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(2));
+    _status = _logBuff.serializeFrom(static_cast<U8>(2));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 #endif
 
-    _status = str1.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 80));
+    _status = str1.serializeTo(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 80));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = str2.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 100));
+    _status = str2.serializeTo(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 100));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3486,7 +3486,7 @@ void QueuedEventsComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(1));
+    _status = _logBuff.serializeFrom(static_cast<U8>(1));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3495,7 +3495,7 @@ void QueuedEventsComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(E::SERIALIZED_SIZE)
     );
     FW_ASSERT(
@@ -3503,7 +3503,7 @@ void QueuedEventsComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(e);
+    _status = _logBuff.serializeFrom(e);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3579,20 +3579,20 @@ void QueuedEventsComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(1 + 1));
+    _status = _logBuff.serializeFrom(static_cast<U8>(1 + 1));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // For FATAL, add stack size of 4 and a dummy entry. No support for stacks yet.
-    _status = _logBuff.serialize(static_cast<U8>(4));
+    _status = _logBuff.serializeFrom(static_cast<U8>(4));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = _logBuff.serialize(static_cast<U32>(0));
+    _status = _logBuff.serializeFrom(static_cast<U32>(0));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3601,7 +3601,7 @@ void QueuedEventsComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(A::SERIALIZED_SIZE)
     );
     FW_ASSERT(
@@ -3609,7 +3609,7 @@ void QueuedEventsComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(a);
+    _status = _logBuff.serializeFrom(a);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3677,7 +3677,7 @@ void QueuedEventsComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(1));
+    _status = _logBuff.serializeFrom(static_cast<U8>(1));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3686,7 +3686,7 @@ void QueuedEventsComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(S::SERIALIZED_SIZE)
     );
     FW_ASSERT(
@@ -3694,7 +3694,7 @@ void QueuedEventsComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(s);
+    _status = _logBuff.serializeFrom(s);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3770,7 +3770,7 @@ void QueuedEventsComponentBase ::
 #if FW_AMPCS_COMPATIBLE
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(0));
+    _status = _logBuff.serializeFrom(static_cast<U8>(0));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3905,7 +3905,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
   _msg.resetDeser();
 
   FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -3918,7 +3918,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
   }
 
   FwIndexType portNum = 0;
-  _deserStatus = _msg.deserialize(portNum);
+  _deserStatus = _msg.deserializeTo(portNum);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -3929,7 +3929,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
     case ALIASTYPEDASYNC_ALIASTYPED: {
       // Deserialize argument u32
       AliasPrim1 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3937,7 +3937,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
 
       // Deserialize argument f32
       AliasPrim2 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3945,7 +3945,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
 
       // Deserialize argument b
       AliasBool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3954,7 +3954,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
       // Deserialize argument str2
       char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
       Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserialize(str2);
+      _deserStatus = _msg.deserializeTo(str2);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3962,7 +3962,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
 
       // Deserialize argument e
       AliasEnum e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3970,7 +3970,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
 
       // Deserialize argument a
       AliasArray a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3978,7 +3978,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
 
       // Deserialize argument s
       AliasStruct s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4010,7 +4010,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
     case TYPEDASYNC_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4018,7 +4018,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4026,7 +4026,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4035,7 +4035,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4043,7 +4043,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4051,7 +4051,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4059,7 +4059,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4083,7 +4083,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
     case TYPEDASYNCASSERT_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4091,7 +4091,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4099,7 +4099,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4108,7 +4108,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4116,7 +4116,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4124,7 +4124,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4132,7 +4132,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4156,7 +4156,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
     case TYPEDASYNCBLOCKPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4164,7 +4164,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4172,7 +4172,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4181,7 +4181,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4189,7 +4189,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4197,7 +4197,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4205,7 +4205,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4229,7 +4229,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
     case TYPEDASYNCDROPPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4237,7 +4237,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4245,7 +4245,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4254,7 +4254,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4262,7 +4262,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4270,7 +4270,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4278,7 +4278,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedExternalParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedExternalParamsComponentAc.ref.cpp
@@ -2218,7 +2218,7 @@ void QueuedExternalParamsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
   );
   FW_ASSERT(
@@ -2227,56 +2227,56 @@ void QueuedExternalParamsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str2
-  _status = msg.serialize(str2);
+  _status = msg.serializeFrom(str2);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2324,7 +2324,7 @@ void QueuedExternalParamsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
   );
   FW_ASSERT(
@@ -2333,7 +2333,7 @@ void QueuedExternalParamsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2578,7 +2578,7 @@ void QueuedExternalParamsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
   );
   FW_ASSERT(
@@ -2587,56 +2587,56 @@ void QueuedExternalParamsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2685,7 +2685,7 @@ void QueuedExternalParamsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
   );
   FW_ASSERT(
@@ -2694,56 +2694,56 @@ void QueuedExternalParamsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2792,7 +2792,7 @@ void QueuedExternalParamsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -2801,56 +2801,56 @@ void QueuedExternalParamsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2899,7 +2899,7 @@ void QueuedExternalParamsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -2908,56 +2908,56 @@ void QueuedExternalParamsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3469,7 +3469,7 @@ I32 QueuedExternalParamsComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -3492,7 +3492,7 @@ F64 QueuedExternalParamsComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -3515,7 +3515,7 @@ Fw::ParamString QueuedExternalParamsComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -3538,7 +3538,7 @@ E QueuedExternalParamsComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -3561,7 +3561,7 @@ A QueuedExternalParamsComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -3584,7 +3584,7 @@ S QueuedExternalParamsComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -3669,7 +3669,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
   _msg.resetDeser();
 
   FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -3682,7 +3682,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
   }
 
   FwIndexType portNum = 0;
-  _deserStatus = _msg.deserialize(portNum);
+  _deserStatus = _msg.deserializeTo(portNum);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -3693,7 +3693,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
     case ALIASTYPEDASYNC_ALIASTYPED: {
       // Deserialize argument u32
       AliasPrim1 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3701,7 +3701,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
 
       // Deserialize argument f32
       AliasPrim2 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3709,7 +3709,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
 
       // Deserialize argument b
       AliasBool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3718,7 +3718,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
       // Deserialize argument str2
       char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
       Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserialize(str2);
+      _deserStatus = _msg.deserializeTo(str2);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3726,7 +3726,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
 
       // Deserialize argument e
       AliasEnum e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3734,7 +3734,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
 
       // Deserialize argument a
       AliasArray a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3742,7 +3742,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
 
       // Deserialize argument s
       AliasStruct s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3774,7 +3774,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
     case TYPEDASYNC_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3782,7 +3782,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3790,7 +3790,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3799,7 +3799,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3807,7 +3807,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3815,7 +3815,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3823,7 +3823,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3847,7 +3847,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
     case TYPEDASYNCASSERT_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3855,7 +3855,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3863,7 +3863,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3872,7 +3872,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3880,7 +3880,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3888,7 +3888,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3896,7 +3896,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3920,7 +3920,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
     case TYPEDASYNCBLOCKPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3928,7 +3928,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3936,7 +3936,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3945,7 +3945,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3953,7 +3953,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3961,7 +3961,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3969,7 +3969,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3993,7 +3993,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
     case TYPEDASYNCDROPPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4001,7 +4001,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4009,7 +4009,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4018,7 +4018,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4026,7 +4026,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4034,7 +4034,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4042,7 +4042,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedExternalParamsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedGetProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedGetProductsComponentAc.ref.cpp
@@ -109,12 +109,12 @@ Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serialize(array[i]);
+      status = this->m_dataBuffer.serializeFrom(array[i]);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -134,9 +134,9 @@ Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(elt);
+    status = this->m_dataBuffer.serializeFrom(elt);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -167,14 +167,14 @@ Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       const Fw::StringBase *const sbPtr = array[i];
       FW_ASSERT(sbPtr != nullptr);
-      status = sbPtr->serialize(this->m_dataBuffer, stringSize);
+      status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -195,9 +195,9 @@ Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = elt.serialize(this->m_dataBuffer, stringSize);
+    status = elt.serializeTo(this->m_dataBuffer, stringSize);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -223,12 +223,12 @@ Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serialize(array[i]);
+      status = this->m_dataBuffer.serializeFrom(array[i]);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -248,9 +248,9 @@ Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32Record;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(elt);
+    status = this->m_dataBuffer.serializeFrom(elt);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -276,11 +276,11 @@ Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
+    status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -2318,7 +2318,7 @@ void QueuedGetProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
   );
   FW_ASSERT(
@@ -2327,56 +2327,56 @@ void QueuedGetProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str2
-  _status = msg.serialize(str2);
+  _status = msg.serializeFrom(str2);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2424,7 +2424,7 @@ void QueuedGetProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
   );
   FW_ASSERT(
@@ -2433,7 +2433,7 @@ void QueuedGetProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2678,7 +2678,7 @@ void QueuedGetProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
   );
   FW_ASSERT(
@@ -2687,56 +2687,56 @@ void QueuedGetProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2785,7 +2785,7 @@ void QueuedGetProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
   );
   FW_ASSERT(
@@ -2794,56 +2794,56 @@ void QueuedGetProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2892,7 +2892,7 @@ void QueuedGetProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -2901,56 +2901,56 @@ void QueuedGetProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2999,7 +2999,7 @@ void QueuedGetProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -3008,56 +3008,56 @@ void QueuedGetProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3662,7 +3662,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
   _msg.resetDeser();
 
   FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -3675,7 +3675,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
   }
 
   FwIndexType portNum = 0;
-  _deserStatus = _msg.deserialize(portNum);
+  _deserStatus = _msg.deserializeTo(portNum);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -3686,7 +3686,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
     case ALIASTYPEDASYNC_ALIASTYPED: {
       // Deserialize argument u32
       AliasPrim1 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3694,7 +3694,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
 
       // Deserialize argument f32
       AliasPrim2 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3702,7 +3702,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
 
       // Deserialize argument b
       AliasBool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3711,7 +3711,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
       // Deserialize argument str2
       char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
       Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserialize(str2);
+      _deserStatus = _msg.deserializeTo(str2);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3719,7 +3719,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
 
       // Deserialize argument e
       AliasEnum e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3727,7 +3727,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
 
       // Deserialize argument a
       AliasArray a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3735,7 +3735,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
 
       // Deserialize argument s
       AliasStruct s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3767,7 +3767,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
     case TYPEDASYNC_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3775,7 +3775,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3783,7 +3783,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3792,7 +3792,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3800,7 +3800,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3808,7 +3808,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3816,7 +3816,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3840,7 +3840,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
     case TYPEDASYNCASSERT_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3848,7 +3848,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3856,7 +3856,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3865,7 +3865,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3873,7 +3873,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3881,7 +3881,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3889,7 +3889,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3913,7 +3913,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
     case TYPEDASYNCBLOCKPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3921,7 +3921,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3929,7 +3929,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3938,7 +3938,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3946,7 +3946,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3954,7 +3954,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3962,7 +3962,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3986,7 +3986,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
     case TYPEDASYNCDROPPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3994,7 +3994,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4002,7 +4002,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4011,7 +4011,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4019,7 +4019,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4027,7 +4027,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4035,7 +4035,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGetProductsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedGuardedProductsComponentAc.ref.cpp
@@ -109,12 +109,12 @@ Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serialize(array[i]);
+      status = this->m_dataBuffer.serializeFrom(array[i]);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -134,9 +134,9 @@ Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(elt);
+    status = this->m_dataBuffer.serializeFrom(elt);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -167,14 +167,14 @@ Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       const Fw::StringBase *const sbPtr = array[i];
       FW_ASSERT(sbPtr != nullptr);
-      status = sbPtr->serialize(this->m_dataBuffer, stringSize);
+      status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -195,9 +195,9 @@ Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = elt.serialize(this->m_dataBuffer, stringSize);
+    status = elt.serializeTo(this->m_dataBuffer, stringSize);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -223,12 +223,12 @@ Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serialize(array[i]);
+      status = this->m_dataBuffer.serializeFrom(array[i]);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -248,9 +248,9 @@ Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32Record;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(elt);
+    status = this->m_dataBuffer.serializeFrom(elt);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -276,11 +276,11 @@ Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
+    status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -2408,7 +2408,7 @@ void QueuedGuardedProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
   );
   FW_ASSERT(
@@ -2417,56 +2417,56 @@ void QueuedGuardedProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str2
-  _status = msg.serialize(str2);
+  _status = msg.serializeFrom(str2);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2514,7 +2514,7 @@ void QueuedGuardedProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
   );
   FW_ASSERT(
@@ -2523,7 +2523,7 @@ void QueuedGuardedProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2768,7 +2768,7 @@ void QueuedGuardedProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
   );
   FW_ASSERT(
@@ -2777,56 +2777,56 @@ void QueuedGuardedProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2875,7 +2875,7 @@ void QueuedGuardedProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
   );
   FW_ASSERT(
@@ -2884,56 +2884,56 @@ void QueuedGuardedProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2982,7 +2982,7 @@ void QueuedGuardedProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -2991,56 +2991,56 @@ void QueuedGuardedProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3089,7 +3089,7 @@ void QueuedGuardedProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -3098,56 +3098,56 @@ void QueuedGuardedProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3750,7 +3750,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
   _msg.resetDeser();
 
   FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -3763,7 +3763,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
   }
 
   FwIndexType portNum = 0;
-  _deserStatus = _msg.deserialize(portNum);
+  _deserStatus = _msg.deserializeTo(portNum);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -3774,7 +3774,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
     case ALIASTYPEDASYNC_ALIASTYPED: {
       // Deserialize argument u32
       AliasPrim1 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3782,7 +3782,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
 
       // Deserialize argument f32
       AliasPrim2 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3790,7 +3790,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
 
       // Deserialize argument b
       AliasBool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3799,7 +3799,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
       // Deserialize argument str2
       char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
       Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserialize(str2);
+      _deserStatus = _msg.deserializeTo(str2);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3807,7 +3807,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
 
       // Deserialize argument e
       AliasEnum e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3815,7 +3815,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
 
       // Deserialize argument a
       AliasArray a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3823,7 +3823,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
 
       // Deserialize argument s
       AliasStruct s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3855,7 +3855,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
     case TYPEDASYNC_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3863,7 +3863,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3871,7 +3871,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3880,7 +3880,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3888,7 +3888,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3896,7 +3896,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3904,7 +3904,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3928,7 +3928,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
     case TYPEDASYNCASSERT_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3936,7 +3936,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3944,7 +3944,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3953,7 +3953,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3961,7 +3961,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3969,7 +3969,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3977,7 +3977,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4001,7 +4001,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
     case TYPEDASYNCBLOCKPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4009,7 +4009,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4017,7 +4017,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4026,7 +4026,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4034,7 +4034,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4042,7 +4042,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4050,7 +4050,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4074,7 +4074,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
     case TYPEDASYNCDROPPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4082,7 +4082,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4090,7 +4090,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4099,7 +4099,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4107,7 +4107,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4115,7 +4115,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4123,7 +4123,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedGuardedProductsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedNoArgsPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedNoArgsPortsOnlyComponentAc.ref.cpp
@@ -421,7 +421,7 @@ void QueuedNoArgsPortsOnlyComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
   );
   FW_ASSERT(
@@ -430,7 +430,7 @@ void QueuedNoArgsPortsOnlyComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -601,7 +601,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedNoArgsPortsOnlyComponentBase ::
   _msg.resetDeser();
 
   FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -614,7 +614,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedNoArgsPortsOnlyComponentBase ::
   }
 
   FwIndexType portNum = 0;
-  _deserStatus = _msg.deserialize(portNum);
+  _deserStatus = _msg.deserializeTo(portNum);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedOverflowComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedOverflowComponentAc.ref.cpp
@@ -1015,7 +1015,7 @@ void QueuedOverflowComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(PRODUCTRECVINHOOK_DPRESPONSE)
   );
   FW_ASSERT(
@@ -1024,28 +1024,28 @@ void QueuedOverflowComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument id
-  _status = msg.serialize(id);
+  _status = msg.serializeFrom(id);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument buffer
-  _status = msg.serialize(buffer);
+  _status = msg.serializeFrom(buffer);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument status
-  _status = msg.serialize(status);
+  _status = msg.serializeFrom(status);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -1105,7 +1105,7 @@ void QueuedOverflowComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(ASSERTASYNC_TYPED)
   );
   FW_ASSERT(
@@ -1114,56 +1114,56 @@ void QueuedOverflowComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -1212,7 +1212,7 @@ void QueuedOverflowComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(BLOCKASYNC_TYPED)
   );
   FW_ASSERT(
@@ -1221,56 +1221,56 @@ void QueuedOverflowComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -1319,7 +1319,7 @@ void QueuedOverflowComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(DROPASYNC_TYPED)
   );
   FW_ASSERT(
@@ -1328,56 +1328,56 @@ void QueuedOverflowComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -1431,7 +1431,7 @@ void QueuedOverflowComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(HOOKASYNC_TYPED)
   );
   FW_ASSERT(
@@ -1440,56 +1440,56 @@ void QueuedOverflowComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -1537,7 +1537,7 @@ void QueuedOverflowComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msgSerBuff.serialize(
+  _status = msgSerBuff.serializeFrom(
     static_cast<FwEnumStoreType>(SERIALASYNCHOOK_SERIAL)
   );
   FW_ASSERT(
@@ -1546,14 +1546,14 @@ void QueuedOverflowComponentBase ::
   );
 
   // Serialize port number
-  _status = msgSerBuff.serialize(portNum);
+  _status = msgSerBuff.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument buffer
-  _status = msgSerBuff.serialize(buffer);
+  _status = msgSerBuff.serializeFrom(buffer);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -1697,14 +1697,14 @@ void QueuedOverflowComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize the message ID
-  _status = msg.serialize(static_cast<FwEnumStoreType>(INT_IF_INTERNALHOOKDROP));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALHOOKDROP));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Fake port number to make message dequeue work
-  _status = msg.serialize(static_cast<FwIndexType>(0));
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -1762,7 +1762,7 @@ void QueuedOverflowComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize for IPC
-  _status = msg.serialize(static_cast<FwEnumStoreType>(CMD_CMD_HOOK));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_HOOK));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -1771,25 +1771,25 @@ void QueuedOverflowComponentBase ::
   // Fake port number to make message dequeue work
   FwIndexType port = 0;
 
-  _status = msg.serialize(port);
+  _status = msg.serializeFrom(port);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(opCode);
+  _status = msg.serializeFrom(opCode);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(cmdSeq);
+  _status = msg.serializeFrom(cmdSeq);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(args);
+  _status = msg.serializeFrom(args);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -1826,7 +1826,7 @@ void QueuedOverflowComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize for IPC
-  _status = msg.serialize(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_HOOK));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_HOOK));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -1835,25 +1835,25 @@ void QueuedOverflowComponentBase ::
   // Fake port number to make message dequeue work
   FwIndexType port = 0;
 
-  _status = msg.serialize(port);
+  _status = msg.serializeFrom(port);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(opCode);
+  _status = msg.serializeFrom(opCode);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(cmdSeq);
+  _status = msg.serializeFrom(cmdSeq);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(args);
+  _status = msg.serializeFrom(args);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -1954,7 +1954,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
   _msg.resetDeser();
 
   FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -1967,7 +1967,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
   }
 
   FwIndexType portNum = 0;
-  _deserStatus = _msg.deserialize(portNum);
+  _deserStatus = _msg.deserializeTo(portNum);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -1978,7 +1978,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
     case PRODUCTRECVINHOOK_DPRESPONSE: {
       // Deserialize argument id
       FwDpIdType id;
-      _deserStatus = _msg.deserialize(id);
+      _deserStatus = _msg.deserializeTo(id);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -1986,7 +1986,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
 
       // Deserialize argument buffer
       Fw::Buffer buffer;
-      _deserStatus = _msg.deserialize(buffer);
+      _deserStatus = _msg.deserializeTo(buffer);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -1994,7 +1994,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
 
       // Deserialize argument status
       Fw::Success status;
-      _deserStatus = _msg.deserialize(status);
+      _deserStatus = _msg.deserializeTo(status);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2014,7 +2014,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
     case ASSERTASYNC_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2022,7 +2022,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2030,7 +2030,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2039,7 +2039,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2047,7 +2047,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2055,7 +2055,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2063,7 +2063,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2087,7 +2087,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
     case BLOCKASYNC_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2095,7 +2095,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2103,7 +2103,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2112,7 +2112,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2120,7 +2120,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2128,7 +2128,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2136,7 +2136,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2160,7 +2160,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
     case DROPASYNC_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2168,7 +2168,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2176,7 +2176,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2185,7 +2185,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2193,7 +2193,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2201,7 +2201,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2209,7 +2209,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2233,7 +2233,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
     case HOOKASYNC_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2241,7 +2241,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2249,7 +2249,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2258,7 +2258,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2266,7 +2266,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2274,7 +2274,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2282,7 +2282,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2310,7 +2310,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
         handBuff,
         static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
       );
-      _deserStatus = _msg.deserialize(serHandBuff);
+      _deserStatus = _msg.deserializeTo(serHandBuff);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2324,7 +2324,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
     case CMD_CMD_HOOK: {
       // Deserialize opcode
       FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserialize(_opCode);
+      _deserStatus = _msg.deserializeTo(_opCode);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2332,7 +2332,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
 
       // Deserialize command sequence
       U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserialize(_cmdSeq);
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2340,7 +2340,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
 
       // Deserialize command argument buffer
       Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserialize(args);
+      _deserStatus = _msg.deserializeTo(args);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2371,7 +2371,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
     case CMD_CMD_PARAMS_PRIORITY_HOOK: {
       // Deserialize opcode
       FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserialize(_opCode);
+      _deserStatus = _msg.deserializeTo(_opCode);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2379,7 +2379,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
 
       // Deserialize command sequence
       U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserialize(_cmdSeq);
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2387,7 +2387,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
 
       // Deserialize command argument buffer
       Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserialize(args);
+      _deserStatus = _msg.deserializeTo(args);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -2398,7 +2398,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedOverflowComponentBase ::
 
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = args.deserialize(u32);
+      _deserStatus = args.deserializeTo(u32);
       if (_deserStatus != Fw::FW_SERIALIZE_OK) {
         if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
           this->cmdResponse_out(

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.cpp
@@ -1589,7 +1589,7 @@ void QueuedParamsComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamU32);
+    _stat = _buff.deserializeTo(this->m_ParamU32);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamU32_valid = Fw::ParamValid::INVALID;
     }
@@ -1614,7 +1614,7 @@ void QueuedParamsComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamF64);
+    _stat = _buff.deserializeTo(this->m_ParamF64);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamF64_valid = Fw::ParamValid::INVALID;
     }
@@ -1639,7 +1639,7 @@ void QueuedParamsComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamString);
+    _stat = _buff.deserializeTo(this->m_ParamString);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
       // Set default value
@@ -1668,7 +1668,7 @@ void QueuedParamsComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamEnum);
+    _stat = _buff.deserializeTo(this->m_ParamEnum);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamEnum_valid = Fw::ParamValid::INVALID;
     }
@@ -1693,7 +1693,7 @@ void QueuedParamsComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamArray);
+    _stat = _buff.deserializeTo(this->m_ParamArray);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
       // Set default value
@@ -1722,7 +1722,7 @@ void QueuedParamsComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamStruct);
+    _stat = _buff.deserializeTo(this->m_ParamStruct);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamStruct_valid = Fw::ParamValid::INVALID;
     }
@@ -2222,7 +2222,7 @@ void QueuedParamsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
   );
   FW_ASSERT(
@@ -2231,56 +2231,56 @@ void QueuedParamsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str2
-  _status = msg.serialize(str2);
+  _status = msg.serializeFrom(str2);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2328,7 +2328,7 @@ void QueuedParamsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
   );
   FW_ASSERT(
@@ -2337,7 +2337,7 @@ void QueuedParamsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2582,7 +2582,7 @@ void QueuedParamsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
   );
   FW_ASSERT(
@@ -2591,56 +2591,56 @@ void QueuedParamsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2689,7 +2689,7 @@ void QueuedParamsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
   );
   FW_ASSERT(
@@ -2698,56 +2698,56 @@ void QueuedParamsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2796,7 +2796,7 @@ void QueuedParamsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -2805,56 +2805,56 @@ void QueuedParamsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2903,7 +2903,7 @@ void QueuedParamsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -2912,56 +2912,56 @@ void QueuedParamsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3590,7 +3590,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
   _msg.resetDeser();
 
   FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -3603,7 +3603,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
   }
 
   FwIndexType portNum = 0;
-  _deserStatus = _msg.deserialize(portNum);
+  _deserStatus = _msg.deserializeTo(portNum);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -3614,7 +3614,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
     case ALIASTYPEDASYNC_ALIASTYPED: {
       // Deserialize argument u32
       AliasPrim1 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3622,7 +3622,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
 
       // Deserialize argument f32
       AliasPrim2 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3630,7 +3630,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
 
       // Deserialize argument b
       AliasBool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3639,7 +3639,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
       // Deserialize argument str2
       char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
       Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserialize(str2);
+      _deserStatus = _msg.deserializeTo(str2);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3647,7 +3647,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
 
       // Deserialize argument e
       AliasEnum e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3655,7 +3655,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
 
       // Deserialize argument a
       AliasArray a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3663,7 +3663,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
 
       // Deserialize argument s
       AliasStruct s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3695,7 +3695,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
     case TYPEDASYNC_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3703,7 +3703,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3711,7 +3711,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3720,7 +3720,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3728,7 +3728,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3736,7 +3736,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3744,7 +3744,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3768,7 +3768,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
     case TYPEDASYNCASSERT_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3776,7 +3776,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3784,7 +3784,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3793,7 +3793,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3801,7 +3801,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3809,7 +3809,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3817,7 +3817,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3841,7 +3841,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
     case TYPEDASYNCBLOCKPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3849,7 +3849,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3857,7 +3857,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3866,7 +3866,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3874,7 +3874,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3882,7 +3882,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3890,7 +3890,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3914,7 +3914,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
     case TYPEDASYNCDROPPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3922,7 +3922,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3930,7 +3930,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3939,7 +3939,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3947,7 +3947,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3955,7 +3955,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3963,7 +3963,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4565,7 +4565,7 @@ Fw::CmdResponse QueuedParamsComponentBase ::
   paramSet_ParamU32(Fw::SerializeBufferBase& val)
 {
   U32 _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -4585,7 +4585,7 @@ Fw::CmdResponse QueuedParamsComponentBase ::
   paramSet_ParamF64(Fw::SerializeBufferBase& val)
 {
   F64 _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -4605,7 +4605,7 @@ Fw::CmdResponse QueuedParamsComponentBase ::
   paramSet_ParamString(Fw::SerializeBufferBase& val)
 {
   Fw::ParamString _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -4625,7 +4625,7 @@ Fw::CmdResponse QueuedParamsComponentBase ::
   paramSet_ParamEnum(Fw::SerializeBufferBase& val)
 {
   E _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -4645,7 +4645,7 @@ Fw::CmdResponse QueuedParamsComponentBase ::
   paramSet_ParamArray(Fw::SerializeBufferBase& val)
 {
   A _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -4665,7 +4665,7 @@ Fw::CmdResponse QueuedParamsComponentBase ::
   paramSet_ParamStruct(Fw::SerializeBufferBase& val)
 {
   S _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -4694,7 +4694,7 @@ Fw::CmdResponse QueuedParamsComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamU32);
+    _stat = _saveBuff.serializeFrom(m_ParamU32);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -4724,7 +4724,7 @@ Fw::CmdResponse QueuedParamsComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamF64);
+    _stat = _saveBuff.serializeFrom(m_ParamF64);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -4754,7 +4754,7 @@ Fw::CmdResponse QueuedParamsComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamString);
+    _stat = _saveBuff.serializeFrom(m_ParamString);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -4784,7 +4784,7 @@ Fw::CmdResponse QueuedParamsComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamEnum);
+    _stat = _saveBuff.serializeFrom(m_ParamEnum);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -4814,7 +4814,7 @@ Fw::CmdResponse QueuedParamsComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamArray);
+    _stat = _saveBuff.serializeFrom(m_ParamArray);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -4844,7 +4844,7 @@ Fw::CmdResponse QueuedParamsComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamStruct);
+    _stat = _saveBuff.serializeFrom(m_ParamStruct);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
@@ -2006,7 +2006,7 @@ void QueuedSerialComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamU32);
+    _stat = _buff.deserializeTo(this->m_ParamU32);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamU32_valid = Fw::ParamValid::INVALID;
     }
@@ -2031,7 +2031,7 @@ void QueuedSerialComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamF64);
+    _stat = _buff.deserializeTo(this->m_ParamF64);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamF64_valid = Fw::ParamValid::INVALID;
     }
@@ -2056,7 +2056,7 @@ void QueuedSerialComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamString);
+    _stat = _buff.deserializeTo(this->m_ParamString);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
       // Set default value
@@ -2085,7 +2085,7 @@ void QueuedSerialComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamEnum);
+    _stat = _buff.deserializeTo(this->m_ParamEnum);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamEnum_valid = Fw::ParamValid::INVALID;
     }
@@ -2110,7 +2110,7 @@ void QueuedSerialComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamArray);
+    _stat = _buff.deserializeTo(this->m_ParamArray);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
       // Set default value
@@ -2139,7 +2139,7 @@ void QueuedSerialComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamStruct);
+    _stat = _buff.deserializeTo(this->m_ParamStruct);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamStruct_valid = Fw::ParamValid::INVALID;
     }
@@ -2872,7 +2872,7 @@ void QueuedSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
   );
   FW_ASSERT(
@@ -2881,56 +2881,56 @@ void QueuedSerialComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str2
-  _status = msg.serialize(str2);
+  _status = msg.serializeFrom(str2);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2978,7 +2978,7 @@ void QueuedSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
   );
   FW_ASSERT(
@@ -2987,7 +2987,7 @@ void QueuedSerialComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3232,7 +3232,7 @@ void QueuedSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
   );
   FW_ASSERT(
@@ -3241,56 +3241,56 @@ void QueuedSerialComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3339,7 +3339,7 @@ void QueuedSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
   );
   FW_ASSERT(
@@ -3348,56 +3348,56 @@ void QueuedSerialComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3446,7 +3446,7 @@ void QueuedSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -3455,56 +3455,56 @@ void QueuedSerialComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3553,7 +3553,7 @@ void QueuedSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -3562,56 +3562,56 @@ void QueuedSerialComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3803,7 +3803,7 @@ void QueuedSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msgSerBuff.serialize(
+  _status = msgSerBuff.serializeFrom(
     static_cast<FwEnumStoreType>(SERIALASYNC_SERIAL)
   );
   FW_ASSERT(
@@ -3812,14 +3812,14 @@ void QueuedSerialComponentBase ::
   );
 
   // Serialize port number
-  _status = msgSerBuff.serialize(portNum);
+  _status = msgSerBuff.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument buffer
-  _status = msgSerBuff.serialize(buffer);
+  _status = msgSerBuff.serializeFrom(buffer);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3856,7 +3856,7 @@ void QueuedSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msgSerBuff.serialize(
+  _status = msgSerBuff.serializeFrom(
     static_cast<FwEnumStoreType>(SERIALASYNCASSERT_SERIAL)
   );
   FW_ASSERT(
@@ -3865,14 +3865,14 @@ void QueuedSerialComponentBase ::
   );
 
   // Serialize port number
-  _status = msgSerBuff.serialize(portNum);
+  _status = msgSerBuff.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument buffer
-  _status = msgSerBuff.serialize(buffer);
+  _status = msgSerBuff.serializeFrom(buffer);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3909,7 +3909,7 @@ void QueuedSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msgSerBuff.serialize(
+  _status = msgSerBuff.serializeFrom(
     static_cast<FwEnumStoreType>(SERIALASYNCBLOCKPRIORITY_SERIAL)
   );
   FW_ASSERT(
@@ -3918,14 +3918,14 @@ void QueuedSerialComponentBase ::
   );
 
   // Serialize port number
-  _status = msgSerBuff.serialize(portNum);
+  _status = msgSerBuff.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument buffer
-  _status = msgSerBuff.serialize(buffer);
+  _status = msgSerBuff.serializeFrom(buffer);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3962,7 +3962,7 @@ void QueuedSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msgSerBuff.serialize(
+  _status = msgSerBuff.serializeFrom(
     static_cast<FwEnumStoreType>(SERIALASYNCDROPPRIORITY_SERIAL)
   );
   FW_ASSERT(
@@ -3971,14 +3971,14 @@ void QueuedSerialComponentBase ::
   );
 
   // Serialize port number
-  _status = msgSerBuff.serialize(portNum);
+  _status = msgSerBuff.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument buffer
-  _status = msgSerBuff.serialize(buffer);
+  _status = msgSerBuff.serializeFrom(buffer);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4420,20 +4420,20 @@ void QueuedSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize the message ID
-  _status = msg.serialize(static_cast<FwEnumStoreType>(INT_IF_INTERNALARRAY));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALARRAY));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Fake port number to make message dequeue work
-  _status = msg.serialize(static_cast<FwIndexType>(0));
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4456,20 +4456,20 @@ void QueuedSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize the message ID
-  _status = msg.serialize(static_cast<FwEnumStoreType>(INT_IF_INTERNALENUM));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALENUM));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Fake port number to make message dequeue work
-  _status = msg.serialize(static_cast<FwIndexType>(0));
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4496,32 +4496,32 @@ void QueuedSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize the message ID
-  _status = msg.serialize(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIMITIVE));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIMITIVE));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Fake port number to make message dequeue work
-  _status = msg.serialize(static_cast<FwIndexType>(0));
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4544,14 +4544,14 @@ void QueuedSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize the message ID
-  _status = msg.serialize(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIORITYDROP));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIORITYDROP));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Fake port number to make message dequeue work
-  _status = msg.serialize(static_cast<FwIndexType>(0));
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4582,26 +4582,26 @@ void QueuedSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize the message ID
-  _status = msg.serialize(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRING));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRING));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Fake port number to make message dequeue work
-  _status = msg.serialize(static_cast<FwIndexType>(0));
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(str1);
+  _status = msg.serializeFrom(str1);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(str2);
+  _status = msg.serializeFrom(str2);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4624,20 +4624,20 @@ void QueuedSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize the message ID
-  _status = msg.serialize(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRUCT));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRUCT));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Fake port number to make message dequeue work
-  _status = msg.serialize(static_cast<FwIndexType>(0));
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4718,7 +4718,7 @@ void QueuedSerialComponentBase ::
   args.resetDeser();
 
   U32 u32;
-  _status = args.deserialize(u32);
+  _status = args.deserializeTo(u32);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4731,7 +4731,7 @@ void QueuedSerialComponentBase ::
   }
 
   F32 f32;
-  _status = args.deserialize(f32);
+  _status = args.deserializeTo(f32);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4744,7 +4744,7 @@ void QueuedSerialComponentBase ::
   }
 
   bool b;
-  _status = args.deserialize(b);
+  _status = args.deserializeTo(b);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4793,7 +4793,7 @@ void QueuedSerialComponentBase ::
   args.resetDeser();
 
   Fw::CmdStringArg str1;
-  _status = args.deserialize(str1);
+  _status = args.deserializeTo(str1);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4806,7 +4806,7 @@ void QueuedSerialComponentBase ::
   }
 
   Fw::CmdStringArg str2;
-  _status = args.deserialize(str2);
+  _status = args.deserializeTo(str2);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4854,7 +4854,7 @@ void QueuedSerialComponentBase ::
   args.resetDeser();
 
   E e;
-  _status = args.deserialize(e);
+  _status = args.deserializeTo(e);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4901,7 +4901,7 @@ void QueuedSerialComponentBase ::
   args.resetDeser();
 
   A a;
-  _status = args.deserialize(a);
+  _status = args.deserializeTo(a);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4948,7 +4948,7 @@ void QueuedSerialComponentBase ::
   args.resetDeser();
 
   S s;
-  _status = args.deserialize(s);
+  _status = args.deserializeTo(s);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -5024,7 +5024,7 @@ void QueuedSerialComponentBase ::
   args.resetDeser();
 
   U32 u32;
-  _status = args.deserialize(u32);
+  _status = args.deserializeTo(u32);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -5037,7 +5037,7 @@ void QueuedSerialComponentBase ::
   }
 
   F32 f32;
-  _status = args.deserialize(f32);
+  _status = args.deserializeTo(f32);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -5050,7 +5050,7 @@ void QueuedSerialComponentBase ::
   }
 
   bool b;
-  _status = args.deserialize(b);
+  _status = args.deserializeTo(b);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -5103,7 +5103,7 @@ void QueuedSerialComponentBase ::
   args.resetDeser();
 
   Fw::CmdStringArg str1;
-  _status = args.deserialize(str1);
+  _status = args.deserializeTo(str1);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -5116,7 +5116,7 @@ void QueuedSerialComponentBase ::
   }
 
   Fw::CmdStringArg str2;
-  _status = args.deserialize(str2);
+  _status = args.deserializeTo(str2);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -5168,7 +5168,7 @@ void QueuedSerialComponentBase ::
   args.resetDeser();
 
   E e;
-  _status = args.deserialize(e);
+  _status = args.deserializeTo(e);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -5219,7 +5219,7 @@ void QueuedSerialComponentBase ::
   args.resetDeser();
 
   A a;
-  _status = args.deserialize(a);
+  _status = args.deserializeTo(a);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -5270,7 +5270,7 @@ void QueuedSerialComponentBase ::
   args.resetDeser();
 
   S s;
-  _status = args.deserialize(s);
+  _status = args.deserializeTo(s);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -5323,7 +5323,7 @@ void QueuedSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize for IPC
-  _status = msg.serialize(static_cast<FwEnumStoreType>(CMD_CMD_ASYNC));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_ASYNC));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -5332,25 +5332,25 @@ void QueuedSerialComponentBase ::
   // Fake port number to make message dequeue work
   FwIndexType port = 0;
 
-  _status = msg.serialize(port);
+  _status = msg.serializeFrom(port);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(opCode);
+  _status = msg.serializeFrom(opCode);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(cmdSeq);
+  _status = msg.serializeFrom(cmdSeq);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(args);
+  _status = msg.serializeFrom(args);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -5382,7 +5382,7 @@ void QueuedSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize for IPC
-  _status = msg.serialize(static_cast<FwEnumStoreType>(CMD_CMD_PRIORITY));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PRIORITY));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -5391,25 +5391,25 @@ void QueuedSerialComponentBase ::
   // Fake port number to make message dequeue work
   FwIndexType port = 0;
 
-  _status = msg.serialize(port);
+  _status = msg.serializeFrom(port);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(opCode);
+  _status = msg.serializeFrom(opCode);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(cmdSeq);
+  _status = msg.serializeFrom(cmdSeq);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(args);
+  _status = msg.serializeFrom(args);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -5441,7 +5441,7 @@ void QueuedSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize for IPC
-  _status = msg.serialize(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -5450,25 +5450,25 @@ void QueuedSerialComponentBase ::
   // Fake port number to make message dequeue work
   FwIndexType port = 0;
 
-  _status = msg.serialize(port);
+  _status = msg.serializeFrom(port);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(opCode);
+  _status = msg.serializeFrom(opCode);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(cmdSeq);
+  _status = msg.serializeFrom(cmdSeq);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(args);
+  _status = msg.serializeFrom(args);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -5500,7 +5500,7 @@ void QueuedSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize for IPC
-  _status = msg.serialize(static_cast<FwEnumStoreType>(CMD_CMD_DROP));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_DROP));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -5509,25 +5509,25 @@ void QueuedSerialComponentBase ::
   // Fake port number to make message dequeue work
   FwIndexType port = 0;
 
-  _status = msg.serialize(port);
+  _status = msg.serializeFrom(port);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(opCode);
+  _status = msg.serializeFrom(opCode);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(cmdSeq);
+  _status = msg.serializeFrom(cmdSeq);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(args);
+  _status = msg.serializeFrom(args);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -5564,7 +5564,7 @@ void QueuedSerialComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize for IPC
-  _status = msg.serialize(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_DROP));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_DROP));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -5573,25 +5573,25 @@ void QueuedSerialComponentBase ::
   // Fake port number to make message dequeue work
   FwIndexType port = 0;
 
-  _status = msg.serialize(port);
+  _status = msg.serializeFrom(port);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(opCode);
+  _status = msg.serializeFrom(opCode);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(cmdSeq);
+  _status = msg.serializeFrom(cmdSeq);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(args);
+  _status = msg.serializeFrom(args);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -5699,7 +5699,7 @@ void QueuedSerialComponentBase ::
 #if FW_AMPCS_COMPATIBLE
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(0));
+    _status = _logBuff.serializeFrom(static_cast<U8>(0));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -5776,7 +5776,7 @@ void QueuedSerialComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(3));
+    _status = _logBuff.serializeFrom(static_cast<U8>(3));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -5785,7 +5785,7 @@ void QueuedSerialComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(sizeof(U32))
     );
     FW_ASSERT(
@@ -5793,7 +5793,7 @@ void QueuedSerialComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(u32);
+    _status = _logBuff.serializeFrom(u32);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -5801,7 +5801,7 @@ void QueuedSerialComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(sizeof(F32))
     );
     FW_ASSERT(
@@ -5809,7 +5809,7 @@ void QueuedSerialComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(f32);
+    _status = _logBuff.serializeFrom(f32);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -5817,7 +5817,7 @@ void QueuedSerialComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(sizeof(U8))
     );
     FW_ASSERT(
@@ -5825,7 +5825,7 @@ void QueuedSerialComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(b);
+    _status = _logBuff.serializeFrom(b);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -5895,20 +5895,20 @@ void QueuedSerialComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(2));
+    _status = _logBuff.serializeFrom(static_cast<U8>(2));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 #endif
 
-    _status = str1.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 80));
+    _status = str1.serializeTo(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 80));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = str2.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 100));
+    _status = str2.serializeTo(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 100));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -5974,7 +5974,7 @@ void QueuedSerialComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(1));
+    _status = _logBuff.serializeFrom(static_cast<U8>(1));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -5983,7 +5983,7 @@ void QueuedSerialComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(E::SERIALIZED_SIZE)
     );
     FW_ASSERT(
@@ -5991,7 +5991,7 @@ void QueuedSerialComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(e);
+    _status = _logBuff.serializeFrom(e);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -6067,20 +6067,20 @@ void QueuedSerialComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(1 + 1));
+    _status = _logBuff.serializeFrom(static_cast<U8>(1 + 1));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // For FATAL, add stack size of 4 and a dummy entry. No support for stacks yet.
-    _status = _logBuff.serialize(static_cast<U8>(4));
+    _status = _logBuff.serializeFrom(static_cast<U8>(4));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = _logBuff.serialize(static_cast<U32>(0));
+    _status = _logBuff.serializeFrom(static_cast<U32>(0));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -6089,7 +6089,7 @@ void QueuedSerialComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(A::SERIALIZED_SIZE)
     );
     FW_ASSERT(
@@ -6097,7 +6097,7 @@ void QueuedSerialComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(a);
+    _status = _logBuff.serializeFrom(a);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -6165,7 +6165,7 @@ void QueuedSerialComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(1));
+    _status = _logBuff.serializeFrom(static_cast<U8>(1));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -6174,7 +6174,7 @@ void QueuedSerialComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(S::SERIALIZED_SIZE)
     );
     FW_ASSERT(
@@ -6182,7 +6182,7 @@ void QueuedSerialComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(s);
+    _status = _logBuff.serializeFrom(s);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -6258,7 +6258,7 @@ void QueuedSerialComponentBase ::
 #if FW_AMPCS_COMPATIBLE
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(0));
+    _status = _logBuff.serializeFrom(static_cast<U8>(0));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -6347,7 +6347,7 @@ void QueuedSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -6380,7 +6380,7 @@ void QueuedSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -6413,7 +6413,7 @@ void QueuedSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = arg.serialize(_tlmBuff, FW_MIN(FW_TLM_STRING_MAX_SIZE, 80));
+    Fw::SerializeStatus _stat = arg.serializeTo(_tlmBuff, FW_MIN(FW_TLM_STRING_MAX_SIZE, 80));
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -6446,7 +6446,7 @@ void QueuedSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -6479,7 +6479,7 @@ void QueuedSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -6512,7 +6512,7 @@ void QueuedSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -6545,7 +6545,7 @@ void QueuedSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -6578,7 +6578,7 @@ void QueuedSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -6611,7 +6611,7 @@ void QueuedSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -6659,7 +6659,7 @@ void QueuedSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -6707,7 +6707,7 @@ void QueuedSerialComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -6825,7 +6825,7 @@ I32 QueuedSerialComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -6848,7 +6848,7 @@ F64 QueuedSerialComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -6871,7 +6871,7 @@ Fw::ParamString QueuedSerialComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -6894,7 +6894,7 @@ E QueuedSerialComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -6917,7 +6917,7 @@ A QueuedSerialComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -6940,7 +6940,7 @@ S QueuedSerialComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -7029,7 +7029,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
   _msg.resetDeser();
 
   FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -7042,7 +7042,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
   }
 
   FwIndexType portNum = 0;
-  _deserStatus = _msg.deserialize(portNum);
+  _deserStatus = _msg.deserializeTo(portNum);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -7053,7 +7053,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
     case ALIASTYPEDASYNC_ALIASTYPED: {
       // Deserialize argument u32
       AliasPrim1 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7061,7 +7061,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize argument f32
       AliasPrim2 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7069,7 +7069,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize argument b
       AliasBool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7078,7 +7078,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
       // Deserialize argument str2
       char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
       Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserialize(str2);
+      _deserStatus = _msg.deserializeTo(str2);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7086,7 +7086,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize argument e
       AliasEnum e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7094,7 +7094,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize argument a
       AliasArray a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7102,7 +7102,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize argument s
       AliasStruct s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7134,7 +7134,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
     case TYPEDASYNC_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7142,7 +7142,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7150,7 +7150,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7159,7 +7159,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7167,7 +7167,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7175,7 +7175,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7183,7 +7183,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7207,7 +7207,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
     case TYPEDASYNCASSERT_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7215,7 +7215,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7223,7 +7223,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7232,7 +7232,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7240,7 +7240,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7248,7 +7248,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7256,7 +7256,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7280,7 +7280,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
     case TYPEDASYNCBLOCKPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7288,7 +7288,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7296,7 +7296,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7305,7 +7305,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7313,7 +7313,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7321,7 +7321,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7329,7 +7329,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7353,7 +7353,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
     case TYPEDASYNCDROPPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7361,7 +7361,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7369,7 +7369,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7378,7 +7378,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7386,7 +7386,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7394,7 +7394,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7402,7 +7402,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7430,7 +7430,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
         handBuff,
         static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
       );
-      _deserStatus = _msg.deserialize(serHandBuff);
+      _deserStatus = _msg.deserializeTo(serHandBuff);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7448,7 +7448,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
         handBuff,
         static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
       );
-      _deserStatus = _msg.deserialize(serHandBuff);
+      _deserStatus = _msg.deserializeTo(serHandBuff);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7466,7 +7466,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
         handBuff,
         static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
       );
-      _deserStatus = _msg.deserialize(serHandBuff);
+      _deserStatus = _msg.deserializeTo(serHandBuff);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7484,7 +7484,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
         handBuff,
         static_cast<Fw::Serializable::SizeType>(this->m_msgSize)
       );
-      _deserStatus = _msg.deserialize(serHandBuff);
+      _deserStatus = _msg.deserializeTo(serHandBuff);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7498,7 +7498,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
     case CMD_CMD_ASYNC: {
       // Deserialize opcode
       FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserialize(_opCode);
+      _deserStatus = _msg.deserializeTo(_opCode);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7506,7 +7506,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize command sequence
       U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserialize(_cmdSeq);
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7514,7 +7514,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize command argument buffer
       Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserialize(args);
+      _deserStatus = _msg.deserializeTo(args);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7545,7 +7545,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
     case CMD_CMD_PRIORITY: {
       // Deserialize opcode
       FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserialize(_opCode);
+      _deserStatus = _msg.deserializeTo(_opCode);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7553,7 +7553,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize command sequence
       U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserialize(_cmdSeq);
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7561,7 +7561,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize command argument buffer
       Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserialize(args);
+      _deserStatus = _msg.deserializeTo(args);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7592,7 +7592,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
     case CMD_CMD_PARAMS_PRIORITY: {
       // Deserialize opcode
       FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserialize(_opCode);
+      _deserStatus = _msg.deserializeTo(_opCode);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7600,7 +7600,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize command sequence
       U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserialize(_cmdSeq);
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7608,7 +7608,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize command argument buffer
       Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserialize(args);
+      _deserStatus = _msg.deserializeTo(args);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7619,7 +7619,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = args.deserialize(u32);
+      _deserStatus = args.deserializeTo(u32);
       if (_deserStatus != Fw::FW_SERIALIZE_OK) {
         if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
           this->cmdResponse_out(
@@ -7657,7 +7657,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
     case CMD_CMD_DROP: {
       // Deserialize opcode
       FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserialize(_opCode);
+      _deserStatus = _msg.deserializeTo(_opCode);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7665,7 +7665,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize command sequence
       U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserialize(_cmdSeq);
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7673,7 +7673,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize command argument buffer
       Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserialize(args);
+      _deserStatus = _msg.deserializeTo(args);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7704,7 +7704,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
     case CMD_CMD_PARAMS_PRIORITY_DROP: {
       // Deserialize opcode
       FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserialize(_opCode);
+      _deserStatus = _msg.deserializeTo(_opCode);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7712,7 +7712,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize command sequence
       U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserialize(_cmdSeq);
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7720,7 +7720,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize command argument buffer
       Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserialize(args);
+      _deserStatus = _msg.deserializeTo(args);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7731,7 +7731,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
 
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = args.deserialize(u32);
+      _deserStatus = args.deserializeTo(u32);
       if (_deserStatus != Fw::FW_SERIALIZE_OK) {
         if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
           this->cmdResponse_out(
@@ -7768,7 +7768,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
     // Handle internal interface internalArray
     case INT_IF_INTERNALARRAY: {
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
 
       // Internal interface should always deserialize
       FW_ASSERT(
@@ -7794,7 +7794,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
     // Handle internal interface internalEnum
     case INT_IF_INTERNALENUM: {
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
 
       // Internal interface should always deserialize
       FW_ASSERT(
@@ -7820,7 +7820,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
     // Handle internal interface internalPrimitive
     case INT_IF_INTERNALPRIMITIVE: {
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
 
       // Internal interface should always deserialize
       FW_ASSERT(
@@ -7829,7 +7829,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
       );
 
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
 
       // Internal interface should always deserialize
       FW_ASSERT(
@@ -7838,7 +7838,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
       );
 
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
 
       // Internal interface should always deserialize
       FW_ASSERT(
@@ -7881,7 +7881,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
     // Handle internal interface internalString
     case INT_IF_INTERNALSTRING: {
       Fw::InternalInterfaceString str1;
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
 
       // Internal interface should always deserialize
       FW_ASSERT(
@@ -7890,7 +7890,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
       );
 
       Fw::InternalInterfaceString str2;
-      _deserStatus = _msg.deserialize(str2);
+      _deserStatus = _msg.deserializeTo(str2);
 
       // Internal interface should always deserialize
       FW_ASSERT(
@@ -7917,7 +7917,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
     // Handle internal interface internalStruct
     case INT_IF_INTERNALSTRUCT: {
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
 
       // Internal interface should always deserialize
       FW_ASSERT(
@@ -8893,7 +8893,7 @@ Fw::CmdResponse QueuedSerialComponentBase ::
   paramSet_ParamU32(Fw::SerializeBufferBase& val)
 {
   U32 _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -8913,7 +8913,7 @@ Fw::CmdResponse QueuedSerialComponentBase ::
   paramSet_ParamF64(Fw::SerializeBufferBase& val)
 {
   F64 _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -8933,7 +8933,7 @@ Fw::CmdResponse QueuedSerialComponentBase ::
   paramSet_ParamString(Fw::SerializeBufferBase& val)
 {
   Fw::ParamString _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -8953,7 +8953,7 @@ Fw::CmdResponse QueuedSerialComponentBase ::
   paramSet_ParamEnum(Fw::SerializeBufferBase& val)
 {
   E _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -8973,7 +8973,7 @@ Fw::CmdResponse QueuedSerialComponentBase ::
   paramSet_ParamArray(Fw::SerializeBufferBase& val)
 {
   A _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -8993,7 +8993,7 @@ Fw::CmdResponse QueuedSerialComponentBase ::
   paramSet_ParamStruct(Fw::SerializeBufferBase& val)
 {
   S _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -9160,7 +9160,7 @@ Fw::CmdResponse QueuedSerialComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamU32);
+    _stat = _saveBuff.serializeFrom(m_ParamU32);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -9190,7 +9190,7 @@ Fw::CmdResponse QueuedSerialComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamF64);
+    _stat = _saveBuff.serializeFrom(m_ParamF64);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -9220,7 +9220,7 @@ Fw::CmdResponse QueuedSerialComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamString);
+    _stat = _saveBuff.serializeFrom(m_ParamString);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -9250,7 +9250,7 @@ Fw::CmdResponse QueuedSerialComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamEnum);
+    _stat = _saveBuff.serializeFrom(m_ParamEnum);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -9280,7 +9280,7 @@ Fw::CmdResponse QueuedSerialComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamArray);
+    _stat = _saveBuff.serializeFrom(m_ParamArray);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -9310,7 +9310,7 @@ Fw::CmdResponse QueuedSerialComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamStruct);
+    _stat = _saveBuff.serializeFrom(m_ParamStruct);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSyncProductsComponentAc.ref.cpp
@@ -109,12 +109,12 @@ Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serialize(array[i]);
+      status = this->m_dataBuffer.serializeFrom(array[i]);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -134,9 +134,9 @@ Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(elt);
+    status = this->m_dataBuffer.serializeFrom(elt);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -167,14 +167,14 @@ Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       const Fw::StringBase *const sbPtr = array[i];
       FW_ASSERT(sbPtr != nullptr);
-      status = sbPtr->serialize(this->m_dataBuffer, stringSize);
+      status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -195,9 +195,9 @@ Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = elt.serialize(this->m_dataBuffer, stringSize);
+    status = elt.serializeTo(this->m_dataBuffer, stringSize);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -223,12 +223,12 @@ Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serialize(array[i]);
+      status = this->m_dataBuffer.serializeFrom(array[i]);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -248,9 +248,9 @@ Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32Record;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(elt);
+    status = this->m_dataBuffer.serializeFrom(elt);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -276,11 +276,11 @@ Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
+    status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -2402,7 +2402,7 @@ void QueuedSyncProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
   );
   FW_ASSERT(
@@ -2411,56 +2411,56 @@ void QueuedSyncProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str2
-  _status = msg.serialize(str2);
+  _status = msg.serializeFrom(str2);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2508,7 +2508,7 @@ void QueuedSyncProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
   );
   FW_ASSERT(
@@ -2517,7 +2517,7 @@ void QueuedSyncProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2762,7 +2762,7 @@ void QueuedSyncProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
   );
   FW_ASSERT(
@@ -2771,56 +2771,56 @@ void QueuedSyncProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2869,7 +2869,7 @@ void QueuedSyncProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
   );
   FW_ASSERT(
@@ -2878,56 +2878,56 @@ void QueuedSyncProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2976,7 +2976,7 @@ void QueuedSyncProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -2985,56 +2985,56 @@ void QueuedSyncProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3083,7 +3083,7 @@ void QueuedSyncProductsComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -3092,56 +3092,56 @@ void QueuedSyncProductsComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3744,7 +3744,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
   _msg.resetDeser();
 
   FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -3757,7 +3757,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
   }
 
   FwIndexType portNum = 0;
-  _deserStatus = _msg.deserialize(portNum);
+  _deserStatus = _msg.deserializeTo(portNum);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -3768,7 +3768,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
     case ALIASTYPEDASYNC_ALIASTYPED: {
       // Deserialize argument u32
       AliasPrim1 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3776,7 +3776,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
 
       // Deserialize argument f32
       AliasPrim2 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3784,7 +3784,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
 
       // Deserialize argument b
       AliasBool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3793,7 +3793,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
       // Deserialize argument str2
       char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
       Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserialize(str2);
+      _deserStatus = _msg.deserializeTo(str2);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3801,7 +3801,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
 
       // Deserialize argument e
       AliasEnum e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3809,7 +3809,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
 
       // Deserialize argument a
       AliasArray a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3817,7 +3817,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
 
       // Deserialize argument s
       AliasStruct s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3849,7 +3849,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
     case TYPEDASYNC_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3857,7 +3857,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3865,7 +3865,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3874,7 +3874,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3882,7 +3882,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3890,7 +3890,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3898,7 +3898,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3922,7 +3922,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
     case TYPEDASYNCASSERT_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3930,7 +3930,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3938,7 +3938,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3947,7 +3947,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3955,7 +3955,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3963,7 +3963,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3971,7 +3971,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3995,7 +3995,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
     case TYPEDASYNCBLOCKPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4003,7 +4003,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4011,7 +4011,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4020,7 +4020,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4028,7 +4028,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4036,7 +4036,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4044,7 +4044,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4068,7 +4068,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
     case TYPEDASYNCDROPPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4076,7 +4076,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4084,7 +4084,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4093,7 +4093,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4101,7 +4101,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4109,7 +4109,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4117,7 +4117,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSyncProductsComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.cpp
@@ -1988,7 +1988,7 @@ void QueuedTelemetryComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
   );
   FW_ASSERT(
@@ -1997,56 +1997,56 @@ void QueuedTelemetryComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str2
-  _status = msg.serialize(str2);
+  _status = msg.serializeFrom(str2);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2094,7 +2094,7 @@ void QueuedTelemetryComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
   );
   FW_ASSERT(
@@ -2103,7 +2103,7 @@ void QueuedTelemetryComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2348,7 +2348,7 @@ void QueuedTelemetryComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
   );
   FW_ASSERT(
@@ -2357,56 +2357,56 @@ void QueuedTelemetryComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2455,7 +2455,7 @@ void QueuedTelemetryComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
   );
   FW_ASSERT(
@@ -2464,56 +2464,56 @@ void QueuedTelemetryComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2562,7 +2562,7 @@ void QueuedTelemetryComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -2571,56 +2571,56 @@ void QueuedTelemetryComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2669,7 +2669,7 @@ void QueuedTelemetryComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -2678,56 +2678,56 @@ void QueuedTelemetryComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3209,7 +3209,7 @@ void QueuedTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -3242,7 +3242,7 @@ void QueuedTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -3275,7 +3275,7 @@ void QueuedTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = arg.serialize(_tlmBuff, FW_MIN(FW_TLM_STRING_MAX_SIZE, 80));
+    Fw::SerializeStatus _stat = arg.serializeTo(_tlmBuff, FW_MIN(FW_TLM_STRING_MAX_SIZE, 80));
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -3308,7 +3308,7 @@ void QueuedTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -3341,7 +3341,7 @@ void QueuedTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -3374,7 +3374,7 @@ void QueuedTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -3407,7 +3407,7 @@ void QueuedTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -3440,7 +3440,7 @@ void QueuedTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -3473,7 +3473,7 @@ void QueuedTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -3521,7 +3521,7 @@ void QueuedTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -3569,7 +3569,7 @@ void QueuedTelemetryComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -3652,7 +3652,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
   _msg.resetDeser();
 
   FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -3665,7 +3665,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
   }
 
   FwIndexType portNum = 0;
-  _deserStatus = _msg.deserialize(portNum);
+  _deserStatus = _msg.deserializeTo(portNum);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -3676,7 +3676,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
     case ALIASTYPEDASYNC_ALIASTYPED: {
       // Deserialize argument u32
       AliasPrim1 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3684,7 +3684,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
 
       // Deserialize argument f32
       AliasPrim2 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3692,7 +3692,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
 
       // Deserialize argument b
       AliasBool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3701,7 +3701,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
       // Deserialize argument str2
       char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
       Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserialize(str2);
+      _deserStatus = _msg.deserializeTo(str2);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3709,7 +3709,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
 
       // Deserialize argument e
       AliasEnum e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3717,7 +3717,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
 
       // Deserialize argument a
       AliasArray a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3725,7 +3725,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
 
       // Deserialize argument s
       AliasStruct s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3757,7 +3757,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
     case TYPEDASYNC_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3765,7 +3765,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3773,7 +3773,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3782,7 +3782,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3790,7 +3790,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3798,7 +3798,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3806,7 +3806,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3830,7 +3830,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
     case TYPEDASYNCASSERT_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3838,7 +3838,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3846,7 +3846,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3855,7 +3855,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3863,7 +3863,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3871,7 +3871,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3879,7 +3879,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3903,7 +3903,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
     case TYPEDASYNCBLOCKPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3911,7 +3911,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3919,7 +3919,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3928,7 +3928,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3936,7 +3936,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3944,7 +3944,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3952,7 +3952,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3976,7 +3976,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
     case TYPEDASYNCDROPPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3984,7 +3984,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -3992,7 +3992,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4001,7 +4001,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4009,7 +4009,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4017,7 +4017,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -4025,7 +4025,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
@@ -145,12 +145,12 @@ Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serialize(array[i]);
+      status = this->m_dataBuffer.serializeFrom(array[i]);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -170,9 +170,9 @@ Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::DataRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(elt);
+    status = this->m_dataBuffer.serializeFrom(elt);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -203,14 +203,14 @@ Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
       const Fw::StringBase *const sbPtr = array[i];
       FW_ASSERT(sbPtr != nullptr);
-      status = sbPtr->serialize(this->m_dataBuffer, stringSize);
+      status = sbPtr->serializeTo(this->m_dataBuffer, stringSize);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -231,9 +231,9 @@ Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::StringRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = elt.serialize(this->m_dataBuffer, stringSize);
+    status = elt.serializeTo(this->m_dataBuffer, stringSize);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -259,12 +259,12 @@ Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32ArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     for (FwSizeType i = 0; i < size; i++) {
-      status = this->m_dataBuffer.serialize(array[i]);
+      status = this->m_dataBuffer.serializeFrom(array[i]);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     }
     this->m_dataSize += sizeDelta;
@@ -284,9 +284,9 @@ Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U32Record;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(elt);
+    status = this->m_dataBuffer.serializeFrom(elt);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -312,11 +312,11 @@ Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if ((this->m_dataBuffer.getBuffLength() + sizeDelta) <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->m_baseId + RecordId::U8ArrayRecord;
-    status = this->m_dataBuffer.serialize(id);
+    status = this->m_dataBuffer.serializeFrom(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
-    status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
+    status = this->m_dataBuffer.serializeFrom(array, size, Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     this->m_dataSize += sizeDelta;
   }
@@ -2093,7 +2093,7 @@ void QueuedTestComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamU32);
+    _stat = _buff.deserializeTo(this->m_ParamU32);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamU32_valid = Fw::ParamValid::INVALID;
     }
@@ -2118,7 +2118,7 @@ void QueuedTestComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamF64);
+    _stat = _buff.deserializeTo(this->m_ParamF64);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamF64_valid = Fw::ParamValid::INVALID;
     }
@@ -2143,7 +2143,7 @@ void QueuedTestComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamString);
+    _stat = _buff.deserializeTo(this->m_ParamString);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamString_valid = Fw::ParamValid::DEFAULT;
       // Set default value
@@ -2172,7 +2172,7 @@ void QueuedTestComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamEnum);
+    _stat = _buff.deserializeTo(this->m_ParamEnum);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamEnum_valid = Fw::ParamValid::INVALID;
     }
@@ -2197,7 +2197,7 @@ void QueuedTestComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamArray);
+    _stat = _buff.deserializeTo(this->m_ParamArray);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamArray_valid = Fw::ParamValid::DEFAULT;
       // Set default value
@@ -2226,7 +2226,7 @@ void QueuedTestComponentBase ::
 
   // If there was a deserialization issue, mark it invalid
   if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
-    _stat = _buff.deserialize(this->m_ParamStruct);
+    _stat = _buff.deserializeTo(this->m_ParamStruct);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       this->m_param_ParamStruct_valid = Fw::ParamValid::INVALID;
     }
@@ -2926,7 +2926,7 @@ void QueuedTestComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(PRODUCTRECVIN_DPRESPONSE)
   );
   FW_ASSERT(
@@ -2935,28 +2935,28 @@ void QueuedTestComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument id
-  _status = msg.serialize(id);
+  _status = msg.serializeFrom(id);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument buffer
-  _status = msg.serialize(buffer);
+  _status = msg.serializeFrom(buffer);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument status
-  _status = msg.serialize(status);
+  _status = msg.serializeFrom(status);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3011,7 +3011,7 @@ void QueuedTestComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(ALIASTYPEDASYNC_ALIASTYPED)
   );
   FW_ASSERT(
@@ -3020,56 +3020,56 @@ void QueuedTestComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str2
-  _status = msg.serialize(str2);
+  _status = msg.serializeFrom(str2);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3117,7 +3117,7 @@ void QueuedTestComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(NOARGSASYNC_NOARGS)
   );
   FW_ASSERT(
@@ -3126,7 +3126,7 @@ void QueuedTestComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3371,7 +3371,7 @@ void QueuedTestComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNC_TYPED)
   );
   FW_ASSERT(
@@ -3380,56 +3380,56 @@ void QueuedTestComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3478,7 +3478,7 @@ void QueuedTestComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCASSERT_TYPED)
   );
   FW_ASSERT(
@@ -3487,56 +3487,56 @@ void QueuedTestComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3585,7 +3585,7 @@ void QueuedTestComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCBLOCKPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -3594,56 +3594,56 @@ void QueuedTestComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3692,7 +3692,7 @@ void QueuedTestComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize message ID
-  _status = msg.serialize(
+  _status = msg.serializeFrom(
     static_cast<FwEnumStoreType>(TYPEDASYNCDROPPRIORITY_TYPED)
   );
   FW_ASSERT(
@@ -3701,56 +3701,56 @@ void QueuedTestComponentBase ::
   );
 
   // Serialize port number
-  _status = msg.serialize(portNum);
+  _status = msg.serializeFrom(portNum);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument u32
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument f32
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument b
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument str1
-  _status = str1.serialize(msg, 80);
+  _status = str1.serializeTo(msg, 80);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument e
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument a
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Serialize argument s
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4291,20 +4291,20 @@ void QueuedTestComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize the message ID
-  _status = msg.serialize(static_cast<FwEnumStoreType>(INT_IF_INTERNALARRAY));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALARRAY));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Fake port number to make message dequeue work
-  _status = msg.serialize(static_cast<FwIndexType>(0));
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(a);
+  _status = msg.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4327,20 +4327,20 @@ void QueuedTestComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize the message ID
-  _status = msg.serialize(static_cast<FwEnumStoreType>(INT_IF_INTERNALENUM));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALENUM));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Fake port number to make message dequeue work
-  _status = msg.serialize(static_cast<FwIndexType>(0));
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(e);
+  _status = msg.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4367,32 +4367,32 @@ void QueuedTestComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize the message ID
-  _status = msg.serialize(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIMITIVE));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIMITIVE));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Fake port number to make message dequeue work
-  _status = msg.serialize(static_cast<FwIndexType>(0));
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(u32);
+  _status = msg.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(f32);
+  _status = msg.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(b);
+  _status = msg.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4415,14 +4415,14 @@ void QueuedTestComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize the message ID
-  _status = msg.serialize(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIORITYDROP));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALPRIORITYDROP));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Fake port number to make message dequeue work
-  _status = msg.serialize(static_cast<FwIndexType>(0));
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4453,26 +4453,26 @@ void QueuedTestComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize the message ID
-  _status = msg.serialize(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRING));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRING));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Fake port number to make message dequeue work
-  _status = msg.serialize(static_cast<FwIndexType>(0));
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(str1);
+  _status = msg.serializeFrom(str1);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(str2);
+  _status = msg.serializeFrom(str2);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4495,20 +4495,20 @@ void QueuedTestComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize the message ID
-  _status = msg.serialize(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRUCT));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(INT_IF_INTERNALSTRUCT));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
   // Fake port number to make message dequeue work
-  _status = msg.serialize(static_cast<FwIndexType>(0));
+  _status = msg.serializeFrom(static_cast<FwIndexType>(0));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(s);
+  _status = msg.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -4589,7 +4589,7 @@ void QueuedTestComponentBase ::
   args.resetDeser();
 
   U32 u32;
-  _status = args.deserialize(u32);
+  _status = args.deserializeTo(u32);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4602,7 +4602,7 @@ void QueuedTestComponentBase ::
   }
 
   F32 f32;
-  _status = args.deserialize(f32);
+  _status = args.deserializeTo(f32);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4615,7 +4615,7 @@ void QueuedTestComponentBase ::
   }
 
   bool b;
-  _status = args.deserialize(b);
+  _status = args.deserializeTo(b);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4664,7 +4664,7 @@ void QueuedTestComponentBase ::
   args.resetDeser();
 
   Fw::CmdStringArg str1;
-  _status = args.deserialize(str1);
+  _status = args.deserializeTo(str1);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4677,7 +4677,7 @@ void QueuedTestComponentBase ::
   }
 
   Fw::CmdStringArg str2;
-  _status = args.deserialize(str2);
+  _status = args.deserializeTo(str2);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4725,7 +4725,7 @@ void QueuedTestComponentBase ::
   args.resetDeser();
 
   E e;
-  _status = args.deserialize(e);
+  _status = args.deserializeTo(e);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4772,7 +4772,7 @@ void QueuedTestComponentBase ::
   args.resetDeser();
 
   A a;
-  _status = args.deserialize(a);
+  _status = args.deserializeTo(a);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4819,7 +4819,7 @@ void QueuedTestComponentBase ::
   args.resetDeser();
 
   S s;
-  _status = args.deserialize(s);
+  _status = args.deserializeTo(s);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4895,7 +4895,7 @@ void QueuedTestComponentBase ::
   args.resetDeser();
 
   U32 u32;
-  _status = args.deserialize(u32);
+  _status = args.deserializeTo(u32);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4908,7 +4908,7 @@ void QueuedTestComponentBase ::
   }
 
   F32 f32;
-  _status = args.deserialize(f32);
+  _status = args.deserializeTo(f32);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4921,7 +4921,7 @@ void QueuedTestComponentBase ::
   }
 
   bool b;
-  _status = args.deserialize(b);
+  _status = args.deserializeTo(b);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4974,7 +4974,7 @@ void QueuedTestComponentBase ::
   args.resetDeser();
 
   Fw::CmdStringArg str1;
-  _status = args.deserialize(str1);
+  _status = args.deserializeTo(str1);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -4987,7 +4987,7 @@ void QueuedTestComponentBase ::
   }
 
   Fw::CmdStringArg str2;
-  _status = args.deserialize(str2);
+  _status = args.deserializeTo(str2);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -5039,7 +5039,7 @@ void QueuedTestComponentBase ::
   args.resetDeser();
 
   E e;
-  _status = args.deserialize(e);
+  _status = args.deserializeTo(e);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -5090,7 +5090,7 @@ void QueuedTestComponentBase ::
   args.resetDeser();
 
   A a;
-  _status = args.deserialize(a);
+  _status = args.deserializeTo(a);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -5141,7 +5141,7 @@ void QueuedTestComponentBase ::
   args.resetDeser();
 
   S s;
-  _status = args.deserialize(s);
+  _status = args.deserializeTo(s);
   if (_status != Fw::FW_SERIALIZE_OK) {
     if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
       this->m_cmdResponseOut_OutputPort[0].invoke(
@@ -5194,7 +5194,7 @@ void QueuedTestComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize for IPC
-  _status = msg.serialize(static_cast<FwEnumStoreType>(CMD_CMD_ASYNC));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_ASYNC));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -5203,25 +5203,25 @@ void QueuedTestComponentBase ::
   // Fake port number to make message dequeue work
   FwIndexType port = 0;
 
-  _status = msg.serialize(port);
+  _status = msg.serializeFrom(port);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(opCode);
+  _status = msg.serializeFrom(opCode);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(cmdSeq);
+  _status = msg.serializeFrom(cmdSeq);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(args);
+  _status = msg.serializeFrom(args);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -5253,7 +5253,7 @@ void QueuedTestComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize for IPC
-  _status = msg.serialize(static_cast<FwEnumStoreType>(CMD_CMD_PRIORITY));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PRIORITY));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -5262,25 +5262,25 @@ void QueuedTestComponentBase ::
   // Fake port number to make message dequeue work
   FwIndexType port = 0;
 
-  _status = msg.serialize(port);
+  _status = msg.serializeFrom(port);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(opCode);
+  _status = msg.serializeFrom(opCode);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(cmdSeq);
+  _status = msg.serializeFrom(cmdSeq);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(args);
+  _status = msg.serializeFrom(args);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -5312,7 +5312,7 @@ void QueuedTestComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize for IPC
-  _status = msg.serialize(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -5321,25 +5321,25 @@ void QueuedTestComponentBase ::
   // Fake port number to make message dequeue work
   FwIndexType port = 0;
 
-  _status = msg.serialize(port);
+  _status = msg.serializeFrom(port);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(opCode);
+  _status = msg.serializeFrom(opCode);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(cmdSeq);
+  _status = msg.serializeFrom(cmdSeq);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(args);
+  _status = msg.serializeFrom(args);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -5371,7 +5371,7 @@ void QueuedTestComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize for IPC
-  _status = msg.serialize(static_cast<FwEnumStoreType>(CMD_CMD_DROP));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_DROP));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -5380,25 +5380,25 @@ void QueuedTestComponentBase ::
   // Fake port number to make message dequeue work
   FwIndexType port = 0;
 
-  _status = msg.serialize(port);
+  _status = msg.serializeFrom(port);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(opCode);
+  _status = msg.serializeFrom(opCode);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(cmdSeq);
+  _status = msg.serializeFrom(cmdSeq);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(args);
+  _status = msg.serializeFrom(args);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -5435,7 +5435,7 @@ void QueuedTestComponentBase ::
   Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
 
   // Serialize for IPC
-  _status = msg.serialize(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_DROP));
+  _status = msg.serializeFrom(static_cast<FwEnumStoreType>(CMD_CMD_PARAMS_PRIORITY_DROP));
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -5444,25 +5444,25 @@ void QueuedTestComponentBase ::
   // Fake port number to make message dequeue work
   FwIndexType port = 0;
 
-  _status = msg.serialize(port);
+  _status = msg.serializeFrom(port);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(opCode);
+  _status = msg.serializeFrom(opCode);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(cmdSeq);
+  _status = msg.serializeFrom(cmdSeq);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = msg.serialize(args);
+  _status = msg.serializeFrom(args);
   FW_ASSERT (
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -5570,7 +5570,7 @@ void QueuedTestComponentBase ::
 #if FW_AMPCS_COMPATIBLE
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(0));
+    _status = _logBuff.serializeFrom(static_cast<U8>(0));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -5647,7 +5647,7 @@ void QueuedTestComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(3));
+    _status = _logBuff.serializeFrom(static_cast<U8>(3));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -5656,7 +5656,7 @@ void QueuedTestComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(sizeof(U32))
     );
     FW_ASSERT(
@@ -5664,7 +5664,7 @@ void QueuedTestComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(u32);
+    _status = _logBuff.serializeFrom(u32);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -5672,7 +5672,7 @@ void QueuedTestComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(sizeof(F32))
     );
     FW_ASSERT(
@@ -5680,7 +5680,7 @@ void QueuedTestComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(f32);
+    _status = _logBuff.serializeFrom(f32);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -5688,7 +5688,7 @@ void QueuedTestComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(sizeof(U8))
     );
     FW_ASSERT(
@@ -5696,7 +5696,7 @@ void QueuedTestComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(b);
+    _status = _logBuff.serializeFrom(b);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -5766,20 +5766,20 @@ void QueuedTestComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(2));
+    _status = _logBuff.serializeFrom(static_cast<U8>(2));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 #endif
 
-    _status = str1.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 80));
+    _status = str1.serializeTo(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 80));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = str2.serialize(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 100));
+    _status = str2.serializeTo(_logBuff, FW_MIN(FW_LOG_STRING_MAX_SIZE, 100));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -5845,7 +5845,7 @@ void QueuedTestComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(1));
+    _status = _logBuff.serializeFrom(static_cast<U8>(1));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -5854,7 +5854,7 @@ void QueuedTestComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(E::SERIALIZED_SIZE)
     );
     FW_ASSERT(
@@ -5862,7 +5862,7 @@ void QueuedTestComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(e);
+    _status = _logBuff.serializeFrom(e);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -5938,20 +5938,20 @@ void QueuedTestComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(1 + 1));
+    _status = _logBuff.serializeFrom(static_cast<U8>(1 + 1));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
     // For FATAL, add stack size of 4 and a dummy entry. No support for stacks yet.
-    _status = _logBuff.serialize(static_cast<U8>(4));
+    _status = _logBuff.serializeFrom(static_cast<U8>(4));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = _logBuff.serialize(static_cast<U32>(0));
+    _status = _logBuff.serializeFrom(static_cast<U32>(0));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -5960,7 +5960,7 @@ void QueuedTestComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(A::SERIALIZED_SIZE)
     );
     FW_ASSERT(
@@ -5968,7 +5968,7 @@ void QueuedTestComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(a);
+    _status = _logBuff.serializeFrom(a);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -6036,7 +6036,7 @@ void QueuedTestComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(1));
+    _status = _logBuff.serializeFrom(static_cast<U8>(1));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -6045,7 +6045,7 @@ void QueuedTestComponentBase ::
 
 #if FW_AMPCS_COMPATIBLE
     // Serialize the argument size
-    _status = _logBuff.serialize(
+    _status = _logBuff.serializeFrom(
       static_cast<U8>(S::SERIALIZED_SIZE)
     );
     FW_ASSERT(
@@ -6053,7 +6053,7 @@ void QueuedTestComponentBase ::
       static_cast<FwAssertArgType>(_status)
     );
 #endif
-    _status = _logBuff.serialize(s);
+    _status = _logBuff.serializeFrom(s);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -6129,7 +6129,7 @@ void QueuedTestComponentBase ::
 #if FW_AMPCS_COMPATIBLE
     Fw::SerializeStatus _status = Fw::FW_SERIALIZE_OK;
     // Serialize the number of arguments
-    _status = _logBuff.serialize(static_cast<U8>(0));
+    _status = _logBuff.serializeFrom(static_cast<U8>(0));
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -6218,7 +6218,7 @@ void QueuedTestComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -6251,7 +6251,7 @@ void QueuedTestComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -6284,7 +6284,7 @@ void QueuedTestComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = arg.serialize(_tlmBuff, FW_MIN(FW_TLM_STRING_MAX_SIZE, 80));
+    Fw::SerializeStatus _stat = arg.serializeTo(_tlmBuff, FW_MIN(FW_TLM_STRING_MAX_SIZE, 80));
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -6317,7 +6317,7 @@ void QueuedTestComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -6350,7 +6350,7 @@ void QueuedTestComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -6383,7 +6383,7 @@ void QueuedTestComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -6416,7 +6416,7 @@ void QueuedTestComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -6449,7 +6449,7 @@ void QueuedTestComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -6482,7 +6482,7 @@ void QueuedTestComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -6530,7 +6530,7 @@ void QueuedTestComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -6578,7 +6578,7 @@ void QueuedTestComponentBase ::
     }
 
     Fw::TlmBuffer _tlmBuff;
-    Fw::SerializeStatus _stat = _tlmBuff.serialize(arg);
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
     FW_ASSERT(
       _stat == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_stat)
@@ -6696,7 +6696,7 @@ I32 QueuedTestComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -6719,7 +6719,7 @@ F64 QueuedTestComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -6742,7 +6742,7 @@ Fw::ParamString QueuedTestComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -6765,7 +6765,7 @@ E QueuedTestComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -6788,7 +6788,7 @@ A QueuedTestComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -6811,7 +6811,7 @@ S QueuedTestComponentBase ::
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
-    _stat = _getBuff.deserialize(_local);
+    _stat = _getBuff.deserializeTo(_local);
     FW_ASSERT(_stat == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_stat));
     valid = Fw::ParamValid::VALID;
   } else {
@@ -6928,7 +6928,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
   _msg.resetDeser();
 
   FwEnumStoreType _desMsg = 0;
-  Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+  Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -6941,7 +6941,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
   }
 
   FwIndexType portNum = 0;
-  _deserStatus = _msg.deserialize(portNum);
+  _deserStatus = _msg.deserializeTo(portNum);
   FW_ASSERT(
     _deserStatus == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_deserStatus)
@@ -6952,7 +6952,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
     case PRODUCTRECVIN_DPRESPONSE: {
       // Deserialize argument id
       FwDpIdType id;
-      _deserStatus = _msg.deserialize(id);
+      _deserStatus = _msg.deserializeTo(id);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -6960,7 +6960,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize argument buffer
       Fw::Buffer buffer;
-      _deserStatus = _msg.deserialize(buffer);
+      _deserStatus = _msg.deserializeTo(buffer);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -6968,7 +6968,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize argument status
       Fw::Success status;
-      _deserStatus = _msg.deserialize(status);
+      _deserStatus = _msg.deserializeTo(status);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -6988,7 +6988,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
     case ALIASTYPEDASYNC_ALIASTYPED: {
       // Deserialize argument u32
       AliasPrim1 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -6996,7 +6996,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize argument f32
       AliasPrim2 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7004,7 +7004,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize argument b
       AliasBool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7013,7 +7013,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
       // Deserialize argument str2
       char __fprime_ac_str2_buffer[Fw::StringBase::BUFFER_SIZE(32)];
       Fw::ExternalString str2(__fprime_ac_str2_buffer, sizeof __fprime_ac_str2_buffer);
-      _deserStatus = _msg.deserialize(str2);
+      _deserStatus = _msg.deserializeTo(str2);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7021,7 +7021,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize argument e
       AliasEnum e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7029,7 +7029,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize argument a
       AliasArray a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7037,7 +7037,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize argument s
       AliasStruct s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7069,7 +7069,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
     case TYPEDASYNC_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7077,7 +7077,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7085,7 +7085,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7094,7 +7094,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7102,7 +7102,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7110,7 +7110,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7118,7 +7118,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7142,7 +7142,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
     case TYPEDASYNCASSERT_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7150,7 +7150,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7158,7 +7158,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7167,7 +7167,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7175,7 +7175,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7183,7 +7183,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7191,7 +7191,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7215,7 +7215,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
     case TYPEDASYNCBLOCKPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7223,7 +7223,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7231,7 +7231,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7240,7 +7240,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7248,7 +7248,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7256,7 +7256,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7264,7 +7264,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7288,7 +7288,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
     case TYPEDASYNCDROPPRIORITY_TYPED: {
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7296,7 +7296,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize argument f32
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7304,7 +7304,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize argument b
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7313,7 +7313,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
       // Deserialize argument str1
       char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
       Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7321,7 +7321,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize argument e
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7329,7 +7329,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize argument a
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7337,7 +7337,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize argument s
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
       FW_ASSERT(
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7361,7 +7361,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
     case CMD_CMD_ASYNC: {
       // Deserialize opcode
       FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserialize(_opCode);
+      _deserStatus = _msg.deserializeTo(_opCode);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7369,7 +7369,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize command sequence
       U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserialize(_cmdSeq);
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7377,7 +7377,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize command argument buffer
       Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserialize(args);
+      _deserStatus = _msg.deserializeTo(args);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7408,7 +7408,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
     case CMD_CMD_PRIORITY: {
       // Deserialize opcode
       FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserialize(_opCode);
+      _deserStatus = _msg.deserializeTo(_opCode);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7416,7 +7416,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize command sequence
       U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserialize(_cmdSeq);
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7424,7 +7424,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize command argument buffer
       Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserialize(args);
+      _deserStatus = _msg.deserializeTo(args);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7455,7 +7455,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
     case CMD_CMD_PARAMS_PRIORITY: {
       // Deserialize opcode
       FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserialize(_opCode);
+      _deserStatus = _msg.deserializeTo(_opCode);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7463,7 +7463,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize command sequence
       U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserialize(_cmdSeq);
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7471,7 +7471,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize command argument buffer
       Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserialize(args);
+      _deserStatus = _msg.deserializeTo(args);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7482,7 +7482,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = args.deserialize(u32);
+      _deserStatus = args.deserializeTo(u32);
       if (_deserStatus != Fw::FW_SERIALIZE_OK) {
         if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
           this->cmdResponse_out(
@@ -7520,7 +7520,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
     case CMD_CMD_DROP: {
       // Deserialize opcode
       FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserialize(_opCode);
+      _deserStatus = _msg.deserializeTo(_opCode);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7528,7 +7528,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize command sequence
       U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserialize(_cmdSeq);
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7536,7 +7536,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize command argument buffer
       Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserialize(args);
+      _deserStatus = _msg.deserializeTo(args);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7567,7 +7567,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
     case CMD_CMD_PARAMS_PRIORITY_DROP: {
       // Deserialize opcode
       FwOpcodeType _opCode = 0;
-      _deserStatus = _msg.deserialize(_opCode);
+      _deserStatus = _msg.deserializeTo(_opCode);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7575,7 +7575,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize command sequence
       U32 _cmdSeq = 0;
-      _deserStatus = _msg.deserialize(_cmdSeq);
+      _deserStatus = _msg.deserializeTo(_cmdSeq);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7583,7 +7583,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize command argument buffer
       Fw::CmdArgBuffer args;
-      _deserStatus = _msg.deserialize(args);
+      _deserStatus = _msg.deserializeTo(args);
       FW_ASSERT (
         _deserStatus == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_deserStatus)
@@ -7594,7 +7594,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
 
       // Deserialize argument u32
       U32 u32;
-      _deserStatus = args.deserialize(u32);
+      _deserStatus = args.deserializeTo(u32);
       if (_deserStatus != Fw::FW_SERIALIZE_OK) {
         if (this->m_cmdResponseOut_OutputPort[0].isConnected()) {
           this->cmdResponse_out(
@@ -7631,7 +7631,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
     // Handle internal interface internalArray
     case INT_IF_INTERNALARRAY: {
       A a;
-      _deserStatus = _msg.deserialize(a);
+      _deserStatus = _msg.deserializeTo(a);
 
       // Internal interface should always deserialize
       FW_ASSERT(
@@ -7657,7 +7657,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
     // Handle internal interface internalEnum
     case INT_IF_INTERNALENUM: {
       E e;
-      _deserStatus = _msg.deserialize(e);
+      _deserStatus = _msg.deserializeTo(e);
 
       // Internal interface should always deserialize
       FW_ASSERT(
@@ -7683,7 +7683,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
     // Handle internal interface internalPrimitive
     case INT_IF_INTERNALPRIMITIVE: {
       U32 u32;
-      _deserStatus = _msg.deserialize(u32);
+      _deserStatus = _msg.deserializeTo(u32);
 
       // Internal interface should always deserialize
       FW_ASSERT(
@@ -7692,7 +7692,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
       );
 
       F32 f32;
-      _deserStatus = _msg.deserialize(f32);
+      _deserStatus = _msg.deserializeTo(f32);
 
       // Internal interface should always deserialize
       FW_ASSERT(
@@ -7701,7 +7701,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
       );
 
       bool b;
-      _deserStatus = _msg.deserialize(b);
+      _deserStatus = _msg.deserializeTo(b);
 
       // Internal interface should always deserialize
       FW_ASSERT(
@@ -7744,7 +7744,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
     // Handle internal interface internalString
     case INT_IF_INTERNALSTRING: {
       Fw::InternalInterfaceString str1;
-      _deserStatus = _msg.deserialize(str1);
+      _deserStatus = _msg.deserializeTo(str1);
 
       // Internal interface should always deserialize
       FW_ASSERT(
@@ -7753,7 +7753,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
       );
 
       Fw::InternalInterfaceString str2;
-      _deserStatus = _msg.deserialize(str2);
+      _deserStatus = _msg.deserializeTo(str2);
 
       // Internal interface should always deserialize
       FW_ASSERT(
@@ -7780,7 +7780,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
     // Handle internal interface internalStruct
     case INT_IF_INTERNALSTRUCT: {
       S s;
-      _deserStatus = _msg.deserialize(s);
+      _deserStatus = _msg.deserializeTo(s);
 
       // Internal interface should always deserialize
       FW_ASSERT(
@@ -8677,7 +8677,7 @@ Fw::CmdResponse QueuedTestComponentBase ::
   paramSet_ParamU32(Fw::SerializeBufferBase& val)
 {
   U32 _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -8697,7 +8697,7 @@ Fw::CmdResponse QueuedTestComponentBase ::
   paramSet_ParamF64(Fw::SerializeBufferBase& val)
 {
   F64 _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -8717,7 +8717,7 @@ Fw::CmdResponse QueuedTestComponentBase ::
   paramSet_ParamString(Fw::SerializeBufferBase& val)
 {
   Fw::ParamString _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -8737,7 +8737,7 @@ Fw::CmdResponse QueuedTestComponentBase ::
   paramSet_ParamEnum(Fw::SerializeBufferBase& val)
 {
   E _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -8757,7 +8757,7 @@ Fw::CmdResponse QueuedTestComponentBase ::
   paramSet_ParamArray(Fw::SerializeBufferBase& val)
 {
   A _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -8777,7 +8777,7 @@ Fw::CmdResponse QueuedTestComponentBase ::
   paramSet_ParamStruct(Fw::SerializeBufferBase& val)
 {
   S _localVal{};
-  const Fw::SerializeStatus _stat = val.deserialize(_localVal);
+  const Fw::SerializeStatus _stat = val.deserializeTo(_localVal);
   if (_stat != Fw::FW_SERIALIZE_OK) {
     return Fw::CmdResponse::VALIDATION_ERROR;
   }
@@ -8944,7 +8944,7 @@ Fw::CmdResponse QueuedTestComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamU32);
+    _stat = _saveBuff.serializeFrom(m_ParamU32);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -8974,7 +8974,7 @@ Fw::CmdResponse QueuedTestComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamF64);
+    _stat = _saveBuff.serializeFrom(m_ParamF64);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -9004,7 +9004,7 @@ Fw::CmdResponse QueuedTestComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamString);
+    _stat = _saveBuff.serializeFrom(m_ParamString);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -9034,7 +9034,7 @@ Fw::CmdResponse QueuedTestComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamEnum);
+    _stat = _saveBuff.serializeFrom(m_ParamEnum);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -9064,7 +9064,7 @@ Fw::CmdResponse QueuedTestComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamArray);
+    _stat = _saveBuff.serializeFrom(m_ParamArray);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -9094,7 +9094,7 @@ Fw::CmdResponse QueuedTestComponentBase ::
   if (this->m_prmSetOut_OutputPort[0].isConnected()) {
     this->m_paramLock.lock();
 
-    _stat = _saveBuff.serialize(m_ParamStruct);
+    _stat = _saveBuff.serializeFrom(m_ParamStruct);
 
     this->m_paramLock.unLock();
     if (_stat != Fw::FW_SERIALIZE_OK) {

--- a/compiler/tools/fpp-to-cpp/test/component/base/SSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SSerializableAc.ref.cpp
@@ -88,15 +88,15 @@ std::ostream& operator<<(std::ostream& os, const S& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus S ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status;
 
-  status = buffer.serialize(this->m_x);
+  status = buffer.serializeFrom(this->m_x);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_y);
+  status = buffer.serializeFrom(this->m_y);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
@@ -105,15 +105,15 @@ Fw::SerializeStatus S ::
 }
 
 Fw::SerializeStatus S ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status;
 
-  status = buffer.deserialize(this->m_x);
+  status = buffer.deserializeTo(this->m_x);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_y);
+  status = buffer.deserializeTo(this->m_y);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }

--- a/compiler/tools/fpp-to-cpp/test/component/base/SSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SSerializableAc.ref.hpp
@@ -88,12 +88,12 @@ class S :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/SmChoiceActiveComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SmChoiceActiveComponentAc.ref.cpp
@@ -571,7 +571,7 @@ namespace FppTest {
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smChoiceBasicU32, static_cast<FwEnumStoreType>(FppTest_SmChoice_BasicU32::Signal::s), buffer);
     // Serialize the signal data
-    const Fw::SerializeStatus status = buffer.serialize(value);
+    const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smChoiceBasicU32_sendSignalFinish(buffer);
@@ -604,7 +604,7 @@ namespace FppTest {
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smChoiceInputPairU16U32, static_cast<FwEnumStoreType>(FppTest_SmChoice_InputPairU16U32::Signal::s1), buffer);
     // Serialize the signal data
-    const Fw::SerializeStatus status = buffer.serialize(value);
+    const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smChoiceInputPairU16U32_sendSignalFinish(buffer);
@@ -617,7 +617,7 @@ namespace FppTest {
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smChoiceInputPairU16U32, static_cast<FwEnumStoreType>(FppTest_SmChoice_InputPairU16U32::Signal::s2), buffer);
     // Serialize the signal data
-    const Fw::SerializeStatus status = buffer.serialize(value);
+    const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smChoiceInputPairU16U32_sendSignalFinish(buffer);
@@ -640,7 +640,7 @@ namespace FppTest {
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smChoiceSequenceU32, static_cast<FwEnumStoreType>(FppTest_SmChoice_SequenceU32::Signal::s), buffer);
     // Serialize the signal data
-    const Fw::SerializeStatus status = buffer.serialize(value);
+    const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smChoiceSequenceU32_sendSignalFinish(buffer);
@@ -670,7 +670,7 @@ namespace FppTest {
     _msg.resetDeser();
 
     FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
     FW_ASSERT(
       _deserStatus == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_deserStatus)
@@ -683,7 +683,7 @@ namespace FppTest {
     }
 
     FwIndexType portNum = 0;
-    _deserStatus = _msg.deserialize(portNum);
+    _deserStatus = _msg.deserializeTo(portNum);
     FW_ASSERT(
       _deserStatus == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_deserStatus)
@@ -717,19 +717,19 @@ namespace FppTest {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message type
-    status = buffer.serialize(static_cast<FwEnumStoreType>(INTERNAL_STATE_MACHINE_SIGNAL));
+    status = buffer.serializeFrom(static_cast<FwEnumStoreType>(INTERNAL_STATE_MACHINE_SIGNAL));
     FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the port number
-    status = buffer.serialize(static_cast<FwIndexType>(0));
+    status = buffer.serializeFrom(static_cast<FwIndexType>(0));
     FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the state machine ID
-    status = buffer.serialize(static_cast<FwEnumStoreType>(smId));
+    status = buffer.serializeFrom(static_cast<FwEnumStoreType>(smId));
     FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the signal
-    status = buffer.serialize(static_cast<FwEnumStoreType>(signal));
+    status = buffer.serializeFrom(static_cast<FwEnumStoreType>(signal));
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
   }
 
@@ -931,11 +931,11 @@ namespace FppTest {
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Deserialize the state machine ID
-    status = buffer.deserialize(smId);
+    status = buffer.deserializeTo(smId);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Deserialize the signal
-    status = buffer.deserialize(signal);
+    status = buffer.deserializeTo(signal);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
   }
 
@@ -971,7 +971,7 @@ namespace FppTest {
       case FppTest_SmChoice_BasicU32::Signal::s: {
         // Deserialize the data
         U32 value;
-        const Fw::SerializeStatus status = buffer.deserialize(value);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         // Assert no data left in buffer
         FW_ASSERT(buffer.getBuffLeft() == 0, static_cast<FwAssertArgType>(buffer.getBuffLeft()));
@@ -1038,7 +1038,7 @@ namespace FppTest {
       case FppTest_SmChoice_InputPairU16U32::Signal::s1: {
         // Deserialize the data
         U16 value;
-        const Fw::SerializeStatus status = buffer.deserialize(value);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         // Assert no data left in buffer
         FW_ASSERT(buffer.getBuffLeft() == 0, static_cast<FwAssertArgType>(buffer.getBuffLeft()));
@@ -1049,7 +1049,7 @@ namespace FppTest {
       case FppTest_SmChoice_InputPairU16U32::Signal::s2: {
         // Deserialize the data
         U32 value;
-        const Fw::SerializeStatus status = buffer.deserialize(value);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         // Assert no data left in buffer
         FW_ASSERT(buffer.getBuffLeft() == 0, static_cast<FwAssertArgType>(buffer.getBuffLeft()));
@@ -1095,7 +1095,7 @@ namespace FppTest {
       case FppTest_SmChoice_SequenceU32::Signal::s: {
         // Deserialize the data
         U32 value;
-        const Fw::SerializeStatus status = buffer.deserialize(value);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         // Assert no data left in buffer
         FW_ASSERT(buffer.getBuffLeft() == 0, static_cast<FwAssertArgType>(buffer.getBuffLeft()));

--- a/compiler/tools/fpp-to-cpp/test/component/base/SmChoiceQueuedComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SmChoiceQueuedComponentAc.ref.cpp
@@ -645,7 +645,7 @@ namespace FppTest {
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smChoiceBasicU32, static_cast<FwEnumStoreType>(FppTest_SmChoice_BasicU32::Signal::s), buffer);
     // Serialize the signal data
-    const Fw::SerializeStatus status = buffer.serialize(value);
+    const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smChoiceBasicU32_sendSignalFinish(buffer);
@@ -678,7 +678,7 @@ namespace FppTest {
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smChoiceInputPairU16U32, static_cast<FwEnumStoreType>(FppTest_SmChoice_InputPairU16U32::Signal::s1), buffer);
     // Serialize the signal data
-    const Fw::SerializeStatus status = buffer.serialize(value);
+    const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smChoiceInputPairU16U32_sendSignalFinish(buffer);
@@ -691,7 +691,7 @@ namespace FppTest {
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smChoiceInputPairU16U32, static_cast<FwEnumStoreType>(FppTest_SmChoice_InputPairU16U32::Signal::s2), buffer);
     // Serialize the signal data
-    const Fw::SerializeStatus status = buffer.serialize(value);
+    const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smChoiceInputPairU16U32_sendSignalFinish(buffer);
@@ -714,7 +714,7 @@ namespace FppTest {
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smChoiceSequenceU32, static_cast<FwEnumStoreType>(FppTest_SmChoice_SequenceU32::Signal::s), buffer);
     // Serialize the signal data
-    const Fw::SerializeStatus status = buffer.serialize(value);
+    const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smChoiceSequenceU32_sendSignalFinish(buffer);
@@ -749,7 +749,7 @@ namespace FppTest {
     _msg.resetDeser();
 
     FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
     FW_ASSERT(
       _deserStatus == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_deserStatus)
@@ -762,7 +762,7 @@ namespace FppTest {
     }
 
     FwIndexType portNum = 0;
-    _deserStatus = _msg.deserialize(portNum);
+    _deserStatus = _msg.deserializeTo(portNum);
     FW_ASSERT(
       _deserStatus == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_deserStatus)
@@ -834,19 +834,19 @@ namespace FppTest {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message type
-    status = buffer.serialize(static_cast<FwEnumStoreType>(INTERNAL_STATE_MACHINE_SIGNAL));
+    status = buffer.serializeFrom(static_cast<FwEnumStoreType>(INTERNAL_STATE_MACHINE_SIGNAL));
     FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the port number
-    status = buffer.serialize(static_cast<FwIndexType>(0));
+    status = buffer.serializeFrom(static_cast<FwIndexType>(0));
     FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the state machine ID
-    status = buffer.serialize(static_cast<FwEnumStoreType>(smId));
+    status = buffer.serializeFrom(static_cast<FwEnumStoreType>(smId));
     FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the signal
-    status = buffer.serialize(static_cast<FwEnumStoreType>(signal));
+    status = buffer.serializeFrom(static_cast<FwEnumStoreType>(signal));
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
   }
 
@@ -1048,11 +1048,11 @@ namespace FppTest {
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Deserialize the state machine ID
-    status = buffer.deserialize(smId);
+    status = buffer.deserializeTo(smId);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Deserialize the signal
-    status = buffer.deserialize(signal);
+    status = buffer.deserializeTo(signal);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
   }
 
@@ -1088,7 +1088,7 @@ namespace FppTest {
       case FppTest_SmChoice_BasicU32::Signal::s: {
         // Deserialize the data
         U32 value;
-        const Fw::SerializeStatus status = buffer.deserialize(value);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         // Assert no data left in buffer
         FW_ASSERT(buffer.getBuffLeft() == 0, static_cast<FwAssertArgType>(buffer.getBuffLeft()));
@@ -1155,7 +1155,7 @@ namespace FppTest {
       case FppTest_SmChoice_InputPairU16U32::Signal::s1: {
         // Deserialize the data
         U16 value;
-        const Fw::SerializeStatus status = buffer.deserialize(value);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         // Assert no data left in buffer
         FW_ASSERT(buffer.getBuffLeft() == 0, static_cast<FwAssertArgType>(buffer.getBuffLeft()));
@@ -1166,7 +1166,7 @@ namespace FppTest {
       case FppTest_SmChoice_InputPairU16U32::Signal::s2: {
         // Deserialize the data
         U32 value;
-        const Fw::SerializeStatus status = buffer.deserialize(value);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         // Assert no data left in buffer
         FW_ASSERT(buffer.getBuffLeft() == 0, static_cast<FwAssertArgType>(buffer.getBuffLeft()));
@@ -1212,7 +1212,7 @@ namespace FppTest {
       case FppTest_SmChoice_SequenceU32::Signal::s: {
         // Deserialize the data
         U32 value;
-        const Fw::SerializeStatus status = buffer.deserialize(value);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         // Assert no data left in buffer
         FW_ASSERT(buffer.getBuffLeft() == 0, static_cast<FwAssertArgType>(buffer.getBuffLeft()));

--- a/compiler/tools/fpp-to-cpp/test/component/base/SmInitialActiveComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SmInitialActiveComponentAc.ref.cpp
@@ -375,7 +375,7 @@ namespace FppTest {
     _msg.resetDeser();
 
     FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
     FW_ASSERT(
       _deserStatus == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_deserStatus)
@@ -388,7 +388,7 @@ namespace FppTest {
     }
 
     FwIndexType portNum = 0;
-    _deserStatus = _msg.deserialize(portNum);
+    _deserStatus = _msg.deserializeTo(portNum);
     FW_ASSERT(
       _deserStatus == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_deserStatus)
@@ -482,11 +482,11 @@ namespace FppTest {
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Deserialize the state machine ID
-    status = buffer.deserialize(smId);
+    status = buffer.deserializeTo(smId);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Deserialize the signal
-    status = buffer.deserialize(signal);
+    status = buffer.deserializeTo(signal);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
   }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/SmInitialQueuedComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SmInitialQueuedComponentAc.ref.cpp
@@ -454,7 +454,7 @@ namespace FppTest {
     _msg.resetDeser();
 
     FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
     FW_ASSERT(
       _deserStatus == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_deserStatus)
@@ -467,7 +467,7 @@ namespace FppTest {
     }
 
     FwIndexType portNum = 0;
-    _deserStatus = _msg.deserialize(portNum);
+    _deserStatus = _msg.deserializeTo(portNum);
     FW_ASSERT(
       _deserStatus == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_deserStatus)
@@ -599,11 +599,11 @@ namespace FppTest {
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Deserialize the state machine ID
-    status = buffer.deserialize(smId);
+    status = buffer.deserializeTo(smId);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Deserialize the signal
-    status = buffer.deserialize(signal);
+    status = buffer.deserializeTo(signal);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
   }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/SmStateActiveComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SmStateActiveComponentAc.ref.cpp
@@ -1247,7 +1247,7 @@ namespace FppTest {
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smStateBasicGuardString, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardString::Signal::s), buffer);
     // Serialize the signal data
-    const Fw::SerializeStatus status = value.serialize(buffer, 80);
+    const Fw::SerializeStatus status = value.serializeTo(buffer, 80);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardString_sendSignalFinish(buffer);
@@ -1260,7 +1260,7 @@ namespace FppTest {
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smStateBasicGuardTestAbsType, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestAbsType::Signal::s), buffer);
     // Serialize the signal data
-    const Fw::SerializeStatus status = buffer.serialize(value);
+    const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardTestAbsType_sendSignalFinish(buffer);
@@ -1273,7 +1273,7 @@ namespace FppTest {
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smStateBasicGuardTestArray, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestArray::Signal::s), buffer);
     // Serialize the signal data
-    const Fw::SerializeStatus status = buffer.serialize(value);
+    const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardTestArray_sendSignalFinish(buffer);
@@ -1286,7 +1286,7 @@ namespace FppTest {
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smStateBasicGuardTestEnum, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestEnum::Signal::s), buffer);
     // Serialize the signal data
-    const Fw::SerializeStatus status = buffer.serialize(value);
+    const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardTestEnum_sendSignalFinish(buffer);
@@ -1299,7 +1299,7 @@ namespace FppTest {
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smStateBasicGuardTestStruct, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestStruct::Signal::s), buffer);
     // Serialize the signal data
-    const Fw::SerializeStatus status = buffer.serialize(value);
+    const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardTestStruct_sendSignalFinish(buffer);
@@ -1312,7 +1312,7 @@ namespace FppTest {
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smStateBasicGuardU32, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardU32::Signal::s), buffer);
     // Serialize the signal data
-    const Fw::SerializeStatus status = buffer.serialize(value);
+    const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardU32_sendSignalFinish(buffer);
@@ -1345,7 +1345,7 @@ namespace FppTest {
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smStateBasicString, static_cast<FwEnumStoreType>(FppTest_SmState_BasicString::Signal::s), buffer);
     // Serialize the signal data
-    const Fw::SerializeStatus status = value.serialize(buffer, 80);
+    const Fw::SerializeStatus status = value.serializeTo(buffer, 80);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicString_sendSignalFinish(buffer);
@@ -1358,7 +1358,7 @@ namespace FppTest {
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smStateBasicTestAbsType, static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestAbsType::Signal::s), buffer);
     // Serialize the signal data
-    const Fw::SerializeStatus status = buffer.serialize(value);
+    const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicTestAbsType_sendSignalFinish(buffer);
@@ -1371,7 +1371,7 @@ namespace FppTest {
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smStateBasicTestArray, static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestArray::Signal::s), buffer);
     // Serialize the signal data
-    const Fw::SerializeStatus status = buffer.serialize(value);
+    const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicTestArray_sendSignalFinish(buffer);
@@ -1384,7 +1384,7 @@ namespace FppTest {
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smStateBasicTestEnum, static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestEnum::Signal::s), buffer);
     // Serialize the signal data
-    const Fw::SerializeStatus status = buffer.serialize(value);
+    const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicTestEnum_sendSignalFinish(buffer);
@@ -1397,7 +1397,7 @@ namespace FppTest {
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smStateBasicTestStruct, static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestStruct::Signal::s), buffer);
     // Serialize the signal data
-    const Fw::SerializeStatus status = buffer.serialize(value);
+    const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicTestStruct_sendSignalFinish(buffer);
@@ -1410,7 +1410,7 @@ namespace FppTest {
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smStateBasicU32, static_cast<FwEnumStoreType>(FppTest_SmState_BasicU32::Signal::s), buffer);
     // Serialize the signal data
-    const Fw::SerializeStatus status = buffer.serialize(value);
+    const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicU32_sendSignalFinish(buffer);
@@ -1580,7 +1580,7 @@ namespace FppTest {
     _msg.resetDeser();
 
     FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
     FW_ASSERT(
       _deserStatus == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_deserStatus)
@@ -1593,7 +1593,7 @@ namespace FppTest {
     }
 
     FwIndexType portNum = 0;
-    _deserStatus = _msg.deserialize(portNum);
+    _deserStatus = _msg.deserializeTo(portNum);
     FW_ASSERT(
       _deserStatus == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_deserStatus)
@@ -1627,19 +1627,19 @@ namespace FppTest {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message type
-    status = buffer.serialize(static_cast<FwEnumStoreType>(INTERNAL_STATE_MACHINE_SIGNAL));
+    status = buffer.serializeFrom(static_cast<FwEnumStoreType>(INTERNAL_STATE_MACHINE_SIGNAL));
     FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the port number
-    status = buffer.serialize(static_cast<FwIndexType>(0));
+    status = buffer.serializeFrom(static_cast<FwIndexType>(0));
     FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the state machine ID
-    status = buffer.serialize(static_cast<FwEnumStoreType>(smId));
+    status = buffer.serializeFrom(static_cast<FwEnumStoreType>(smId));
     FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the signal
-    status = buffer.serialize(static_cast<FwEnumStoreType>(signal));
+    status = buffer.serializeFrom(static_cast<FwEnumStoreType>(signal));
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
   }
 
@@ -2152,11 +2152,11 @@ namespace FppTest {
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Deserialize the state machine ID
-    status = buffer.deserialize(smId);
+    status = buffer.deserializeTo(smId);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Deserialize the signal
-    status = buffer.deserialize(signal);
+    status = buffer.deserializeTo(signal);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
   }
 
@@ -2214,7 +2214,7 @@ namespace FppTest {
         // Deserialize the data
         char __fprime_ac_value_buffer[Fw::StringBase::BUFFER_SIZE(80)];
         Fw::ExternalString value(__fprime_ac_value_buffer, sizeof __fprime_ac_value_buffer);
-        const Fw::SerializeStatus status = buffer.deserialize(value);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         // Assert no data left in buffer
         FW_ASSERT(buffer.getBuffLeft() == 0, static_cast<FwAssertArgType>(buffer.getBuffLeft()));
@@ -2239,7 +2239,7 @@ namespace FppTest {
       case FppTest_SmState_BasicGuardTestAbsType::Signal::s: {
         // Deserialize the data
         FppTest::SmHarness::TestAbsType value;
-        const Fw::SerializeStatus status = buffer.deserialize(value);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         // Assert no data left in buffer
         FW_ASSERT(buffer.getBuffLeft() == 0, static_cast<FwAssertArgType>(buffer.getBuffLeft()));
@@ -2264,7 +2264,7 @@ namespace FppTest {
       case FppTest_SmState_BasicGuardTestArray::Signal::s: {
         // Deserialize the data
         FppTest::SmHarness::TestArray value;
-        const Fw::SerializeStatus status = buffer.deserialize(value);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         // Assert no data left in buffer
         FW_ASSERT(buffer.getBuffLeft() == 0, static_cast<FwAssertArgType>(buffer.getBuffLeft()));
@@ -2289,7 +2289,7 @@ namespace FppTest {
       case FppTest_SmState_BasicGuardTestEnum::Signal::s: {
         // Deserialize the data
         FppTest::SmHarness::TestEnum value;
-        const Fw::SerializeStatus status = buffer.deserialize(value);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         // Assert no data left in buffer
         FW_ASSERT(buffer.getBuffLeft() == 0, static_cast<FwAssertArgType>(buffer.getBuffLeft()));
@@ -2314,7 +2314,7 @@ namespace FppTest {
       case FppTest_SmState_BasicGuardTestStruct::Signal::s: {
         // Deserialize the data
         FppTest::SmHarness::TestStruct value;
-        const Fw::SerializeStatus status = buffer.deserialize(value);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         // Assert no data left in buffer
         FW_ASSERT(buffer.getBuffLeft() == 0, static_cast<FwAssertArgType>(buffer.getBuffLeft()));
@@ -2339,7 +2339,7 @@ namespace FppTest {
       case FppTest_SmState_BasicGuardU32::Signal::s: {
         // Deserialize the data
         U32 value;
-        const Fw::SerializeStatus status = buffer.deserialize(value);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         // Assert no data left in buffer
         FW_ASSERT(buffer.getBuffLeft() == 0, static_cast<FwAssertArgType>(buffer.getBuffLeft()));
@@ -2407,7 +2407,7 @@ namespace FppTest {
         // Deserialize the data
         char __fprime_ac_value_buffer[Fw::StringBase::BUFFER_SIZE(80)];
         Fw::ExternalString value(__fprime_ac_value_buffer, sizeof __fprime_ac_value_buffer);
-        const Fw::SerializeStatus status = buffer.deserialize(value);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         // Assert no data left in buffer
         FW_ASSERT(buffer.getBuffLeft() == 0, static_cast<FwAssertArgType>(buffer.getBuffLeft()));
@@ -2432,7 +2432,7 @@ namespace FppTest {
       case FppTest_SmState_BasicTestAbsType::Signal::s: {
         // Deserialize the data
         FppTest::SmHarness::TestAbsType value;
-        const Fw::SerializeStatus status = buffer.deserialize(value);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         // Assert no data left in buffer
         FW_ASSERT(buffer.getBuffLeft() == 0, static_cast<FwAssertArgType>(buffer.getBuffLeft()));
@@ -2457,7 +2457,7 @@ namespace FppTest {
       case FppTest_SmState_BasicTestArray::Signal::s: {
         // Deserialize the data
         FppTest::SmHarness::TestArray value;
-        const Fw::SerializeStatus status = buffer.deserialize(value);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         // Assert no data left in buffer
         FW_ASSERT(buffer.getBuffLeft() == 0, static_cast<FwAssertArgType>(buffer.getBuffLeft()));
@@ -2482,7 +2482,7 @@ namespace FppTest {
       case FppTest_SmState_BasicTestEnum::Signal::s: {
         // Deserialize the data
         FppTest::SmHarness::TestEnum value;
-        const Fw::SerializeStatus status = buffer.deserialize(value);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         // Assert no data left in buffer
         FW_ASSERT(buffer.getBuffLeft() == 0, static_cast<FwAssertArgType>(buffer.getBuffLeft()));
@@ -2507,7 +2507,7 @@ namespace FppTest {
       case FppTest_SmState_BasicTestStruct::Signal::s: {
         // Deserialize the data
         FppTest::SmHarness::TestStruct value;
-        const Fw::SerializeStatus status = buffer.deserialize(value);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         // Assert no data left in buffer
         FW_ASSERT(buffer.getBuffLeft() == 0, static_cast<FwAssertArgType>(buffer.getBuffLeft()));
@@ -2532,7 +2532,7 @@ namespace FppTest {
       case FppTest_SmState_BasicU32::Signal::s: {
         // Deserialize the data
         U32 value;
-        const Fw::SerializeStatus status = buffer.deserialize(value);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         // Assert no data left in buffer
         FW_ASSERT(buffer.getBuffLeft() == 0, static_cast<FwAssertArgType>(buffer.getBuffLeft()));

--- a/compiler/tools/fpp-to-cpp/test/component/base/SmStateQueuedComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SmStateQueuedComponentAc.ref.cpp
@@ -1321,7 +1321,7 @@ namespace FppTest {
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smStateBasicGuardString, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardString::Signal::s), buffer);
     // Serialize the signal data
-    const Fw::SerializeStatus status = value.serialize(buffer, 80);
+    const Fw::SerializeStatus status = value.serializeTo(buffer, 80);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardString_sendSignalFinish(buffer);
@@ -1334,7 +1334,7 @@ namespace FppTest {
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smStateBasicGuardTestAbsType, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestAbsType::Signal::s), buffer);
     // Serialize the signal data
-    const Fw::SerializeStatus status = buffer.serialize(value);
+    const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardTestAbsType_sendSignalFinish(buffer);
@@ -1347,7 +1347,7 @@ namespace FppTest {
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smStateBasicGuardTestArray, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestArray::Signal::s), buffer);
     // Serialize the signal data
-    const Fw::SerializeStatus status = buffer.serialize(value);
+    const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardTestArray_sendSignalFinish(buffer);
@@ -1360,7 +1360,7 @@ namespace FppTest {
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smStateBasicGuardTestEnum, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestEnum::Signal::s), buffer);
     // Serialize the signal data
-    const Fw::SerializeStatus status = buffer.serialize(value);
+    const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardTestEnum_sendSignalFinish(buffer);
@@ -1373,7 +1373,7 @@ namespace FppTest {
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smStateBasicGuardTestStruct, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardTestStruct::Signal::s), buffer);
     // Serialize the signal data
-    const Fw::SerializeStatus status = buffer.serialize(value);
+    const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardTestStruct_sendSignalFinish(buffer);
@@ -1386,7 +1386,7 @@ namespace FppTest {
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smStateBasicGuardU32, static_cast<FwEnumStoreType>(FppTest_SmState_BasicGuardU32::Signal::s), buffer);
     // Serialize the signal data
-    const Fw::SerializeStatus status = buffer.serialize(value);
+    const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicGuardU32_sendSignalFinish(buffer);
@@ -1419,7 +1419,7 @@ namespace FppTest {
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smStateBasicString, static_cast<FwEnumStoreType>(FppTest_SmState_BasicString::Signal::s), buffer);
     // Serialize the signal data
-    const Fw::SerializeStatus status = value.serialize(buffer, 80);
+    const Fw::SerializeStatus status = value.serializeTo(buffer, 80);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicString_sendSignalFinish(buffer);
@@ -1432,7 +1432,7 @@ namespace FppTest {
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smStateBasicTestAbsType, static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestAbsType::Signal::s), buffer);
     // Serialize the signal data
-    const Fw::SerializeStatus status = buffer.serialize(value);
+    const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicTestAbsType_sendSignalFinish(buffer);
@@ -1445,7 +1445,7 @@ namespace FppTest {
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smStateBasicTestArray, static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestArray::Signal::s), buffer);
     // Serialize the signal data
-    const Fw::SerializeStatus status = buffer.serialize(value);
+    const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicTestArray_sendSignalFinish(buffer);
@@ -1458,7 +1458,7 @@ namespace FppTest {
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smStateBasicTestEnum, static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestEnum::Signal::s), buffer);
     // Serialize the signal data
-    const Fw::SerializeStatus status = buffer.serialize(value);
+    const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicTestEnum_sendSignalFinish(buffer);
@@ -1471,7 +1471,7 @@ namespace FppTest {
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smStateBasicTestStruct, static_cast<FwEnumStoreType>(FppTest_SmState_BasicTestStruct::Signal::s), buffer);
     // Serialize the signal data
-    const Fw::SerializeStatus status = buffer.serialize(value);
+    const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicTestStruct_sendSignalFinish(buffer);
@@ -1484,7 +1484,7 @@ namespace FppTest {
     // Serialize the message type, port number, state ID, and signal
     this->sendSignalStart(SmId::smStateBasicU32, static_cast<FwEnumStoreType>(FppTest_SmState_BasicU32::Signal::s), buffer);
     // Serialize the signal data
-    const Fw::SerializeStatus status = buffer.serialize(value);
+    const Fw::SerializeStatus status = buffer.serializeFrom(value);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Send the message and handle overflow
     this->smStateBasicU32_sendSignalFinish(buffer);
@@ -1659,7 +1659,7 @@ namespace FppTest {
     _msg.resetDeser();
 
     FwEnumStoreType _desMsg = 0;
-    Fw::SerializeStatus _deserStatus = _msg.deserialize(_desMsg);
+    Fw::SerializeStatus _deserStatus = _msg.deserializeTo(_desMsg);
     FW_ASSERT(
       _deserStatus == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_deserStatus)
@@ -1672,7 +1672,7 @@ namespace FppTest {
     }
 
     FwIndexType portNum = 0;
-    _deserStatus = _msg.deserialize(portNum);
+    _deserStatus = _msg.deserializeTo(portNum);
     FW_ASSERT(
       _deserStatus == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_deserStatus)
@@ -1744,19 +1744,19 @@ namespace FppTest {
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
 
     // Serialize the message type
-    status = buffer.serialize(static_cast<FwEnumStoreType>(INTERNAL_STATE_MACHINE_SIGNAL));
+    status = buffer.serializeFrom(static_cast<FwEnumStoreType>(INTERNAL_STATE_MACHINE_SIGNAL));
     FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the port number
-    status = buffer.serialize(static_cast<FwIndexType>(0));
+    status = buffer.serializeFrom(static_cast<FwIndexType>(0));
     FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the state machine ID
-    status = buffer.serialize(static_cast<FwEnumStoreType>(smId));
+    status = buffer.serializeFrom(static_cast<FwEnumStoreType>(smId));
     FW_ASSERT (status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Serialize the signal
-    status = buffer.serialize(static_cast<FwEnumStoreType>(signal));
+    status = buffer.serializeFrom(static_cast<FwEnumStoreType>(signal));
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
   }
 
@@ -2269,11 +2269,11 @@ namespace FppTest {
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Deserialize the state machine ID
-    status = buffer.deserialize(smId);
+    status = buffer.deserializeTo(smId);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
 
     // Deserialize the signal
-    status = buffer.deserialize(signal);
+    status = buffer.deserializeTo(signal);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
   }
 
@@ -2331,7 +2331,7 @@ namespace FppTest {
         // Deserialize the data
         char __fprime_ac_value_buffer[Fw::StringBase::BUFFER_SIZE(80)];
         Fw::ExternalString value(__fprime_ac_value_buffer, sizeof __fprime_ac_value_buffer);
-        const Fw::SerializeStatus status = buffer.deserialize(value);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         // Assert no data left in buffer
         FW_ASSERT(buffer.getBuffLeft() == 0, static_cast<FwAssertArgType>(buffer.getBuffLeft()));
@@ -2356,7 +2356,7 @@ namespace FppTest {
       case FppTest_SmState_BasicGuardTestAbsType::Signal::s: {
         // Deserialize the data
         FppTest::SmHarness::TestAbsType value;
-        const Fw::SerializeStatus status = buffer.deserialize(value);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         // Assert no data left in buffer
         FW_ASSERT(buffer.getBuffLeft() == 0, static_cast<FwAssertArgType>(buffer.getBuffLeft()));
@@ -2381,7 +2381,7 @@ namespace FppTest {
       case FppTest_SmState_BasicGuardTestArray::Signal::s: {
         // Deserialize the data
         FppTest::SmHarness::TestArray value;
-        const Fw::SerializeStatus status = buffer.deserialize(value);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         // Assert no data left in buffer
         FW_ASSERT(buffer.getBuffLeft() == 0, static_cast<FwAssertArgType>(buffer.getBuffLeft()));
@@ -2406,7 +2406,7 @@ namespace FppTest {
       case FppTest_SmState_BasicGuardTestEnum::Signal::s: {
         // Deserialize the data
         FppTest::SmHarness::TestEnum value;
-        const Fw::SerializeStatus status = buffer.deserialize(value);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         // Assert no data left in buffer
         FW_ASSERT(buffer.getBuffLeft() == 0, static_cast<FwAssertArgType>(buffer.getBuffLeft()));
@@ -2431,7 +2431,7 @@ namespace FppTest {
       case FppTest_SmState_BasicGuardTestStruct::Signal::s: {
         // Deserialize the data
         FppTest::SmHarness::TestStruct value;
-        const Fw::SerializeStatus status = buffer.deserialize(value);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         // Assert no data left in buffer
         FW_ASSERT(buffer.getBuffLeft() == 0, static_cast<FwAssertArgType>(buffer.getBuffLeft()));
@@ -2456,7 +2456,7 @@ namespace FppTest {
       case FppTest_SmState_BasicGuardU32::Signal::s: {
         // Deserialize the data
         U32 value;
-        const Fw::SerializeStatus status = buffer.deserialize(value);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         // Assert no data left in buffer
         FW_ASSERT(buffer.getBuffLeft() == 0, static_cast<FwAssertArgType>(buffer.getBuffLeft()));
@@ -2524,7 +2524,7 @@ namespace FppTest {
         // Deserialize the data
         char __fprime_ac_value_buffer[Fw::StringBase::BUFFER_SIZE(80)];
         Fw::ExternalString value(__fprime_ac_value_buffer, sizeof __fprime_ac_value_buffer);
-        const Fw::SerializeStatus status = buffer.deserialize(value);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         // Assert no data left in buffer
         FW_ASSERT(buffer.getBuffLeft() == 0, static_cast<FwAssertArgType>(buffer.getBuffLeft()));
@@ -2549,7 +2549,7 @@ namespace FppTest {
       case FppTest_SmState_BasicTestAbsType::Signal::s: {
         // Deserialize the data
         FppTest::SmHarness::TestAbsType value;
-        const Fw::SerializeStatus status = buffer.deserialize(value);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         // Assert no data left in buffer
         FW_ASSERT(buffer.getBuffLeft() == 0, static_cast<FwAssertArgType>(buffer.getBuffLeft()));
@@ -2574,7 +2574,7 @@ namespace FppTest {
       case FppTest_SmState_BasicTestArray::Signal::s: {
         // Deserialize the data
         FppTest::SmHarness::TestArray value;
-        const Fw::SerializeStatus status = buffer.deserialize(value);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         // Assert no data left in buffer
         FW_ASSERT(buffer.getBuffLeft() == 0, static_cast<FwAssertArgType>(buffer.getBuffLeft()));
@@ -2599,7 +2599,7 @@ namespace FppTest {
       case FppTest_SmState_BasicTestEnum::Signal::s: {
         // Deserialize the data
         FppTest::SmHarness::TestEnum value;
-        const Fw::SerializeStatus status = buffer.deserialize(value);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         // Assert no data left in buffer
         FW_ASSERT(buffer.getBuffLeft() == 0, static_cast<FwAssertArgType>(buffer.getBuffLeft()));
@@ -2624,7 +2624,7 @@ namespace FppTest {
       case FppTest_SmState_BasicTestStruct::Signal::s: {
         // Deserialize the data
         FppTest::SmHarness::TestStruct value;
-        const Fw::SerializeStatus status = buffer.deserialize(value);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         // Assert no data left in buffer
         FW_ASSERT(buffer.getBuffLeft() == 0, static_cast<FwAssertArgType>(buffer.getBuffLeft()));
@@ -2649,7 +2649,7 @@ namespace FppTest {
       case FppTest_SmState_BasicU32::Signal::s: {
         // Deserialize the data
         U32 value;
-        const Fw::SerializeStatus status = buffer.deserialize(value);
+        const Fw::SerializeStatus status = buffer.deserializeTo(value);
         FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
         // Assert no data left in buffer
         FW_ASSERT(buffer.getBuffLeft() == 0, static_cast<FwAssertArgType>(buffer.getBuffLeft()));

--- a/compiler/tools/fpp-to-cpp/test/component/base/StructWithAliasSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/StructWithAliasSerializableAc.ref.cpp
@@ -103,27 +103,27 @@ std::ostream& operator<<(std::ostream& os, const StructWithAlias& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus StructWithAlias ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status;
 
-  status = buffer.serialize(this->m_x);
+  status = buffer.serializeFrom(this->m_x);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_y);
+  status = buffer.serializeFrom(this->m_y);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_z);
+  status = buffer.serializeFrom(this->m_z);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_w);
+  status = buffer.serializeFrom(this->m_w);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_q);
+  status = buffer.serializeFrom(this->m_q);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
@@ -132,27 +132,27 @@ Fw::SerializeStatus StructWithAlias ::
 }
 
 Fw::SerializeStatus StructWithAlias ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status;
 
-  status = buffer.deserialize(this->m_x);
+  status = buffer.deserializeTo(this->m_x);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_y);
+  status = buffer.deserializeTo(this->m_y);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_z);
+  status = buffer.deserializeTo(this->m_z);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_w);
+  status = buffer.deserializeTo(this->m_w);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_q);
+  status = buffer.deserializeTo(this->m_q);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }

--- a/compiler/tools/fpp-to-cpp/test/component/base/StructWithAliasSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/StructWithAliasSerializableAc.ref.hpp
@@ -98,12 +98,12 @@ class StructWithAlias :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/TypedPortAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/TypedPortAc.ref.cpp
@@ -108,44 +108,44 @@ namespace Ports {
     FW_ASSERT(this->m_func != nullptr);
 
     U32 u32;
-    _status = _buffer.deserialize(u32);
+    _status = _buffer.deserializeTo(u32);
     if (_status != Fw::FW_SERIALIZE_OK) {
       return _status;
     }
 
     F32 f32;
-    _status = _buffer.deserialize(f32);
+    _status = _buffer.deserializeTo(f32);
     if (_status != Fw::FW_SERIALIZE_OK) {
       return _status;
     }
 
     bool b;
-    _status = _buffer.deserialize(b);
+    _status = _buffer.deserializeTo(b);
     if (_status != Fw::FW_SERIALIZE_OK) {
       return _status;
     }
 
     char __fprime_ac_str1_buffer[Fw::StringBase::BUFFER_SIZE(80)];
     Fw::ExternalString str1(__fprime_ac_str1_buffer, sizeof __fprime_ac_str1_buffer);
-    _status = _buffer.deserialize(str1);
+    _status = _buffer.deserializeTo(str1);
     if (_status != Fw::FW_SERIALIZE_OK) {
       return _status;
     }
 
     E e;
-    _status = _buffer.deserialize(e);
+    _status = _buffer.deserializeTo(e);
     if (_status != Fw::FW_SERIALIZE_OK) {
       return _status;
     }
 
     A a;
-    _status = _buffer.deserialize(a);
+    _status = _buffer.deserializeTo(a);
     if (_status != Fw::FW_SERIALIZE_OK) {
       return _status;
     }
 
     S s;
-    _status = _buffer.deserialize(s);
+    _status = _buffer.deserializeTo(s);
     if (_status != Fw::FW_SERIALIZE_OK) {
       return _status;
     }
@@ -213,25 +213,25 @@ namespace Ports {
       Fw::SerializeStatus _status;
       TypedPortBuffer _buffer;
 
-      _status = _buffer.serialize(u32);
+      _status = _buffer.serializeFrom(u32);
       FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-      _status = _buffer.serialize(f32);
+      _status = _buffer.serializeFrom(f32);
       FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-      _status = _buffer.serialize(b);
+      _status = _buffer.serializeFrom(b);
       FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-      _status = _buffer.serialize(str1);
+      _status = _buffer.serializeFrom(str1);
       FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-      _status = _buffer.serialize(e);
+      _status = _buffer.serializeFrom(e);
       FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-      _status = _buffer.serialize(a);
+      _status = _buffer.serializeFrom(a);
       FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-      _status = _buffer.serialize(s);
+      _status = _buffer.serializeFrom(s);
       FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
       _status = this->m_serPort->invokeSerial(_buffer);

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsTesterBase.ref.cpp
@@ -2395,19 +2395,19 @@ void ActiveCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(u32);
+  _status = buf.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(f32);
+  _status = buf.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(b);
+  _status = buf.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2442,13 +2442,13 @@ void ActiveCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+  _status = str1.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+  _status = str2.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2482,7 +2482,7 @@ void ActiveCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(e);
+  _status = buf.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2516,7 +2516,7 @@ void ActiveCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(a);
+  _status = buf.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2550,7 +2550,7 @@ void ActiveCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(s);
+  _status = buf.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2611,19 +2611,19 @@ void ActiveCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(u32);
+  _status = buf.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(f32);
+  _status = buf.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(b);
+  _status = buf.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2658,13 +2658,13 @@ void ActiveCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+  _status = str1.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+  _status = str2.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2698,7 +2698,7 @@ void ActiveCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(e);
+  _status = buf.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2732,7 +2732,7 @@ void ActiveCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(a);
+  _status = buf.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2766,7 +2766,7 @@ void ActiveCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(s);
+  _status = buf.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2850,7 +2850,7 @@ void ActiveCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(u32);
+  _status = buf.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2909,7 +2909,7 @@ void ActiveCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(u32);
+  _status = buf.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsTesterBase.ref.cpp
@@ -2345,7 +2345,7 @@ void ActiveEventsTesterBase ::
       // For AMPCS, decode zero arguments
       Fw::SerializeStatus _zero_status = Fw::FW_SERIALIZE_OK;
       U8 _noArgs;
-      _zero_status = args.deserialize(_noArgs);
+      _zero_status = args.deserializeTo(_noArgs);
       FW_ASSERT(
         _zero_status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_zero_status)
@@ -2361,7 +2361,7 @@ void ActiveEventsTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2379,7 +2379,7 @@ void ActiveEventsTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2391,7 +2391,7 @@ void ActiveEventsTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_u32);
+      _status = args.deserializeTo(_event_arg_u32);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2402,7 +2402,7 @@ void ActiveEventsTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2414,7 +2414,7 @@ void ActiveEventsTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_f32);
+      _status = args.deserializeTo(_event_arg_f32);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2425,7 +2425,7 @@ void ActiveEventsTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2437,7 +2437,7 @@ void ActiveEventsTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_b);
+      _status = args.deserializeTo(_event_arg_b);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2452,7 +2452,7 @@ void ActiveEventsTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2470,7 +2470,7 @@ void ActiveEventsTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2482,7 +2482,7 @@ void ActiveEventsTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_str1);
+      _status = args.deserializeTo(_event_arg_str1);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2493,7 +2493,7 @@ void ActiveEventsTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2505,7 +2505,7 @@ void ActiveEventsTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_str2);
+      _status = args.deserializeTo(_event_arg_str2);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2520,7 +2520,7 @@ void ActiveEventsTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2538,7 +2538,7 @@ void ActiveEventsTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2550,7 +2550,7 @@ void ActiveEventsTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_e);
+      _status = args.deserializeTo(_event_arg_e);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2565,7 +2565,7 @@ void ActiveEventsTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2579,7 +2579,7 @@ void ActiveEventsTesterBase ::
 
       // For FATAL, there is a stack size of 4 and a dummy entry
       U8 stackArgLen;
-      _status = args.deserialize(stackArgLen);
+      _status = args.deserializeTo(stackArgLen);
       FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2590,7 +2590,7 @@ void ActiveEventsTesterBase ::
       );
 
       U32 dummyStackArg;
-      _status = args.deserialize(dummyStackArg);
+      _status = args.deserializeTo(dummyStackArg);
       FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2606,7 +2606,7 @@ void ActiveEventsTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2618,7 +2618,7 @@ void ActiveEventsTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_a);
+      _status = args.deserializeTo(_event_arg_a);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2633,7 +2633,7 @@ void ActiveEventsTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2651,7 +2651,7 @@ void ActiveEventsTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2663,7 +2663,7 @@ void ActiveEventsTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_s);
+      _status = args.deserializeTo(_event_arg_s);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2677,7 +2677,7 @@ void ActiveEventsTesterBase ::
       // For AMPCS, decode zero arguments
       Fw::SerializeStatus _zero_status = Fw::FW_SERIALIZE_OK;
       U8 _noArgs;
-      _zero_status = args.deserialize(_noArgs);
+      _zero_status = args.deserializeTo(_noArgs);
       FW_ASSERT(
         _zero_status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_zero_status)

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveExternalParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveExternalParamsTesterBase.ref.cpp
@@ -29,27 +29,27 @@ Fw::SerializeStatus ActiveExternalParamsTesterBase::ActiveExternalParamsComponen
   {
     // ParamI32Ext
     case ActiveExternalParamsComponentBase::PARAMID_PARAMI32EXT:
-      stat = buff.deserialize(this->m_param_ParamI32Ext);
+      stat = buff.deserializeTo(this->m_param_ParamI32Ext);
       break;
     // ParamF64Ext
     case ActiveExternalParamsComponentBase::PARAMID_PARAMF64EXT:
-      stat = buff.deserialize(this->m_param_ParamF64Ext);
+      stat = buff.deserializeTo(this->m_param_ParamF64Ext);
       break;
     // ParamStringExt
     case ActiveExternalParamsComponentBase::PARAMID_PARAMSTRINGEXT:
-      stat = buff.deserialize(this->m_param_ParamStringExt);
+      stat = buff.deserializeTo(this->m_param_ParamStringExt);
       break;
     // ParamEnumExt
     case ActiveExternalParamsComponentBase::PARAMID_PARAMENUMEXT:
-      stat = buff.deserialize(this->m_param_ParamEnumExt);
+      stat = buff.deserializeTo(this->m_param_ParamEnumExt);
       break;
     // ParamArrayExt
     case ActiveExternalParamsComponentBase::PARAMID_PARAMARRAYEXT:
-      stat = buff.deserialize(this->m_param_ParamArrayExt);
+      stat = buff.deserializeTo(this->m_param_ParamArrayExt);
       break;
     // ParamStructExt
     case ActiveExternalParamsComponentBase::PARAMID_PARAMSTRUCTEXT:
-      stat = buff.deserialize(this->m_param_ParamStructExt);
+      stat = buff.deserializeTo(this->m_param_ParamStructExt);
       break;
     default:
       // Unknown ID; should not have gotten here
@@ -74,27 +74,27 @@ Fw::SerializeStatus ActiveExternalParamsTesterBase::ActiveExternalParamsComponen
   {
     // ParamI32Ext
     case ActiveExternalParamsComponentBase::PARAMID_PARAMI32EXT:
-      stat = buff.serialize(this->m_param_ParamI32Ext);
+      stat = buff.serializeFrom(this->m_param_ParamI32Ext);
       break;
     // ParamF64Ext
     case ActiveExternalParamsComponentBase::PARAMID_PARAMF64EXT:
-      stat = buff.serialize(this->m_param_ParamF64Ext);
+      stat = buff.serializeFrom(this->m_param_ParamF64Ext);
       break;
     // ParamStringExt
     case ActiveExternalParamsComponentBase::PARAMID_PARAMSTRINGEXT:
-      stat = buff.serialize(this->m_param_ParamStringExt);
+      stat = buff.serializeFrom(this->m_param_ParamStringExt);
       break;
     // ParamEnumExt
     case ActiveExternalParamsComponentBase::PARAMID_PARAMENUMEXT:
-      stat = buff.serialize(this->m_param_ParamEnumExt);
+      stat = buff.serializeFrom(this->m_param_ParamEnumExt);
       break;
     // ParamArrayExt
     case ActiveExternalParamsComponentBase::PARAMID_PARAMARRAYEXT:
-      stat = buff.serialize(this->m_param_ParamArrayExt);
+      stat = buff.serializeFrom(this->m_param_ParamArrayExt);
       break;
     // ParamStructExt
     case ActiveExternalParamsComponentBase::PARAMID_PARAMSTRUCTEXT:
-      stat = buff.serialize(this->m_param_ParamStructExt);
+      stat = buff.serializeFrom(this->m_param_ParamStructExt);
       break;
     default:
       // Unknown ID; should not have gotten here
@@ -2523,7 +2523,7 @@ void ActiveExternalParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamI32Ext) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamI32Ext) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -2582,7 +2582,7 @@ void ActiveExternalParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamF64Ext) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamF64Ext) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -2641,7 +2641,7 @@ void ActiveExternalParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamStringExt) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamStringExt) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -2700,7 +2700,7 @@ void ActiveExternalParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamEnumExt) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamEnumExt) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -2759,7 +2759,7 @@ void ActiveExternalParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamArrayExt) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamArrayExt) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -2818,7 +2818,7 @@ void ActiveExternalParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamStructExt) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamStructExt) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -3106,7 +3106,7 @@ Fw::ParamValid ActiveExternalParamsTesterBase ::
 
   switch (id - idBase) {
     case ActiveExternalParamsComponentBase::PARAMID_PARAMI32EXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamI32Ext);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamI32Ext);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamI32Ext_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -3116,7 +3116,7 @@ Fw::ParamValid ActiveExternalParamsTesterBase ::
     };
 
     case ActiveExternalParamsComponentBase::PARAMID_PARAMF64EXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamF64Ext);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamF64Ext);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamF64Ext_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -3126,7 +3126,7 @@ Fw::ParamValid ActiveExternalParamsTesterBase ::
     };
 
     case ActiveExternalParamsComponentBase::PARAMID_PARAMSTRINGEXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamStringExt);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamStringExt);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamStringExt_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -3136,7 +3136,7 @@ Fw::ParamValid ActiveExternalParamsTesterBase ::
     };
 
     case ActiveExternalParamsComponentBase::PARAMID_PARAMENUMEXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamEnumExt);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamEnumExt);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamEnumExt_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -3146,7 +3146,7 @@ Fw::ParamValid ActiveExternalParamsTesterBase ::
     };
 
     case ActiveExternalParamsComponentBase::PARAMID_PARAMARRAYEXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamArrayExt);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamArrayExt);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamArrayExt_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -3156,7 +3156,7 @@ Fw::ParamValid ActiveExternalParamsTesterBase ::
     };
 
     case ActiveExternalParamsComponentBase::PARAMID_PARAMSTRUCTEXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamStructExt);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamStructExt);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamStructExt_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -3194,7 +3194,7 @@ void ActiveExternalParamsTesterBase ::
   switch (id - idBase) {
     case ActiveExternalParamsComponentBase::PARAMID_PARAMI32EXT: {
       I32 ParamI32ExtVal;
-      _status = val.deserialize(ParamI32ExtVal);
+      _status = val.deserializeTo(ParamI32ExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3208,7 +3208,7 @@ void ActiveExternalParamsTesterBase ::
 
     case ActiveExternalParamsComponentBase::PARAMID_PARAMF64EXT: {
       F64 ParamF64ExtVal;
-      _status = val.deserialize(ParamF64ExtVal);
+      _status = val.deserializeTo(ParamF64ExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3222,7 +3222,7 @@ void ActiveExternalParamsTesterBase ::
 
     case ActiveExternalParamsComponentBase::PARAMID_PARAMSTRINGEXT: {
       Fw::ParamString ParamStringExtVal;
-      _status = val.deserialize(ParamStringExtVal);
+      _status = val.deserializeTo(ParamStringExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3236,7 +3236,7 @@ void ActiveExternalParamsTesterBase ::
 
     case ActiveExternalParamsComponentBase::PARAMID_PARAMENUMEXT: {
       E ParamEnumExtVal;
-      _status = val.deserialize(ParamEnumExtVal);
+      _status = val.deserializeTo(ParamEnumExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3250,7 +3250,7 @@ void ActiveExternalParamsTesterBase ::
 
     case ActiveExternalParamsComponentBase::PARAMID_PARAMARRAYEXT: {
       A ParamArrayExtVal;
-      _status = val.deserialize(ParamArrayExtVal);
+      _status = val.deserializeTo(ParamArrayExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3264,7 +3264,7 @@ void ActiveExternalParamsTesterBase ::
 
     case ActiveExternalParamsComponentBase::PARAMID_PARAMSTRUCTEXT: {
       S ParamStructExtVal;
-      _status = val.deserialize(ParamStructExtVal);
+      _status = val.deserializeTo(ParamStructExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsTesterBase.ref.cpp
@@ -2434,7 +2434,7 @@ void ActiveParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamU32) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamU32) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -2493,7 +2493,7 @@ void ActiveParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamF64) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamF64) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -2552,7 +2552,7 @@ void ActiveParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamString) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamString) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -2611,7 +2611,7 @@ void ActiveParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamEnum) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamEnum) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -2670,7 +2670,7 @@ void ActiveParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamArray) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamArray) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -2729,7 +2729,7 @@ void ActiveParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamStruct) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamStruct) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -3017,7 +3017,7 @@ Fw::ParamValid ActiveParamsTesterBase ::
 
   switch (id - idBase) {
     case ActiveParamsComponentBase::PARAMID_PARAMU32: {
-      _status = val.serialize(_testerBase->m_param_ParamU32);
+      _status = val.serializeFrom(_testerBase->m_param_ParamU32);
       _ret = _testerBase->m_param_ParamU32_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -3027,7 +3027,7 @@ Fw::ParamValid ActiveParamsTesterBase ::
     };
 
     case ActiveParamsComponentBase::PARAMID_PARAMF64: {
-      _status = val.serialize(_testerBase->m_param_ParamF64);
+      _status = val.serializeFrom(_testerBase->m_param_ParamF64);
       _ret = _testerBase->m_param_ParamF64_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -3037,7 +3037,7 @@ Fw::ParamValid ActiveParamsTesterBase ::
     };
 
     case ActiveParamsComponentBase::PARAMID_PARAMSTRING: {
-      _status = val.serialize(_testerBase->m_param_ParamString);
+      _status = val.serializeFrom(_testerBase->m_param_ParamString);
       _ret = _testerBase->m_param_ParamString_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -3047,7 +3047,7 @@ Fw::ParamValid ActiveParamsTesterBase ::
     };
 
     case ActiveParamsComponentBase::PARAMID_PARAMENUM: {
-      _status = val.serialize(_testerBase->m_param_ParamEnum);
+      _status = val.serializeFrom(_testerBase->m_param_ParamEnum);
       _ret = _testerBase->m_param_ParamEnum_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -3057,7 +3057,7 @@ Fw::ParamValid ActiveParamsTesterBase ::
     };
 
     case ActiveParamsComponentBase::PARAMID_PARAMARRAY: {
-      _status = val.serialize(_testerBase->m_param_ParamArray);
+      _status = val.serializeFrom(_testerBase->m_param_ParamArray);
       _ret = _testerBase->m_param_ParamArray_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -3067,7 +3067,7 @@ Fw::ParamValid ActiveParamsTesterBase ::
     };
 
     case ActiveParamsComponentBase::PARAMID_PARAMSTRUCT: {
-      _status = val.serialize(_testerBase->m_param_ParamStruct);
+      _status = val.serializeFrom(_testerBase->m_param_ParamStruct);
       _ret = _testerBase->m_param_ParamStruct_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -3105,7 +3105,7 @@ void ActiveParamsTesterBase ::
   switch (id - idBase) {
     case ActiveParamsComponentBase::PARAMID_PARAMU32: {
       U32 ParamU32Val;
-      _status = val.deserialize(ParamU32Val);
+      _status = val.deserializeTo(ParamU32Val);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3119,7 +3119,7 @@ void ActiveParamsTesterBase ::
 
     case ActiveParamsComponentBase::PARAMID_PARAMF64: {
       F64 ParamF64Val;
-      _status = val.deserialize(ParamF64Val);
+      _status = val.deserializeTo(ParamF64Val);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3133,7 +3133,7 @@ void ActiveParamsTesterBase ::
 
     case ActiveParamsComponentBase::PARAMID_PARAMSTRING: {
       Fw::ParamString ParamStringVal;
-      _status = val.deserialize(ParamStringVal);
+      _status = val.deserializeTo(ParamStringVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3147,7 +3147,7 @@ void ActiveParamsTesterBase ::
 
     case ActiveParamsComponentBase::PARAMID_PARAMENUM: {
       E ParamEnumVal;
-      _status = val.deserialize(ParamEnumVal);
+      _status = val.deserializeTo(ParamEnumVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3161,7 +3161,7 @@ void ActiveParamsTesterBase ::
 
     case ActiveParamsComponentBase::PARAMID_PARAMARRAY: {
       A ParamArrayVal;
-      _status = val.deserialize(ParamArrayVal);
+      _status = val.deserializeTo(ParamArrayVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3175,7 +3175,7 @@ void ActiveParamsTesterBase ::
 
     case ActiveParamsComponentBase::PARAMID_PARAMSTRUCT: {
       S ParamStructVal;
-      _status = val.deserialize(ParamStructVal);
+      _status = val.deserializeTo(ParamStructVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.cpp
@@ -29,27 +29,27 @@ Fw::SerializeStatus ActiveSerialTesterBase::ActiveSerialComponentBaseParamExtern
   {
     // ParamI32Ext
     case ActiveSerialComponentBase::PARAMID_PARAMI32EXT:
-      stat = buff.deserialize(this->m_param_ParamI32Ext);
+      stat = buff.deserializeTo(this->m_param_ParamI32Ext);
       break;
     // ParamF64Ext
     case ActiveSerialComponentBase::PARAMID_PARAMF64EXT:
-      stat = buff.deserialize(this->m_param_ParamF64Ext);
+      stat = buff.deserializeTo(this->m_param_ParamF64Ext);
       break;
     // ParamStringExt
     case ActiveSerialComponentBase::PARAMID_PARAMSTRINGEXT:
-      stat = buff.deserialize(this->m_param_ParamStringExt);
+      stat = buff.deserializeTo(this->m_param_ParamStringExt);
       break;
     // ParamEnumExt
     case ActiveSerialComponentBase::PARAMID_PARAMENUMEXT:
-      stat = buff.deserialize(this->m_param_ParamEnumExt);
+      stat = buff.deserializeTo(this->m_param_ParamEnumExt);
       break;
     // ParamArrayExt
     case ActiveSerialComponentBase::PARAMID_PARAMARRAYEXT:
-      stat = buff.deserialize(this->m_param_ParamArrayExt);
+      stat = buff.deserializeTo(this->m_param_ParamArrayExt);
       break;
     // ParamStructExt
     case ActiveSerialComponentBase::PARAMID_PARAMSTRUCTEXT:
-      stat = buff.deserialize(this->m_param_ParamStructExt);
+      stat = buff.deserializeTo(this->m_param_ParamStructExt);
       break;
     default:
       // Unknown ID; should not have gotten here
@@ -74,27 +74,27 @@ Fw::SerializeStatus ActiveSerialTesterBase::ActiveSerialComponentBaseParamExtern
   {
     // ParamI32Ext
     case ActiveSerialComponentBase::PARAMID_PARAMI32EXT:
-      stat = buff.serialize(this->m_param_ParamI32Ext);
+      stat = buff.serializeFrom(this->m_param_ParamI32Ext);
       break;
     // ParamF64Ext
     case ActiveSerialComponentBase::PARAMID_PARAMF64EXT:
-      stat = buff.serialize(this->m_param_ParamF64Ext);
+      stat = buff.serializeFrom(this->m_param_ParamF64Ext);
       break;
     // ParamStringExt
     case ActiveSerialComponentBase::PARAMID_PARAMSTRINGEXT:
-      stat = buff.serialize(this->m_param_ParamStringExt);
+      stat = buff.serializeFrom(this->m_param_ParamStringExt);
       break;
     // ParamEnumExt
     case ActiveSerialComponentBase::PARAMID_PARAMENUMEXT:
-      stat = buff.serialize(this->m_param_ParamEnumExt);
+      stat = buff.serializeFrom(this->m_param_ParamEnumExt);
       break;
     // ParamArrayExt
     case ActiveSerialComponentBase::PARAMID_PARAMARRAYEXT:
-      stat = buff.serialize(this->m_param_ParamArrayExt);
+      stat = buff.serializeFrom(this->m_param_ParamArrayExt);
       break;
     // ParamStructExt
     case ActiveSerialComponentBase::PARAMID_PARAMSTRUCTEXT:
-      stat = buff.serialize(this->m_param_ParamStructExt);
+      stat = buff.serializeFrom(this->m_param_ParamStructExt);
       break;
     default:
       // Unknown ID; should not have gotten here
@@ -3132,19 +3132,19 @@ void ActiveSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(u32);
+  _status = buf.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(f32);
+  _status = buf.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(b);
+  _status = buf.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3179,13 +3179,13 @@ void ActiveSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+  _status = str1.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+  _status = str2.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3219,7 +3219,7 @@ void ActiveSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(e);
+  _status = buf.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3253,7 +3253,7 @@ void ActiveSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(a);
+  _status = buf.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3287,7 +3287,7 @@ void ActiveSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(s);
+  _status = buf.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3348,19 +3348,19 @@ void ActiveSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(u32);
+  _status = buf.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(f32);
+  _status = buf.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(b);
+  _status = buf.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3395,13 +3395,13 @@ void ActiveSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+  _status = str1.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+  _status = str2.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3435,7 +3435,7 @@ void ActiveSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(e);
+  _status = buf.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3469,7 +3469,7 @@ void ActiveSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(a);
+  _status = buf.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3503,7 +3503,7 @@ void ActiveSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(s);
+  _status = buf.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3587,7 +3587,7 @@ void ActiveSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(u32);
+  _status = buf.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3646,7 +3646,7 @@ void ActiveSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(u32);
+  _status = buf.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3696,7 +3696,7 @@ void ActiveSerialTesterBase ::
       // For AMPCS, decode zero arguments
       Fw::SerializeStatus _zero_status = Fw::FW_SERIALIZE_OK;
       U8 _noArgs;
-      _zero_status = args.deserialize(_noArgs);
+      _zero_status = args.deserializeTo(_noArgs);
       FW_ASSERT(
         _zero_status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_zero_status)
@@ -3712,7 +3712,7 @@ void ActiveSerialTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3730,7 +3730,7 @@ void ActiveSerialTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3742,7 +3742,7 @@ void ActiveSerialTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_u32);
+      _status = args.deserializeTo(_event_arg_u32);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3753,7 +3753,7 @@ void ActiveSerialTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3765,7 +3765,7 @@ void ActiveSerialTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_f32);
+      _status = args.deserializeTo(_event_arg_f32);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3776,7 +3776,7 @@ void ActiveSerialTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3788,7 +3788,7 @@ void ActiveSerialTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_b);
+      _status = args.deserializeTo(_event_arg_b);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3803,7 +3803,7 @@ void ActiveSerialTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3821,7 +3821,7 @@ void ActiveSerialTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3833,7 +3833,7 @@ void ActiveSerialTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_str1);
+      _status = args.deserializeTo(_event_arg_str1);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3844,7 +3844,7 @@ void ActiveSerialTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3856,7 +3856,7 @@ void ActiveSerialTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_str2);
+      _status = args.deserializeTo(_event_arg_str2);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3871,7 +3871,7 @@ void ActiveSerialTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3889,7 +3889,7 @@ void ActiveSerialTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3901,7 +3901,7 @@ void ActiveSerialTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_e);
+      _status = args.deserializeTo(_event_arg_e);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3916,7 +3916,7 @@ void ActiveSerialTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3930,7 +3930,7 @@ void ActiveSerialTesterBase ::
 
       // For FATAL, there is a stack size of 4 and a dummy entry
       U8 stackArgLen;
-      _status = args.deserialize(stackArgLen);
+      _status = args.deserializeTo(stackArgLen);
       FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3941,7 +3941,7 @@ void ActiveSerialTesterBase ::
       );
 
       U32 dummyStackArg;
-      _status = args.deserialize(dummyStackArg);
+      _status = args.deserializeTo(dummyStackArg);
       FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3957,7 +3957,7 @@ void ActiveSerialTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3969,7 +3969,7 @@ void ActiveSerialTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_a);
+      _status = args.deserializeTo(_event_arg_a);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3984,7 +3984,7 @@ void ActiveSerialTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -4002,7 +4002,7 @@ void ActiveSerialTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -4014,7 +4014,7 @@ void ActiveSerialTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_s);
+      _status = args.deserializeTo(_event_arg_s);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -4028,7 +4028,7 @@ void ActiveSerialTesterBase ::
       // For AMPCS, decode zero arguments
       Fw::SerializeStatus _zero_status = Fw::FW_SERIALIZE_OK;
       U8 _noArgs;
-      _zero_status = args.deserialize(_noArgs);
+      _zero_status = args.deserializeTo(_noArgs);
       FW_ASSERT(
         _zero_status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_zero_status)
@@ -4158,7 +4158,7 @@ void ActiveSerialTesterBase ::
   switch (id - idBase) {
     case ActiveSerialComponentBase::CHANNELID_CHANNELU32FORMAT: {
       U32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelU32Format: %d\n", _status);
@@ -4171,7 +4171,7 @@ void ActiveSerialTesterBase ::
 
     case ActiveSerialComponentBase::CHANNELID_CHANNELF32FORMAT: {
       F32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelF32Format: %d\n", _status);
@@ -4184,7 +4184,7 @@ void ActiveSerialTesterBase ::
 
     case ActiveSerialComponentBase::CHANNELID_CHANNELSTRINGFORMAT: {
       Fw::TlmString arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelStringFormat: %d\n", _status);
@@ -4197,7 +4197,7 @@ void ActiveSerialTesterBase ::
 
     case ActiveSerialComponentBase::CHANNELID_CHANNELENUM: {
       E arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelEnum: %d\n", _status);
@@ -4210,7 +4210,7 @@ void ActiveSerialTesterBase ::
 
     case ActiveSerialComponentBase::CHANNELID_CHANNELARRAYFREQ: {
       A arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelArrayFreq: %d\n", _status);
@@ -4223,7 +4223,7 @@ void ActiveSerialTesterBase ::
 
     case ActiveSerialComponentBase::CHANNELID_CHANNELSTRUCTFREQ: {
       S arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelStructFreq: %d\n", _status);
@@ -4236,7 +4236,7 @@ void ActiveSerialTesterBase ::
 
     case ActiveSerialComponentBase::CHANNELID_CHANNELU32LIMITS: {
       U32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelU32Limits: %d\n", _status);
@@ -4249,7 +4249,7 @@ void ActiveSerialTesterBase ::
 
     case ActiveSerialComponentBase::CHANNELID_CHANNELF32LIMITS: {
       F32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelF32Limits: %d\n", _status);
@@ -4262,7 +4262,7 @@ void ActiveSerialTesterBase ::
 
     case ActiveSerialComponentBase::CHANNELID_CHANNELF64: {
       F64 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelF64: %d\n", _status);
@@ -4275,7 +4275,7 @@ void ActiveSerialTesterBase ::
 
     case ActiveSerialComponentBase::CHANNELID_CHANNELU32ONCHANGE: {
       U32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelU32OnChange: %d\n", _status);
@@ -4288,7 +4288,7 @@ void ActiveSerialTesterBase ::
 
     case ActiveSerialComponentBase::CHANNELID_CHANNELENUMONCHANGE: {
       E arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelEnumOnChange: %d\n", _status);
@@ -4450,7 +4450,7 @@ void ActiveSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamU32) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamU32) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4509,7 +4509,7 @@ void ActiveSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamF64) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamF64) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4568,7 +4568,7 @@ void ActiveSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamString) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamString) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4627,7 +4627,7 @@ void ActiveSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamEnum) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamEnum) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4686,7 +4686,7 @@ void ActiveSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamArray) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamArray) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4745,7 +4745,7 @@ void ActiveSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamStruct) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamStruct) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4804,7 +4804,7 @@ void ActiveSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamI32Ext) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamI32Ext) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4863,7 +4863,7 @@ void ActiveSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamF64Ext) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamF64Ext) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4922,7 +4922,7 @@ void ActiveSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamStringExt) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamStringExt) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4981,7 +4981,7 @@ void ActiveSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamEnumExt) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamEnumExt) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -5040,7 +5040,7 @@ void ActiveSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamArrayExt) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamArrayExt) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -5099,7 +5099,7 @@ void ActiveSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamStructExt) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamStructExt) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -5498,7 +5498,7 @@ Fw::ParamValid ActiveSerialTesterBase ::
 
   switch (id - idBase) {
     case ActiveSerialComponentBase::PARAMID_PARAMU32: {
-      _status = val.serialize(_testerBase->m_param_ParamU32);
+      _status = val.serializeFrom(_testerBase->m_param_ParamU32);
       _ret = _testerBase->m_param_ParamU32_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5508,7 +5508,7 @@ Fw::ParamValid ActiveSerialTesterBase ::
     };
 
     case ActiveSerialComponentBase::PARAMID_PARAMF64: {
-      _status = val.serialize(_testerBase->m_param_ParamF64);
+      _status = val.serializeFrom(_testerBase->m_param_ParamF64);
       _ret = _testerBase->m_param_ParamF64_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5518,7 +5518,7 @@ Fw::ParamValid ActiveSerialTesterBase ::
     };
 
     case ActiveSerialComponentBase::PARAMID_PARAMSTRING: {
-      _status = val.serialize(_testerBase->m_param_ParamString);
+      _status = val.serializeFrom(_testerBase->m_param_ParamString);
       _ret = _testerBase->m_param_ParamString_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5528,7 +5528,7 @@ Fw::ParamValid ActiveSerialTesterBase ::
     };
 
     case ActiveSerialComponentBase::PARAMID_PARAMENUM: {
-      _status = val.serialize(_testerBase->m_param_ParamEnum);
+      _status = val.serializeFrom(_testerBase->m_param_ParamEnum);
       _ret = _testerBase->m_param_ParamEnum_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5538,7 +5538,7 @@ Fw::ParamValid ActiveSerialTesterBase ::
     };
 
     case ActiveSerialComponentBase::PARAMID_PARAMARRAY: {
-      _status = val.serialize(_testerBase->m_param_ParamArray);
+      _status = val.serializeFrom(_testerBase->m_param_ParamArray);
       _ret = _testerBase->m_param_ParamArray_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5548,7 +5548,7 @@ Fw::ParamValid ActiveSerialTesterBase ::
     };
 
     case ActiveSerialComponentBase::PARAMID_PARAMSTRUCT: {
-      _status = val.serialize(_testerBase->m_param_ParamStruct);
+      _status = val.serializeFrom(_testerBase->m_param_ParamStruct);
       _ret = _testerBase->m_param_ParamStruct_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5558,7 +5558,7 @@ Fw::ParamValid ActiveSerialTesterBase ::
     };
 
     case ActiveSerialComponentBase::PARAMID_PARAMI32EXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamI32Ext);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamI32Ext);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamI32Ext_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5568,7 +5568,7 @@ Fw::ParamValid ActiveSerialTesterBase ::
     };
 
     case ActiveSerialComponentBase::PARAMID_PARAMF64EXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamF64Ext);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamF64Ext);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamF64Ext_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5578,7 +5578,7 @@ Fw::ParamValid ActiveSerialTesterBase ::
     };
 
     case ActiveSerialComponentBase::PARAMID_PARAMSTRINGEXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamStringExt);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamStringExt);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamStringExt_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5588,7 +5588,7 @@ Fw::ParamValid ActiveSerialTesterBase ::
     };
 
     case ActiveSerialComponentBase::PARAMID_PARAMENUMEXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamEnumExt);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamEnumExt);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamEnumExt_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5598,7 +5598,7 @@ Fw::ParamValid ActiveSerialTesterBase ::
     };
 
     case ActiveSerialComponentBase::PARAMID_PARAMARRAYEXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamArrayExt);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamArrayExt);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamArrayExt_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5608,7 +5608,7 @@ Fw::ParamValid ActiveSerialTesterBase ::
     };
 
     case ActiveSerialComponentBase::PARAMID_PARAMSTRUCTEXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamStructExt);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamStructExt);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamStructExt_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5646,7 +5646,7 @@ void ActiveSerialTesterBase ::
   switch (id - idBase) {
     case ActiveSerialComponentBase::PARAMID_PARAMU32: {
       U32 ParamU32Val;
-      _status = val.deserialize(ParamU32Val);
+      _status = val.deserializeTo(ParamU32Val);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5660,7 +5660,7 @@ void ActiveSerialTesterBase ::
 
     case ActiveSerialComponentBase::PARAMID_PARAMF64: {
       F64 ParamF64Val;
-      _status = val.deserialize(ParamF64Val);
+      _status = val.deserializeTo(ParamF64Val);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5674,7 +5674,7 @@ void ActiveSerialTesterBase ::
 
     case ActiveSerialComponentBase::PARAMID_PARAMSTRING: {
       Fw::ParamString ParamStringVal;
-      _status = val.deserialize(ParamStringVal);
+      _status = val.deserializeTo(ParamStringVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5688,7 +5688,7 @@ void ActiveSerialTesterBase ::
 
     case ActiveSerialComponentBase::PARAMID_PARAMENUM: {
       E ParamEnumVal;
-      _status = val.deserialize(ParamEnumVal);
+      _status = val.deserializeTo(ParamEnumVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5702,7 +5702,7 @@ void ActiveSerialTesterBase ::
 
     case ActiveSerialComponentBase::PARAMID_PARAMARRAY: {
       A ParamArrayVal;
-      _status = val.deserialize(ParamArrayVal);
+      _status = val.deserializeTo(ParamArrayVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5716,7 +5716,7 @@ void ActiveSerialTesterBase ::
 
     case ActiveSerialComponentBase::PARAMID_PARAMSTRUCT: {
       S ParamStructVal;
-      _status = val.deserialize(ParamStructVal);
+      _status = val.deserializeTo(ParamStructVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5730,7 +5730,7 @@ void ActiveSerialTesterBase ::
 
     case ActiveSerialComponentBase::PARAMID_PARAMI32EXT: {
       I32 ParamI32ExtVal;
-      _status = val.deserialize(ParamI32ExtVal);
+      _status = val.deserializeTo(ParamI32ExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5744,7 +5744,7 @@ void ActiveSerialTesterBase ::
 
     case ActiveSerialComponentBase::PARAMID_PARAMF64EXT: {
       F64 ParamF64ExtVal;
-      _status = val.deserialize(ParamF64ExtVal);
+      _status = val.deserializeTo(ParamF64ExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5758,7 +5758,7 @@ void ActiveSerialTesterBase ::
 
     case ActiveSerialComponentBase::PARAMID_PARAMSTRINGEXT: {
       Fw::ParamString ParamStringExtVal;
-      _status = val.deserialize(ParamStringExtVal);
+      _status = val.deserializeTo(ParamStringExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5772,7 +5772,7 @@ void ActiveSerialTesterBase ::
 
     case ActiveSerialComponentBase::PARAMID_PARAMENUMEXT: {
       E ParamEnumExtVal;
-      _status = val.deserialize(ParamEnumExtVal);
+      _status = val.deserializeTo(ParamEnumExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5786,7 +5786,7 @@ void ActiveSerialTesterBase ::
 
     case ActiveSerialComponentBase::PARAMID_PARAMARRAYEXT: {
       A ParamArrayExtVal;
-      _status = val.deserialize(ParamArrayExtVal);
+      _status = val.deserializeTo(ParamArrayExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5800,7 +5800,7 @@ void ActiveSerialTesterBase ::
 
     case ActiveSerialComponentBase::PARAMID_PARAMSTRUCTEXT: {
       S ParamStructExtVal;
-      _status = val.deserialize(ParamStructExtVal);
+      _status = val.deserializeTo(ParamStructExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryTesterBase.ref.cpp
@@ -2321,7 +2321,7 @@ void ActiveTelemetryTesterBase ::
   switch (id - idBase) {
     case ActiveTelemetryComponentBase::CHANNELID_CHANNELU32FORMAT: {
       U32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelU32Format: %d\n", _status);
@@ -2334,7 +2334,7 @@ void ActiveTelemetryTesterBase ::
 
     case ActiveTelemetryComponentBase::CHANNELID_CHANNELF32FORMAT: {
       F32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelF32Format: %d\n", _status);
@@ -2347,7 +2347,7 @@ void ActiveTelemetryTesterBase ::
 
     case ActiveTelemetryComponentBase::CHANNELID_CHANNELSTRINGFORMAT: {
       Fw::TlmString arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelStringFormat: %d\n", _status);
@@ -2360,7 +2360,7 @@ void ActiveTelemetryTesterBase ::
 
     case ActiveTelemetryComponentBase::CHANNELID_CHANNELENUM: {
       E arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelEnum: %d\n", _status);
@@ -2373,7 +2373,7 @@ void ActiveTelemetryTesterBase ::
 
     case ActiveTelemetryComponentBase::CHANNELID_CHANNELARRAYFREQ: {
       A arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelArrayFreq: %d\n", _status);
@@ -2386,7 +2386,7 @@ void ActiveTelemetryTesterBase ::
 
     case ActiveTelemetryComponentBase::CHANNELID_CHANNELSTRUCTFREQ: {
       S arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelStructFreq: %d\n", _status);
@@ -2399,7 +2399,7 @@ void ActiveTelemetryTesterBase ::
 
     case ActiveTelemetryComponentBase::CHANNELID_CHANNELU32LIMITS: {
       U32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelU32Limits: %d\n", _status);
@@ -2412,7 +2412,7 @@ void ActiveTelemetryTesterBase ::
 
     case ActiveTelemetryComponentBase::CHANNELID_CHANNELF32LIMITS: {
       F32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelF32Limits: %d\n", _status);
@@ -2425,7 +2425,7 @@ void ActiveTelemetryTesterBase ::
 
     case ActiveTelemetryComponentBase::CHANNELID_CHANNELF64: {
       F64 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelF64: %d\n", _status);
@@ -2438,7 +2438,7 @@ void ActiveTelemetryTesterBase ::
 
     case ActiveTelemetryComponentBase::CHANNELID_CHANNELU32ONCHANGE: {
       U32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelU32OnChange: %d\n", _status);
@@ -2451,7 +2451,7 @@ void ActiveTelemetryTesterBase ::
 
     case ActiveTelemetryComponentBase::CHANNELID_CHANNELENUMONCHANGE: {
       E arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelEnumOnChange: %d\n", _status);

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.cpp
@@ -31,27 +31,27 @@ namespace M {
     {
       // ParamI32Ext
       case ActiveTestComponentBase::PARAMID_PARAMI32EXT:
-        stat = buff.deserialize(this->m_param_ParamI32Ext);
+        stat = buff.deserializeTo(this->m_param_ParamI32Ext);
         break;
       // ParamF64Ext
       case ActiveTestComponentBase::PARAMID_PARAMF64EXT:
-        stat = buff.deserialize(this->m_param_ParamF64Ext);
+        stat = buff.deserializeTo(this->m_param_ParamF64Ext);
         break;
       // ParamStringExt
       case ActiveTestComponentBase::PARAMID_PARAMSTRINGEXT:
-        stat = buff.deserialize(this->m_param_ParamStringExt);
+        stat = buff.deserializeTo(this->m_param_ParamStringExt);
         break;
       // ParamEnumExt
       case ActiveTestComponentBase::PARAMID_PARAMENUMEXT:
-        stat = buff.deserialize(this->m_param_ParamEnumExt);
+        stat = buff.deserializeTo(this->m_param_ParamEnumExt);
         break;
       // ParamArrayExt
       case ActiveTestComponentBase::PARAMID_PARAMARRAYEXT:
-        stat = buff.deserialize(this->m_param_ParamArrayExt);
+        stat = buff.deserializeTo(this->m_param_ParamArrayExt);
         break;
       // ParamStructExt
       case ActiveTestComponentBase::PARAMID_PARAMSTRUCTEXT:
-        stat = buff.deserialize(this->m_param_ParamStructExt);
+        stat = buff.deserializeTo(this->m_param_ParamStructExt);
         break;
       default:
         // Unknown ID; should not have gotten here
@@ -76,27 +76,27 @@ namespace M {
     {
       // ParamI32Ext
       case ActiveTestComponentBase::PARAMID_PARAMI32EXT:
-        stat = buff.serialize(this->m_param_ParamI32Ext);
+        stat = buff.serializeFrom(this->m_param_ParamI32Ext);
         break;
       // ParamF64Ext
       case ActiveTestComponentBase::PARAMID_PARAMF64EXT:
-        stat = buff.serialize(this->m_param_ParamF64Ext);
+        stat = buff.serializeFrom(this->m_param_ParamF64Ext);
         break;
       // ParamStringExt
       case ActiveTestComponentBase::PARAMID_PARAMSTRINGEXT:
-        stat = buff.serialize(this->m_param_ParamStringExt);
+        stat = buff.serializeFrom(this->m_param_ParamStringExt);
         break;
       // ParamEnumExt
       case ActiveTestComponentBase::PARAMID_PARAMENUMEXT:
-        stat = buff.serialize(this->m_param_ParamEnumExt);
+        stat = buff.serializeFrom(this->m_param_ParamEnumExt);
         break;
       // ParamArrayExt
       case ActiveTestComponentBase::PARAMID_PARAMARRAYEXT:
-        stat = buff.serialize(this->m_param_ParamArrayExt);
+        stat = buff.serializeFrom(this->m_param_ParamArrayExt);
         break;
       // ParamStructExt
       case ActiveTestComponentBase::PARAMID_PARAMSTRUCTEXT:
-        stat = buff.serialize(this->m_param_ParamStructExt);
+        stat = buff.serializeFrom(this->m_param_ParamStructExt);
         break;
       default:
         // Unknown ID; should not have gotten here
@@ -2806,19 +2806,19 @@ namespace M {
     Fw::CmdArgBuffer buf;
     Fw::SerializeStatus _status;
 
-    _status = buf.serialize(u32);
+    _status = buf.serializeFrom(u32);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = buf.serialize(f32);
+    _status = buf.serializeFrom(f32);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = buf.serialize(b);
+    _status = buf.serializeFrom(b);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -2853,13 +2853,13 @@ namespace M {
     Fw::CmdArgBuffer buf;
     Fw::SerializeStatus _status;
 
-    _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+    _status = str1.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+    _status = str2.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -2893,7 +2893,7 @@ namespace M {
     Fw::CmdArgBuffer buf;
     Fw::SerializeStatus _status;
 
-    _status = buf.serialize(e);
+    _status = buf.serializeFrom(e);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -2927,7 +2927,7 @@ namespace M {
     Fw::CmdArgBuffer buf;
     Fw::SerializeStatus _status;
 
-    _status = buf.serialize(a);
+    _status = buf.serializeFrom(a);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -2961,7 +2961,7 @@ namespace M {
     Fw::CmdArgBuffer buf;
     Fw::SerializeStatus _status;
 
-    _status = buf.serialize(s);
+    _status = buf.serializeFrom(s);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3022,19 +3022,19 @@ namespace M {
     Fw::CmdArgBuffer buf;
     Fw::SerializeStatus _status;
 
-    _status = buf.serialize(u32);
+    _status = buf.serializeFrom(u32);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = buf.serialize(f32);
+    _status = buf.serializeFrom(f32);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = buf.serialize(b);
+    _status = buf.serializeFrom(b);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3069,13 +3069,13 @@ namespace M {
     Fw::CmdArgBuffer buf;
     Fw::SerializeStatus _status;
 
-    _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+    _status = str1.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
     );
 
-    _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+    _status = str2.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3109,7 +3109,7 @@ namespace M {
     Fw::CmdArgBuffer buf;
     Fw::SerializeStatus _status;
 
-    _status = buf.serialize(e);
+    _status = buf.serializeFrom(e);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3143,7 +3143,7 @@ namespace M {
     Fw::CmdArgBuffer buf;
     Fw::SerializeStatus _status;
 
-    _status = buf.serialize(a);
+    _status = buf.serializeFrom(a);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3177,7 +3177,7 @@ namespace M {
     Fw::CmdArgBuffer buf;
     Fw::SerializeStatus _status;
 
-    _status = buf.serialize(s);
+    _status = buf.serializeFrom(s);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3261,7 +3261,7 @@ namespace M {
     Fw::CmdArgBuffer buf;
     Fw::SerializeStatus _status;
 
-    _status = buf.serialize(u32);
+    _status = buf.serializeFrom(u32);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3320,7 +3320,7 @@ namespace M {
     Fw::CmdArgBuffer buf;
     Fw::SerializeStatus _status;
 
-    _status = buf.serialize(u32);
+    _status = buf.serializeFrom(u32);
     FW_ASSERT(
       _status == Fw::FW_SERIALIZE_OK,
       static_cast<FwAssertArgType>(_status)
@@ -3370,7 +3370,7 @@ namespace M {
         // For AMPCS, decode zero arguments
         Fw::SerializeStatus _zero_status = Fw::FW_SERIALIZE_OK;
         U8 _noArgs;
-        _zero_status = args.deserialize(_noArgs);
+        _zero_status = args.deserializeTo(_noArgs);
         FW_ASSERT(
           _zero_status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_zero_status)
@@ -3386,7 +3386,7 @@ namespace M {
 #if FW_AMPCS_COMPATIBLE
         // Deserialize the number of arguments.
         U8 _numArgs;
-        _status = args.deserialize(_numArgs);
+        _status = args.deserializeTo(_numArgs);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3404,7 +3404,7 @@ namespace M {
         {
           // Deserialize the argument size
           U8 _argSize;
-          _status = args.deserialize(_argSize);
+          _status = args.deserializeTo(_argSize);
           FW_ASSERT(
             _status == Fw::FW_SERIALIZE_OK,
             static_cast<FwAssertArgType>(_status)
@@ -3416,7 +3416,7 @@ namespace M {
           );
         }
 #endif
-        _status = args.deserialize(_event_arg_u32);
+        _status = args.deserializeTo(_event_arg_u32);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3427,7 +3427,7 @@ namespace M {
         {
           // Deserialize the argument size
           U8 _argSize;
-          _status = args.deserialize(_argSize);
+          _status = args.deserializeTo(_argSize);
           FW_ASSERT(
             _status == Fw::FW_SERIALIZE_OK,
             static_cast<FwAssertArgType>(_status)
@@ -3439,7 +3439,7 @@ namespace M {
           );
         }
 #endif
-        _status = args.deserialize(_event_arg_f32);
+        _status = args.deserializeTo(_event_arg_f32);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3450,7 +3450,7 @@ namespace M {
         {
           // Deserialize the argument size
           U8 _argSize;
-          _status = args.deserialize(_argSize);
+          _status = args.deserializeTo(_argSize);
           FW_ASSERT(
             _status == Fw::FW_SERIALIZE_OK,
             static_cast<FwAssertArgType>(_status)
@@ -3462,7 +3462,7 @@ namespace M {
           );
         }
 #endif
-        _status = args.deserialize(_event_arg_b);
+        _status = args.deserializeTo(_event_arg_b);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3477,7 +3477,7 @@ namespace M {
 #if FW_AMPCS_COMPATIBLE
         // Deserialize the number of arguments.
         U8 _numArgs;
-        _status = args.deserialize(_numArgs);
+        _status = args.deserializeTo(_numArgs);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3495,7 +3495,7 @@ namespace M {
         {
           // Deserialize the argument size
           U8 _argSize;
-          _status = args.deserialize(_argSize);
+          _status = args.deserializeTo(_argSize);
           FW_ASSERT(
             _status == Fw::FW_SERIALIZE_OK,
             static_cast<FwAssertArgType>(_status)
@@ -3507,7 +3507,7 @@ namespace M {
           );
         }
 #endif
-        _status = args.deserialize(_event_arg_str1);
+        _status = args.deserializeTo(_event_arg_str1);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3518,7 +3518,7 @@ namespace M {
         {
           // Deserialize the argument size
           U8 _argSize;
-          _status = args.deserialize(_argSize);
+          _status = args.deserializeTo(_argSize);
           FW_ASSERT(
             _status == Fw::FW_SERIALIZE_OK,
             static_cast<FwAssertArgType>(_status)
@@ -3530,7 +3530,7 @@ namespace M {
           );
         }
 #endif
-        _status = args.deserialize(_event_arg_str2);
+        _status = args.deserializeTo(_event_arg_str2);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3545,7 +3545,7 @@ namespace M {
 #if FW_AMPCS_COMPATIBLE
         // Deserialize the number of arguments.
         U8 _numArgs;
-        _status = args.deserialize(_numArgs);
+        _status = args.deserializeTo(_numArgs);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3563,7 +3563,7 @@ namespace M {
         {
           // Deserialize the argument size
           U8 _argSize;
-          _status = args.deserialize(_argSize);
+          _status = args.deserializeTo(_argSize);
           FW_ASSERT(
             _status == Fw::FW_SERIALIZE_OK,
             static_cast<FwAssertArgType>(_status)
@@ -3575,7 +3575,7 @@ namespace M {
           );
         }
 #endif
-        _status = args.deserialize(_event_arg_e);
+        _status = args.deserializeTo(_event_arg_e);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3590,7 +3590,7 @@ namespace M {
 #if FW_AMPCS_COMPATIBLE
         // Deserialize the number of arguments.
         U8 _numArgs;
-        _status = args.deserialize(_numArgs);
+        _status = args.deserializeTo(_numArgs);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3604,7 +3604,7 @@ namespace M {
 
         // For FATAL, there is a stack size of 4 and a dummy entry
         U8 stackArgLen;
-        _status = args.deserialize(stackArgLen);
+        _status = args.deserializeTo(stackArgLen);
         FW_ASSERT(
             _status == Fw::FW_SERIALIZE_OK,
             static_cast<FwAssertArgType>(_status)
@@ -3615,7 +3615,7 @@ namespace M {
         );
 
         U32 dummyStackArg;
-        _status = args.deserialize(dummyStackArg);
+        _status = args.deserializeTo(dummyStackArg);
         FW_ASSERT(
             _status == Fw::FW_SERIALIZE_OK,
             static_cast<FwAssertArgType>(_status)
@@ -3631,7 +3631,7 @@ namespace M {
         {
           // Deserialize the argument size
           U8 _argSize;
-          _status = args.deserialize(_argSize);
+          _status = args.deserializeTo(_argSize);
           FW_ASSERT(
             _status == Fw::FW_SERIALIZE_OK,
             static_cast<FwAssertArgType>(_status)
@@ -3643,7 +3643,7 @@ namespace M {
           );
         }
 #endif
-        _status = args.deserialize(_event_arg_a);
+        _status = args.deserializeTo(_event_arg_a);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3658,7 +3658,7 @@ namespace M {
 #if FW_AMPCS_COMPATIBLE
         // Deserialize the number of arguments.
         U8 _numArgs;
-        _status = args.deserialize(_numArgs);
+        _status = args.deserializeTo(_numArgs);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3676,7 +3676,7 @@ namespace M {
         {
           // Deserialize the argument size
           U8 _argSize;
-          _status = args.deserialize(_argSize);
+          _status = args.deserializeTo(_argSize);
           FW_ASSERT(
             _status == Fw::FW_SERIALIZE_OK,
             static_cast<FwAssertArgType>(_status)
@@ -3688,7 +3688,7 @@ namespace M {
           );
         }
 #endif
-        _status = args.deserialize(_event_arg_s);
+        _status = args.deserializeTo(_event_arg_s);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3702,7 +3702,7 @@ namespace M {
         // For AMPCS, decode zero arguments
         Fw::SerializeStatus _zero_status = Fw::FW_SERIALIZE_OK;
         U8 _noArgs;
-        _zero_status = args.deserialize(_noArgs);
+        _zero_status = args.deserializeTo(_noArgs);
         FW_ASSERT(
           _zero_status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_zero_status)
@@ -3832,7 +3832,7 @@ namespace M {
     switch (id - idBase) {
       case ActiveTestComponentBase::CHANNELID_CHANNELU32FORMAT: {
         U32 arg;
-        const Fw::SerializeStatus _status = val.deserialize(arg);
+        const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
         if (_status != Fw::FW_SERIALIZE_OK) {
           printf("Error deserializing ChannelU32Format: %d\n", _status);
@@ -3845,7 +3845,7 @@ namespace M {
 
       case ActiveTestComponentBase::CHANNELID_CHANNELF32FORMAT: {
         F32 arg;
-        const Fw::SerializeStatus _status = val.deserialize(arg);
+        const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
         if (_status != Fw::FW_SERIALIZE_OK) {
           printf("Error deserializing ChannelF32Format: %d\n", _status);
@@ -3858,7 +3858,7 @@ namespace M {
 
       case ActiveTestComponentBase::CHANNELID_CHANNELSTRINGFORMAT: {
         Fw::TlmString arg;
-        const Fw::SerializeStatus _status = val.deserialize(arg);
+        const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
         if (_status != Fw::FW_SERIALIZE_OK) {
           printf("Error deserializing ChannelStringFormat: %d\n", _status);
@@ -3871,7 +3871,7 @@ namespace M {
 
       case ActiveTestComponentBase::CHANNELID_CHANNELENUM: {
         E arg;
-        const Fw::SerializeStatus _status = val.deserialize(arg);
+        const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
         if (_status != Fw::FW_SERIALIZE_OK) {
           printf("Error deserializing ChannelEnum: %d\n", _status);
@@ -3884,7 +3884,7 @@ namespace M {
 
       case ActiveTestComponentBase::CHANNELID_CHANNELARRAYFREQ: {
         A arg;
-        const Fw::SerializeStatus _status = val.deserialize(arg);
+        const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
         if (_status != Fw::FW_SERIALIZE_OK) {
           printf("Error deserializing ChannelArrayFreq: %d\n", _status);
@@ -3897,7 +3897,7 @@ namespace M {
 
       case ActiveTestComponentBase::CHANNELID_CHANNELSTRUCTFREQ: {
         S arg;
-        const Fw::SerializeStatus _status = val.deserialize(arg);
+        const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
         if (_status != Fw::FW_SERIALIZE_OK) {
           printf("Error deserializing ChannelStructFreq: %d\n", _status);
@@ -3910,7 +3910,7 @@ namespace M {
 
       case ActiveTestComponentBase::CHANNELID_CHANNELU32LIMITS: {
         U32 arg;
-        const Fw::SerializeStatus _status = val.deserialize(arg);
+        const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
         if (_status != Fw::FW_SERIALIZE_OK) {
           printf("Error deserializing ChannelU32Limits: %d\n", _status);
@@ -3923,7 +3923,7 @@ namespace M {
 
       case ActiveTestComponentBase::CHANNELID_CHANNELF32LIMITS: {
         F32 arg;
-        const Fw::SerializeStatus _status = val.deserialize(arg);
+        const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
         if (_status != Fw::FW_SERIALIZE_OK) {
           printf("Error deserializing ChannelF32Limits: %d\n", _status);
@@ -3936,7 +3936,7 @@ namespace M {
 
       case ActiveTestComponentBase::CHANNELID_CHANNELF64: {
         F64 arg;
-        const Fw::SerializeStatus _status = val.deserialize(arg);
+        const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
         if (_status != Fw::FW_SERIALIZE_OK) {
           printf("Error deserializing ChannelF64: %d\n", _status);
@@ -3949,7 +3949,7 @@ namespace M {
 
       case ActiveTestComponentBase::CHANNELID_CHANNELU32ONCHANGE: {
         U32 arg;
-        const Fw::SerializeStatus _status = val.deserialize(arg);
+        const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
         if (_status != Fw::FW_SERIALIZE_OK) {
           printf("Error deserializing ChannelU32OnChange: %d\n", _status);
@@ -3962,7 +3962,7 @@ namespace M {
 
       case ActiveTestComponentBase::CHANNELID_CHANNELENUMONCHANGE: {
         E arg;
-        const Fw::SerializeStatus _status = val.deserialize(arg);
+        const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
         if (_status != Fw::FW_SERIALIZE_OK) {
           printf("Error deserializing ChannelEnumOnChange: %d\n", _status);
@@ -4124,7 +4124,7 @@ namespace M {
     // Build command for parameter set
     Fw::CmdArgBuffer args;
     FW_ASSERT(
-      args.serialize(this->m_param_ParamU32) == Fw::FW_SERIALIZE_OK
+      args.serializeFrom(this->m_param_ParamU32) == Fw::FW_SERIALIZE_OK
     );
 
     const U32 idBase = this->getIdBase();
@@ -4183,7 +4183,7 @@ namespace M {
     // Build command for parameter set
     Fw::CmdArgBuffer args;
     FW_ASSERT(
-      args.serialize(this->m_param_ParamF64) == Fw::FW_SERIALIZE_OK
+      args.serializeFrom(this->m_param_ParamF64) == Fw::FW_SERIALIZE_OK
     );
 
     const U32 idBase = this->getIdBase();
@@ -4242,7 +4242,7 @@ namespace M {
     // Build command for parameter set
     Fw::CmdArgBuffer args;
     FW_ASSERT(
-      args.serialize(this->m_param_ParamString) == Fw::FW_SERIALIZE_OK
+      args.serializeFrom(this->m_param_ParamString) == Fw::FW_SERIALIZE_OK
     );
 
     const U32 idBase = this->getIdBase();
@@ -4301,7 +4301,7 @@ namespace M {
     // Build command for parameter set
     Fw::CmdArgBuffer args;
     FW_ASSERT(
-      args.serialize(this->m_param_ParamEnum) == Fw::FW_SERIALIZE_OK
+      args.serializeFrom(this->m_param_ParamEnum) == Fw::FW_SERIALIZE_OK
     );
 
     const U32 idBase = this->getIdBase();
@@ -4360,7 +4360,7 @@ namespace M {
     // Build command for parameter set
     Fw::CmdArgBuffer args;
     FW_ASSERT(
-      args.serialize(this->m_param_ParamArray) == Fw::FW_SERIALIZE_OK
+      args.serializeFrom(this->m_param_ParamArray) == Fw::FW_SERIALIZE_OK
     );
 
     const U32 idBase = this->getIdBase();
@@ -4419,7 +4419,7 @@ namespace M {
     // Build command for parameter set
     Fw::CmdArgBuffer args;
     FW_ASSERT(
-      args.serialize(this->m_param_ParamStruct) == Fw::FW_SERIALIZE_OK
+      args.serializeFrom(this->m_param_ParamStruct) == Fw::FW_SERIALIZE_OK
     );
 
     const U32 idBase = this->getIdBase();
@@ -4478,7 +4478,7 @@ namespace M {
     // Build command for parameter set
     Fw::CmdArgBuffer args;
     FW_ASSERT(
-      args.serialize(this->paramTesterDelegate.m_param_ParamI32Ext) == Fw::FW_SERIALIZE_OK
+      args.serializeFrom(this->paramTesterDelegate.m_param_ParamI32Ext) == Fw::FW_SERIALIZE_OK
     );
 
     const U32 idBase = this->getIdBase();
@@ -4537,7 +4537,7 @@ namespace M {
     // Build command for parameter set
     Fw::CmdArgBuffer args;
     FW_ASSERT(
-      args.serialize(this->paramTesterDelegate.m_param_ParamF64Ext) == Fw::FW_SERIALIZE_OK
+      args.serializeFrom(this->paramTesterDelegate.m_param_ParamF64Ext) == Fw::FW_SERIALIZE_OK
     );
 
     const U32 idBase = this->getIdBase();
@@ -4596,7 +4596,7 @@ namespace M {
     // Build command for parameter set
     Fw::CmdArgBuffer args;
     FW_ASSERT(
-      args.serialize(this->paramTesterDelegate.m_param_ParamStringExt) == Fw::FW_SERIALIZE_OK
+      args.serializeFrom(this->paramTesterDelegate.m_param_ParamStringExt) == Fw::FW_SERIALIZE_OK
     );
 
     const U32 idBase = this->getIdBase();
@@ -4655,7 +4655,7 @@ namespace M {
     // Build command for parameter set
     Fw::CmdArgBuffer args;
     FW_ASSERT(
-      args.serialize(this->paramTesterDelegate.m_param_ParamEnumExt) == Fw::FW_SERIALIZE_OK
+      args.serializeFrom(this->paramTesterDelegate.m_param_ParamEnumExt) == Fw::FW_SERIALIZE_OK
     );
 
     const U32 idBase = this->getIdBase();
@@ -4714,7 +4714,7 @@ namespace M {
     // Build command for parameter set
     Fw::CmdArgBuffer args;
     FW_ASSERT(
-      args.serialize(this->paramTesterDelegate.m_param_ParamArrayExt) == Fw::FW_SERIALIZE_OK
+      args.serializeFrom(this->paramTesterDelegate.m_param_ParamArrayExt) == Fw::FW_SERIALIZE_OK
     );
 
     const U32 idBase = this->getIdBase();
@@ -4773,7 +4773,7 @@ namespace M {
     // Build command for parameter set
     Fw::CmdArgBuffer args;
     FW_ASSERT(
-      args.serialize(this->paramTesterDelegate.m_param_ParamStructExt) == Fw::FW_SERIALIZE_OK
+      args.serializeFrom(this->paramTesterDelegate.m_param_ParamStructExt) == Fw::FW_SERIALIZE_OK
     );
 
     const U32 idBase = this->getIdBase();
@@ -5228,7 +5228,7 @@ namespace M {
 
     switch (id - idBase) {
       case ActiveTestComponentBase::PARAMID_PARAMU32: {
-        _status = val.serialize(_testerBase->m_param_ParamU32);
+        _status = val.serializeFrom(_testerBase->m_param_ParamU32);
         _ret = _testerBase->m_param_ParamU32_valid;
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
@@ -5238,7 +5238,7 @@ namespace M {
       };
 
       case ActiveTestComponentBase::PARAMID_PARAMF64: {
-        _status = val.serialize(_testerBase->m_param_ParamF64);
+        _status = val.serializeFrom(_testerBase->m_param_ParamF64);
         _ret = _testerBase->m_param_ParamF64_valid;
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
@@ -5248,7 +5248,7 @@ namespace M {
       };
 
       case ActiveTestComponentBase::PARAMID_PARAMSTRING: {
-        _status = val.serialize(_testerBase->m_param_ParamString);
+        _status = val.serializeFrom(_testerBase->m_param_ParamString);
         _ret = _testerBase->m_param_ParamString_valid;
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
@@ -5258,7 +5258,7 @@ namespace M {
       };
 
       case ActiveTestComponentBase::PARAMID_PARAMENUM: {
-        _status = val.serialize(_testerBase->m_param_ParamEnum);
+        _status = val.serializeFrom(_testerBase->m_param_ParamEnum);
         _ret = _testerBase->m_param_ParamEnum_valid;
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
@@ -5268,7 +5268,7 @@ namespace M {
       };
 
       case ActiveTestComponentBase::PARAMID_PARAMARRAY: {
-        _status = val.serialize(_testerBase->m_param_ParamArray);
+        _status = val.serializeFrom(_testerBase->m_param_ParamArray);
         _ret = _testerBase->m_param_ParamArray_valid;
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
@@ -5278,7 +5278,7 @@ namespace M {
       };
 
       case ActiveTestComponentBase::PARAMID_PARAMSTRUCT: {
-        _status = val.serialize(_testerBase->m_param_ParamStruct);
+        _status = val.serializeFrom(_testerBase->m_param_ParamStruct);
         _ret = _testerBase->m_param_ParamStruct_valid;
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
@@ -5288,7 +5288,7 @@ namespace M {
       };
 
       case ActiveTestComponentBase::PARAMID_PARAMI32EXT: {
-        _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamI32Ext);
+        _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamI32Ext);
         _ret = _testerBase->paramTesterDelegate.m_param_ParamI32Ext_valid;
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
@@ -5298,7 +5298,7 @@ namespace M {
       };
 
       case ActiveTestComponentBase::PARAMID_PARAMF64EXT: {
-        _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamF64Ext);
+        _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamF64Ext);
         _ret = _testerBase->paramTesterDelegate.m_param_ParamF64Ext_valid;
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
@@ -5308,7 +5308,7 @@ namespace M {
       };
 
       case ActiveTestComponentBase::PARAMID_PARAMSTRINGEXT: {
-        _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamStringExt);
+        _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamStringExt);
         _ret = _testerBase->paramTesterDelegate.m_param_ParamStringExt_valid;
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
@@ -5318,7 +5318,7 @@ namespace M {
       };
 
       case ActiveTestComponentBase::PARAMID_PARAMENUMEXT: {
-        _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamEnumExt);
+        _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamEnumExt);
         _ret = _testerBase->paramTesterDelegate.m_param_ParamEnumExt_valid;
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
@@ -5328,7 +5328,7 @@ namespace M {
       };
 
       case ActiveTestComponentBase::PARAMID_PARAMARRAYEXT: {
-        _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamArrayExt);
+        _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamArrayExt);
         _ret = _testerBase->paramTesterDelegate.m_param_ParamArrayExt_valid;
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
@@ -5338,7 +5338,7 @@ namespace M {
       };
 
       case ActiveTestComponentBase::PARAMID_PARAMSTRUCTEXT: {
-        _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamStructExt);
+        _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamStructExt);
         _ret = _testerBase->paramTesterDelegate.m_param_ParamStructExt_valid;
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
@@ -5376,7 +5376,7 @@ namespace M {
     switch (id - idBase) {
       case ActiveTestComponentBase::PARAMID_PARAMU32: {
         U32 ParamU32Val;
-        _status = val.deserialize(ParamU32Val);
+        _status = val.deserializeTo(ParamU32Val);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -5390,7 +5390,7 @@ namespace M {
 
       case ActiveTestComponentBase::PARAMID_PARAMF64: {
         F64 ParamF64Val;
-        _status = val.deserialize(ParamF64Val);
+        _status = val.deserializeTo(ParamF64Val);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -5404,7 +5404,7 @@ namespace M {
 
       case ActiveTestComponentBase::PARAMID_PARAMSTRING: {
         Fw::ParamString ParamStringVal;
-        _status = val.deserialize(ParamStringVal);
+        _status = val.deserializeTo(ParamStringVal);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -5418,7 +5418,7 @@ namespace M {
 
       case ActiveTestComponentBase::PARAMID_PARAMENUM: {
         E ParamEnumVal;
-        _status = val.deserialize(ParamEnumVal);
+        _status = val.deserializeTo(ParamEnumVal);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -5432,7 +5432,7 @@ namespace M {
 
       case ActiveTestComponentBase::PARAMID_PARAMARRAY: {
         A ParamArrayVal;
-        _status = val.deserialize(ParamArrayVal);
+        _status = val.deserializeTo(ParamArrayVal);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -5446,7 +5446,7 @@ namespace M {
 
       case ActiveTestComponentBase::PARAMID_PARAMSTRUCT: {
         S ParamStructVal;
-        _status = val.deserialize(ParamStructVal);
+        _status = val.deserializeTo(ParamStructVal);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -5460,7 +5460,7 @@ namespace M {
 
       case ActiveTestComponentBase::PARAMID_PARAMI32EXT: {
         I32 ParamI32ExtVal;
-        _status = val.deserialize(ParamI32ExtVal);
+        _status = val.deserializeTo(ParamI32ExtVal);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -5474,7 +5474,7 @@ namespace M {
 
       case ActiveTestComponentBase::PARAMID_PARAMF64EXT: {
         F64 ParamF64ExtVal;
-        _status = val.deserialize(ParamF64ExtVal);
+        _status = val.deserializeTo(ParamF64ExtVal);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -5488,7 +5488,7 @@ namespace M {
 
       case ActiveTestComponentBase::PARAMID_PARAMSTRINGEXT: {
         Fw::ParamString ParamStringExtVal;
-        _status = val.deserialize(ParamStringExtVal);
+        _status = val.deserializeTo(ParamStringExtVal);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -5502,7 +5502,7 @@ namespace M {
 
       case ActiveTestComponentBase::PARAMID_PARAMENUMEXT: {
         E ParamEnumExtVal;
-        _status = val.deserialize(ParamEnumExtVal);
+        _status = val.deserializeTo(ParamEnumExtVal);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -5516,7 +5516,7 @@ namespace M {
 
       case ActiveTestComponentBase::PARAMID_PARAMARRAYEXT: {
         A ParamArrayExtVal;
-        _status = val.deserialize(ParamArrayExtVal);
+        _status = val.deserializeTo(ParamArrayExtVal);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -5530,7 +5530,7 @@ namespace M {
 
       case ActiveTestComponentBase::PARAMID_PARAMSTRUCTEXT: {
         S ParamStructExtVal;
-        _status = val.deserialize(ParamStructExtVal);
+        _status = val.deserializeTo(ParamStructExtVal);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsTesterBase.ref.cpp
@@ -1944,19 +1944,19 @@ void PassiveCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(u32);
+  _status = buf.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(f32);
+  _status = buf.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(b);
+  _status = buf.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -1991,13 +1991,13 @@ void PassiveCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+  _status = str1.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+  _status = str2.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2031,7 +2031,7 @@ void PassiveCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(e);
+  _status = buf.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2065,7 +2065,7 @@ void PassiveCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(a);
+  _status = buf.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2099,7 +2099,7 @@ void PassiveCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(s);
+  _status = buf.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2160,19 +2160,19 @@ void PassiveCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(u32);
+  _status = buf.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(f32);
+  _status = buf.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(b);
+  _status = buf.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2207,13 +2207,13 @@ void PassiveCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+  _status = str1.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+  _status = str2.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2247,7 +2247,7 @@ void PassiveCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(e);
+  _status = buf.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2281,7 +2281,7 @@ void PassiveCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(a);
+  _status = buf.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2315,7 +2315,7 @@ void PassiveCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(s);
+  _status = buf.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsTesterBase.ref.cpp
@@ -1894,7 +1894,7 @@ void PassiveEventsTesterBase ::
       // For AMPCS, decode zero arguments
       Fw::SerializeStatus _zero_status = Fw::FW_SERIALIZE_OK;
       U8 _noArgs;
-      _zero_status = args.deserialize(_noArgs);
+      _zero_status = args.deserializeTo(_noArgs);
       FW_ASSERT(
         _zero_status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_zero_status)
@@ -1910,7 +1910,7 @@ void PassiveEventsTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -1928,7 +1928,7 @@ void PassiveEventsTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -1940,7 +1940,7 @@ void PassiveEventsTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_u32);
+      _status = args.deserializeTo(_event_arg_u32);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -1951,7 +1951,7 @@ void PassiveEventsTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -1963,7 +1963,7 @@ void PassiveEventsTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_f32);
+      _status = args.deserializeTo(_event_arg_f32);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -1974,7 +1974,7 @@ void PassiveEventsTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -1986,7 +1986,7 @@ void PassiveEventsTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_b);
+      _status = args.deserializeTo(_event_arg_b);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2001,7 +2001,7 @@ void PassiveEventsTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2019,7 +2019,7 @@ void PassiveEventsTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2031,7 +2031,7 @@ void PassiveEventsTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_str1);
+      _status = args.deserializeTo(_event_arg_str1);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2042,7 +2042,7 @@ void PassiveEventsTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2054,7 +2054,7 @@ void PassiveEventsTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_str2);
+      _status = args.deserializeTo(_event_arg_str2);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2069,7 +2069,7 @@ void PassiveEventsTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2087,7 +2087,7 @@ void PassiveEventsTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2099,7 +2099,7 @@ void PassiveEventsTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_e);
+      _status = args.deserializeTo(_event_arg_e);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2114,7 +2114,7 @@ void PassiveEventsTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2128,7 +2128,7 @@ void PassiveEventsTesterBase ::
 
       // For FATAL, there is a stack size of 4 and a dummy entry
       U8 stackArgLen;
-      _status = args.deserialize(stackArgLen);
+      _status = args.deserializeTo(stackArgLen);
       FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2139,7 +2139,7 @@ void PassiveEventsTesterBase ::
       );
 
       U32 dummyStackArg;
-      _status = args.deserialize(dummyStackArg);
+      _status = args.deserializeTo(dummyStackArg);
       FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2155,7 +2155,7 @@ void PassiveEventsTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2167,7 +2167,7 @@ void PassiveEventsTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_a);
+      _status = args.deserializeTo(_event_arg_a);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2182,7 +2182,7 @@ void PassiveEventsTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2200,7 +2200,7 @@ void PassiveEventsTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2212,7 +2212,7 @@ void PassiveEventsTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_s);
+      _status = args.deserializeTo(_event_arg_s);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2226,7 +2226,7 @@ void PassiveEventsTesterBase ::
       // For AMPCS, decode zero arguments
       Fw::SerializeStatus _zero_status = Fw::FW_SERIALIZE_OK;
       U8 _noArgs;
-      _zero_status = args.deserialize(_noArgs);
+      _zero_status = args.deserializeTo(_noArgs);
       FW_ASSERT(
         _zero_status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_zero_status)

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveExternalParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveExternalParamsTesterBase.ref.cpp
@@ -29,27 +29,27 @@ Fw::SerializeStatus PassiveExternalParamsTesterBase::PassiveExternalParamsCompon
   {
     // ParamI32Ext
     case PassiveExternalParamsComponentBase::PARAMID_PARAMI32EXT:
-      stat = buff.deserialize(this->m_param_ParamI32Ext);
+      stat = buff.deserializeTo(this->m_param_ParamI32Ext);
       break;
     // ParamF64Ext
     case PassiveExternalParamsComponentBase::PARAMID_PARAMF64EXT:
-      stat = buff.deserialize(this->m_param_ParamF64Ext);
+      stat = buff.deserializeTo(this->m_param_ParamF64Ext);
       break;
     // ParamStringExt
     case PassiveExternalParamsComponentBase::PARAMID_PARAMSTRINGEXT:
-      stat = buff.deserialize(this->m_param_ParamStringExt);
+      stat = buff.deserializeTo(this->m_param_ParamStringExt);
       break;
     // ParamEnumExt
     case PassiveExternalParamsComponentBase::PARAMID_PARAMENUMEXT:
-      stat = buff.deserialize(this->m_param_ParamEnumExt);
+      stat = buff.deserializeTo(this->m_param_ParamEnumExt);
       break;
     // ParamArrayExt
     case PassiveExternalParamsComponentBase::PARAMID_PARAMARRAYEXT:
-      stat = buff.deserialize(this->m_param_ParamArrayExt);
+      stat = buff.deserializeTo(this->m_param_ParamArrayExt);
       break;
     // ParamStructExt
     case PassiveExternalParamsComponentBase::PARAMID_PARAMSTRUCTEXT:
-      stat = buff.deserialize(this->m_param_ParamStructExt);
+      stat = buff.deserializeTo(this->m_param_ParamStructExt);
       break;
     default:
       // Unknown ID; should not have gotten here
@@ -74,27 +74,27 @@ Fw::SerializeStatus PassiveExternalParamsTesterBase::PassiveExternalParamsCompon
   {
     // ParamI32Ext
     case PassiveExternalParamsComponentBase::PARAMID_PARAMI32EXT:
-      stat = buff.serialize(this->m_param_ParamI32Ext);
+      stat = buff.serializeFrom(this->m_param_ParamI32Ext);
       break;
     // ParamF64Ext
     case PassiveExternalParamsComponentBase::PARAMID_PARAMF64EXT:
-      stat = buff.serialize(this->m_param_ParamF64Ext);
+      stat = buff.serializeFrom(this->m_param_ParamF64Ext);
       break;
     // ParamStringExt
     case PassiveExternalParamsComponentBase::PARAMID_PARAMSTRINGEXT:
-      stat = buff.serialize(this->m_param_ParamStringExt);
+      stat = buff.serializeFrom(this->m_param_ParamStringExt);
       break;
     // ParamEnumExt
     case PassiveExternalParamsComponentBase::PARAMID_PARAMENUMEXT:
-      stat = buff.serialize(this->m_param_ParamEnumExt);
+      stat = buff.serializeFrom(this->m_param_ParamEnumExt);
       break;
     // ParamArrayExt
     case PassiveExternalParamsComponentBase::PARAMID_PARAMARRAYEXT:
-      stat = buff.serialize(this->m_param_ParamArrayExt);
+      stat = buff.serializeFrom(this->m_param_ParamArrayExt);
       break;
     // ParamStructExt
     case PassiveExternalParamsComponentBase::PARAMID_PARAMSTRUCTEXT:
-      stat = buff.serialize(this->m_param_ParamStructExt);
+      stat = buff.serializeFrom(this->m_param_ParamStructExt);
       break;
     default:
       // Unknown ID; should not have gotten here
@@ -2072,7 +2072,7 @@ void PassiveExternalParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamI32Ext) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamI32Ext) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -2131,7 +2131,7 @@ void PassiveExternalParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamF64Ext) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamF64Ext) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -2190,7 +2190,7 @@ void PassiveExternalParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamStringExt) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamStringExt) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -2249,7 +2249,7 @@ void PassiveExternalParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamEnumExt) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamEnumExt) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -2308,7 +2308,7 @@ void PassiveExternalParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamArrayExt) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamArrayExt) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -2367,7 +2367,7 @@ void PassiveExternalParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamStructExt) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamStructExt) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -2629,7 +2629,7 @@ Fw::ParamValid PassiveExternalParamsTesterBase ::
 
   switch (id - idBase) {
     case PassiveExternalParamsComponentBase::PARAMID_PARAMI32EXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamI32Ext);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamI32Ext);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamI32Ext_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -2639,7 +2639,7 @@ Fw::ParamValid PassiveExternalParamsTesterBase ::
     };
 
     case PassiveExternalParamsComponentBase::PARAMID_PARAMF64EXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamF64Ext);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamF64Ext);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamF64Ext_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -2649,7 +2649,7 @@ Fw::ParamValid PassiveExternalParamsTesterBase ::
     };
 
     case PassiveExternalParamsComponentBase::PARAMID_PARAMSTRINGEXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamStringExt);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamStringExt);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamStringExt_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -2659,7 +2659,7 @@ Fw::ParamValid PassiveExternalParamsTesterBase ::
     };
 
     case PassiveExternalParamsComponentBase::PARAMID_PARAMENUMEXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamEnumExt);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamEnumExt);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamEnumExt_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -2669,7 +2669,7 @@ Fw::ParamValid PassiveExternalParamsTesterBase ::
     };
 
     case PassiveExternalParamsComponentBase::PARAMID_PARAMARRAYEXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamArrayExt);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamArrayExt);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamArrayExt_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -2679,7 +2679,7 @@ Fw::ParamValid PassiveExternalParamsTesterBase ::
     };
 
     case PassiveExternalParamsComponentBase::PARAMID_PARAMSTRUCTEXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamStructExt);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamStructExt);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamStructExt_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -2717,7 +2717,7 @@ void PassiveExternalParamsTesterBase ::
   switch (id - idBase) {
     case PassiveExternalParamsComponentBase::PARAMID_PARAMI32EXT: {
       I32 ParamI32ExtVal;
-      _status = val.deserialize(ParamI32ExtVal);
+      _status = val.deserializeTo(ParamI32ExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2731,7 +2731,7 @@ void PassiveExternalParamsTesterBase ::
 
     case PassiveExternalParamsComponentBase::PARAMID_PARAMF64EXT: {
       F64 ParamF64ExtVal;
-      _status = val.deserialize(ParamF64ExtVal);
+      _status = val.deserializeTo(ParamF64ExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2745,7 +2745,7 @@ void PassiveExternalParamsTesterBase ::
 
     case PassiveExternalParamsComponentBase::PARAMID_PARAMSTRINGEXT: {
       Fw::ParamString ParamStringExtVal;
-      _status = val.deserialize(ParamStringExtVal);
+      _status = val.deserializeTo(ParamStringExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2759,7 +2759,7 @@ void PassiveExternalParamsTesterBase ::
 
     case PassiveExternalParamsComponentBase::PARAMID_PARAMENUMEXT: {
       E ParamEnumExtVal;
-      _status = val.deserialize(ParamEnumExtVal);
+      _status = val.deserializeTo(ParamEnumExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2773,7 +2773,7 @@ void PassiveExternalParamsTesterBase ::
 
     case PassiveExternalParamsComponentBase::PARAMID_PARAMARRAYEXT: {
       A ParamArrayExtVal;
-      _status = val.deserialize(ParamArrayExtVal);
+      _status = val.deserializeTo(ParamArrayExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2787,7 +2787,7 @@ void PassiveExternalParamsTesterBase ::
 
     case PassiveExternalParamsComponentBase::PARAMID_PARAMSTRUCTEXT: {
       S ParamStructExtVal;
-      _status = val.deserialize(ParamStructExtVal);
+      _status = val.deserializeTo(ParamStructExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsTesterBase.ref.cpp
@@ -1983,7 +1983,7 @@ void PassiveParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamU32) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamU32) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -2042,7 +2042,7 @@ void PassiveParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamF64) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamF64) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -2101,7 +2101,7 @@ void PassiveParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamString) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamString) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -2160,7 +2160,7 @@ void PassiveParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamEnum) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamEnum) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -2219,7 +2219,7 @@ void PassiveParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamArray) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamArray) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -2278,7 +2278,7 @@ void PassiveParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamStruct) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamStruct) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -2540,7 +2540,7 @@ Fw::ParamValid PassiveParamsTesterBase ::
 
   switch (id - idBase) {
     case PassiveParamsComponentBase::PARAMID_PARAMU32: {
-      _status = val.serialize(_testerBase->m_param_ParamU32);
+      _status = val.serializeFrom(_testerBase->m_param_ParamU32);
       _ret = _testerBase->m_param_ParamU32_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -2550,7 +2550,7 @@ Fw::ParamValid PassiveParamsTesterBase ::
     };
 
     case PassiveParamsComponentBase::PARAMID_PARAMF64: {
-      _status = val.serialize(_testerBase->m_param_ParamF64);
+      _status = val.serializeFrom(_testerBase->m_param_ParamF64);
       _ret = _testerBase->m_param_ParamF64_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -2560,7 +2560,7 @@ Fw::ParamValid PassiveParamsTesterBase ::
     };
 
     case PassiveParamsComponentBase::PARAMID_PARAMSTRING: {
-      _status = val.serialize(_testerBase->m_param_ParamString);
+      _status = val.serializeFrom(_testerBase->m_param_ParamString);
       _ret = _testerBase->m_param_ParamString_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -2570,7 +2570,7 @@ Fw::ParamValid PassiveParamsTesterBase ::
     };
 
     case PassiveParamsComponentBase::PARAMID_PARAMENUM: {
-      _status = val.serialize(_testerBase->m_param_ParamEnum);
+      _status = val.serializeFrom(_testerBase->m_param_ParamEnum);
       _ret = _testerBase->m_param_ParamEnum_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -2580,7 +2580,7 @@ Fw::ParamValid PassiveParamsTesterBase ::
     };
 
     case PassiveParamsComponentBase::PARAMID_PARAMARRAY: {
-      _status = val.serialize(_testerBase->m_param_ParamArray);
+      _status = val.serializeFrom(_testerBase->m_param_ParamArray);
       _ret = _testerBase->m_param_ParamArray_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -2590,7 +2590,7 @@ Fw::ParamValid PassiveParamsTesterBase ::
     };
 
     case PassiveParamsComponentBase::PARAMID_PARAMSTRUCT: {
-      _status = val.serialize(_testerBase->m_param_ParamStruct);
+      _status = val.serializeFrom(_testerBase->m_param_ParamStruct);
       _ret = _testerBase->m_param_ParamStruct_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -2628,7 +2628,7 @@ void PassiveParamsTesterBase ::
   switch (id - idBase) {
     case PassiveParamsComponentBase::PARAMID_PARAMU32: {
       U32 ParamU32Val;
-      _status = val.deserialize(ParamU32Val);
+      _status = val.deserializeTo(ParamU32Val);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2642,7 +2642,7 @@ void PassiveParamsTesterBase ::
 
     case PassiveParamsComponentBase::PARAMID_PARAMF64: {
       F64 ParamF64Val;
-      _status = val.deserialize(ParamF64Val);
+      _status = val.deserializeTo(ParamF64Val);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2656,7 +2656,7 @@ void PassiveParamsTesterBase ::
 
     case PassiveParamsComponentBase::PARAMID_PARAMSTRING: {
       Fw::ParamString ParamStringVal;
-      _status = val.deserialize(ParamStringVal);
+      _status = val.deserializeTo(ParamStringVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2670,7 +2670,7 @@ void PassiveParamsTesterBase ::
 
     case PassiveParamsComponentBase::PARAMID_PARAMENUM: {
       E ParamEnumVal;
-      _status = val.deserialize(ParamEnumVal);
+      _status = val.deserializeTo(ParamEnumVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2684,7 +2684,7 @@ void PassiveParamsTesterBase ::
 
     case PassiveParamsComponentBase::PARAMID_PARAMARRAY: {
       A ParamArrayVal;
-      _status = val.deserialize(ParamArrayVal);
+      _status = val.deserializeTo(ParamArrayVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2698,7 +2698,7 @@ void PassiveParamsTesterBase ::
 
     case PassiveParamsComponentBase::PARAMID_PARAMSTRUCT: {
       S ParamStructVal;
-      _status = val.deserialize(ParamStructVal);
+      _status = val.deserializeTo(ParamStructVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.cpp
@@ -29,27 +29,27 @@ Fw::SerializeStatus PassiveSerialTesterBase::PassiveSerialComponentBaseParamExte
   {
     // ParamI32Ext
     case PassiveSerialComponentBase::PARAMID_PARAMI32EXT:
-      stat = buff.deserialize(this->m_param_ParamI32Ext);
+      stat = buff.deserializeTo(this->m_param_ParamI32Ext);
       break;
     // ParamF64Ext
     case PassiveSerialComponentBase::PARAMID_PARAMF64EXT:
-      stat = buff.deserialize(this->m_param_ParamF64Ext);
+      stat = buff.deserializeTo(this->m_param_ParamF64Ext);
       break;
     // ParamStringExt
     case PassiveSerialComponentBase::PARAMID_PARAMSTRINGEXT:
-      stat = buff.deserialize(this->m_param_ParamStringExt);
+      stat = buff.deserializeTo(this->m_param_ParamStringExt);
       break;
     // ParamEnumExt
     case PassiveSerialComponentBase::PARAMID_PARAMENUMEXT:
-      stat = buff.deserialize(this->m_param_ParamEnumExt);
+      stat = buff.deserializeTo(this->m_param_ParamEnumExt);
       break;
     // ParamArrayExt
     case PassiveSerialComponentBase::PARAMID_PARAMARRAYEXT:
-      stat = buff.deserialize(this->m_param_ParamArrayExt);
+      stat = buff.deserializeTo(this->m_param_ParamArrayExt);
       break;
     // ParamStructExt
     case PassiveSerialComponentBase::PARAMID_PARAMSTRUCTEXT:
-      stat = buff.deserialize(this->m_param_ParamStructExt);
+      stat = buff.deserializeTo(this->m_param_ParamStructExt);
       break;
     default:
       // Unknown ID; should not have gotten here
@@ -74,27 +74,27 @@ Fw::SerializeStatus PassiveSerialTesterBase::PassiveSerialComponentBaseParamExte
   {
     // ParamI32Ext
     case PassiveSerialComponentBase::PARAMID_PARAMI32EXT:
-      stat = buff.serialize(this->m_param_ParamI32Ext);
+      stat = buff.serializeFrom(this->m_param_ParamI32Ext);
       break;
     // ParamF64Ext
     case PassiveSerialComponentBase::PARAMID_PARAMF64EXT:
-      stat = buff.serialize(this->m_param_ParamF64Ext);
+      stat = buff.serializeFrom(this->m_param_ParamF64Ext);
       break;
     // ParamStringExt
     case PassiveSerialComponentBase::PARAMID_PARAMSTRINGEXT:
-      stat = buff.serialize(this->m_param_ParamStringExt);
+      stat = buff.serializeFrom(this->m_param_ParamStringExt);
       break;
     // ParamEnumExt
     case PassiveSerialComponentBase::PARAMID_PARAMENUMEXT:
-      stat = buff.serialize(this->m_param_ParamEnumExt);
+      stat = buff.serializeFrom(this->m_param_ParamEnumExt);
       break;
     // ParamArrayExt
     case PassiveSerialComponentBase::PARAMID_PARAMARRAYEXT:
-      stat = buff.serialize(this->m_param_ParamArrayExt);
+      stat = buff.serializeFrom(this->m_param_ParamArrayExt);
       break;
     // ParamStructExt
     case PassiveSerialComponentBase::PARAMID_PARAMSTRUCTEXT:
-      stat = buff.serialize(this->m_param_ParamStructExt);
+      stat = buff.serializeFrom(this->m_param_ParamStructExt);
       break;
     default:
       // Unknown ID; should not have gotten here
@@ -2417,19 +2417,19 @@ void PassiveSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(u32);
+  _status = buf.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(f32);
+  _status = buf.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(b);
+  _status = buf.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2464,13 +2464,13 @@ void PassiveSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+  _status = str1.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+  _status = str2.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2504,7 +2504,7 @@ void PassiveSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(e);
+  _status = buf.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2538,7 +2538,7 @@ void PassiveSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(a);
+  _status = buf.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2572,7 +2572,7 @@ void PassiveSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(s);
+  _status = buf.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2633,19 +2633,19 @@ void PassiveSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(u32);
+  _status = buf.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(f32);
+  _status = buf.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(b);
+  _status = buf.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2680,13 +2680,13 @@ void PassiveSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+  _status = str1.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+  _status = str2.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2720,7 +2720,7 @@ void PassiveSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(e);
+  _status = buf.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2754,7 +2754,7 @@ void PassiveSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(a);
+  _status = buf.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2788,7 +2788,7 @@ void PassiveSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(s);
+  _status = buf.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2838,7 +2838,7 @@ void PassiveSerialTesterBase ::
       // For AMPCS, decode zero arguments
       Fw::SerializeStatus _zero_status = Fw::FW_SERIALIZE_OK;
       U8 _noArgs;
-      _zero_status = args.deserialize(_noArgs);
+      _zero_status = args.deserializeTo(_noArgs);
       FW_ASSERT(
         _zero_status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_zero_status)
@@ -2854,7 +2854,7 @@ void PassiveSerialTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2872,7 +2872,7 @@ void PassiveSerialTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2884,7 +2884,7 @@ void PassiveSerialTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_u32);
+      _status = args.deserializeTo(_event_arg_u32);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2895,7 +2895,7 @@ void PassiveSerialTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2907,7 +2907,7 @@ void PassiveSerialTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_f32);
+      _status = args.deserializeTo(_event_arg_f32);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2918,7 +2918,7 @@ void PassiveSerialTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2930,7 +2930,7 @@ void PassiveSerialTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_b);
+      _status = args.deserializeTo(_event_arg_b);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2945,7 +2945,7 @@ void PassiveSerialTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2963,7 +2963,7 @@ void PassiveSerialTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2975,7 +2975,7 @@ void PassiveSerialTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_str1);
+      _status = args.deserializeTo(_event_arg_str1);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2986,7 +2986,7 @@ void PassiveSerialTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2998,7 +2998,7 @@ void PassiveSerialTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_str2);
+      _status = args.deserializeTo(_event_arg_str2);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3013,7 +3013,7 @@ void PassiveSerialTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3031,7 +3031,7 @@ void PassiveSerialTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3043,7 +3043,7 @@ void PassiveSerialTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_e);
+      _status = args.deserializeTo(_event_arg_e);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3058,7 +3058,7 @@ void PassiveSerialTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3072,7 +3072,7 @@ void PassiveSerialTesterBase ::
 
       // For FATAL, there is a stack size of 4 and a dummy entry
       U8 stackArgLen;
-      _status = args.deserialize(stackArgLen);
+      _status = args.deserializeTo(stackArgLen);
       FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3083,7 +3083,7 @@ void PassiveSerialTesterBase ::
       );
 
       U32 dummyStackArg;
-      _status = args.deserialize(dummyStackArg);
+      _status = args.deserializeTo(dummyStackArg);
       FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3099,7 +3099,7 @@ void PassiveSerialTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3111,7 +3111,7 @@ void PassiveSerialTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_a);
+      _status = args.deserializeTo(_event_arg_a);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3126,7 +3126,7 @@ void PassiveSerialTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3144,7 +3144,7 @@ void PassiveSerialTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3156,7 +3156,7 @@ void PassiveSerialTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_s);
+      _status = args.deserializeTo(_event_arg_s);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3170,7 +3170,7 @@ void PassiveSerialTesterBase ::
       // For AMPCS, decode zero arguments
       Fw::SerializeStatus _zero_status = Fw::FW_SERIALIZE_OK;
       U8 _noArgs;
-      _zero_status = args.deserialize(_noArgs);
+      _zero_status = args.deserializeTo(_noArgs);
       FW_ASSERT(
         _zero_status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_zero_status)
@@ -3300,7 +3300,7 @@ void PassiveSerialTesterBase ::
   switch (id - idBase) {
     case PassiveSerialComponentBase::CHANNELID_CHANNELU32FORMAT: {
       U32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelU32Format: %d\n", _status);
@@ -3313,7 +3313,7 @@ void PassiveSerialTesterBase ::
 
     case PassiveSerialComponentBase::CHANNELID_CHANNELF32FORMAT: {
       F32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelF32Format: %d\n", _status);
@@ -3326,7 +3326,7 @@ void PassiveSerialTesterBase ::
 
     case PassiveSerialComponentBase::CHANNELID_CHANNELSTRINGFORMAT: {
       Fw::TlmString arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelStringFormat: %d\n", _status);
@@ -3339,7 +3339,7 @@ void PassiveSerialTesterBase ::
 
     case PassiveSerialComponentBase::CHANNELID_CHANNELENUM: {
       E arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelEnum: %d\n", _status);
@@ -3352,7 +3352,7 @@ void PassiveSerialTesterBase ::
 
     case PassiveSerialComponentBase::CHANNELID_CHANNELARRAYFREQ: {
       A arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelArrayFreq: %d\n", _status);
@@ -3365,7 +3365,7 @@ void PassiveSerialTesterBase ::
 
     case PassiveSerialComponentBase::CHANNELID_CHANNELSTRUCTFREQ: {
       S arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelStructFreq: %d\n", _status);
@@ -3378,7 +3378,7 @@ void PassiveSerialTesterBase ::
 
     case PassiveSerialComponentBase::CHANNELID_CHANNELU32LIMITS: {
       U32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelU32Limits: %d\n", _status);
@@ -3391,7 +3391,7 @@ void PassiveSerialTesterBase ::
 
     case PassiveSerialComponentBase::CHANNELID_CHANNELF32LIMITS: {
       F32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelF32Limits: %d\n", _status);
@@ -3404,7 +3404,7 @@ void PassiveSerialTesterBase ::
 
     case PassiveSerialComponentBase::CHANNELID_CHANNELF64: {
       F64 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelF64: %d\n", _status);
@@ -3417,7 +3417,7 @@ void PassiveSerialTesterBase ::
 
     case PassiveSerialComponentBase::CHANNELID_CHANNELU32ONCHANGE: {
       U32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelU32OnChange: %d\n", _status);
@@ -3430,7 +3430,7 @@ void PassiveSerialTesterBase ::
 
     case PassiveSerialComponentBase::CHANNELID_CHANNELENUMONCHANGE: {
       E arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelEnumOnChange: %d\n", _status);
@@ -3592,7 +3592,7 @@ void PassiveSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamU32) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamU32) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -3651,7 +3651,7 @@ void PassiveSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamF64) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamF64) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -3710,7 +3710,7 @@ void PassiveSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamString) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamString) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -3769,7 +3769,7 @@ void PassiveSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamEnum) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamEnum) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -3828,7 +3828,7 @@ void PassiveSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamArray) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamArray) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -3887,7 +3887,7 @@ void PassiveSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamStruct) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamStruct) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -3946,7 +3946,7 @@ void PassiveSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamI32Ext) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamI32Ext) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4005,7 +4005,7 @@ void PassiveSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamF64Ext) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamF64Ext) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4064,7 +4064,7 @@ void PassiveSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamStringExt) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamStringExt) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4123,7 +4123,7 @@ void PassiveSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamEnumExt) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamEnumExt) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4182,7 +4182,7 @@ void PassiveSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamArrayExt) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamArrayExt) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4241,7 +4241,7 @@ void PassiveSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamStructExt) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamStructExt) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4614,7 +4614,7 @@ Fw::ParamValid PassiveSerialTesterBase ::
 
   switch (id - idBase) {
     case PassiveSerialComponentBase::PARAMID_PARAMU32: {
-      _status = val.serialize(_testerBase->m_param_ParamU32);
+      _status = val.serializeFrom(_testerBase->m_param_ParamU32);
       _ret = _testerBase->m_param_ParamU32_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -4624,7 +4624,7 @@ Fw::ParamValid PassiveSerialTesterBase ::
     };
 
     case PassiveSerialComponentBase::PARAMID_PARAMF64: {
-      _status = val.serialize(_testerBase->m_param_ParamF64);
+      _status = val.serializeFrom(_testerBase->m_param_ParamF64);
       _ret = _testerBase->m_param_ParamF64_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -4634,7 +4634,7 @@ Fw::ParamValid PassiveSerialTesterBase ::
     };
 
     case PassiveSerialComponentBase::PARAMID_PARAMSTRING: {
-      _status = val.serialize(_testerBase->m_param_ParamString);
+      _status = val.serializeFrom(_testerBase->m_param_ParamString);
       _ret = _testerBase->m_param_ParamString_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -4644,7 +4644,7 @@ Fw::ParamValid PassiveSerialTesterBase ::
     };
 
     case PassiveSerialComponentBase::PARAMID_PARAMENUM: {
-      _status = val.serialize(_testerBase->m_param_ParamEnum);
+      _status = val.serializeFrom(_testerBase->m_param_ParamEnum);
       _ret = _testerBase->m_param_ParamEnum_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -4654,7 +4654,7 @@ Fw::ParamValid PassiveSerialTesterBase ::
     };
 
     case PassiveSerialComponentBase::PARAMID_PARAMARRAY: {
-      _status = val.serialize(_testerBase->m_param_ParamArray);
+      _status = val.serializeFrom(_testerBase->m_param_ParamArray);
       _ret = _testerBase->m_param_ParamArray_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -4664,7 +4664,7 @@ Fw::ParamValid PassiveSerialTesterBase ::
     };
 
     case PassiveSerialComponentBase::PARAMID_PARAMSTRUCT: {
-      _status = val.serialize(_testerBase->m_param_ParamStruct);
+      _status = val.serializeFrom(_testerBase->m_param_ParamStruct);
       _ret = _testerBase->m_param_ParamStruct_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -4674,7 +4674,7 @@ Fw::ParamValid PassiveSerialTesterBase ::
     };
 
     case PassiveSerialComponentBase::PARAMID_PARAMI32EXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamI32Ext);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamI32Ext);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamI32Ext_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -4684,7 +4684,7 @@ Fw::ParamValid PassiveSerialTesterBase ::
     };
 
     case PassiveSerialComponentBase::PARAMID_PARAMF64EXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamF64Ext);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamF64Ext);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamF64Ext_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -4694,7 +4694,7 @@ Fw::ParamValid PassiveSerialTesterBase ::
     };
 
     case PassiveSerialComponentBase::PARAMID_PARAMSTRINGEXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamStringExt);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamStringExt);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamStringExt_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -4704,7 +4704,7 @@ Fw::ParamValid PassiveSerialTesterBase ::
     };
 
     case PassiveSerialComponentBase::PARAMID_PARAMENUMEXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamEnumExt);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamEnumExt);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamEnumExt_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -4714,7 +4714,7 @@ Fw::ParamValid PassiveSerialTesterBase ::
     };
 
     case PassiveSerialComponentBase::PARAMID_PARAMARRAYEXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamArrayExt);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamArrayExt);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamArrayExt_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -4724,7 +4724,7 @@ Fw::ParamValid PassiveSerialTesterBase ::
     };
 
     case PassiveSerialComponentBase::PARAMID_PARAMSTRUCTEXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamStructExt);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamStructExt);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamStructExt_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -4762,7 +4762,7 @@ void PassiveSerialTesterBase ::
   switch (id - idBase) {
     case PassiveSerialComponentBase::PARAMID_PARAMU32: {
       U32 ParamU32Val;
-      _status = val.deserialize(ParamU32Val);
+      _status = val.deserializeTo(ParamU32Val);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -4776,7 +4776,7 @@ void PassiveSerialTesterBase ::
 
     case PassiveSerialComponentBase::PARAMID_PARAMF64: {
       F64 ParamF64Val;
-      _status = val.deserialize(ParamF64Val);
+      _status = val.deserializeTo(ParamF64Val);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -4790,7 +4790,7 @@ void PassiveSerialTesterBase ::
 
     case PassiveSerialComponentBase::PARAMID_PARAMSTRING: {
       Fw::ParamString ParamStringVal;
-      _status = val.deserialize(ParamStringVal);
+      _status = val.deserializeTo(ParamStringVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -4804,7 +4804,7 @@ void PassiveSerialTesterBase ::
 
     case PassiveSerialComponentBase::PARAMID_PARAMENUM: {
       E ParamEnumVal;
-      _status = val.deserialize(ParamEnumVal);
+      _status = val.deserializeTo(ParamEnumVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -4818,7 +4818,7 @@ void PassiveSerialTesterBase ::
 
     case PassiveSerialComponentBase::PARAMID_PARAMARRAY: {
       A ParamArrayVal;
-      _status = val.deserialize(ParamArrayVal);
+      _status = val.deserializeTo(ParamArrayVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -4832,7 +4832,7 @@ void PassiveSerialTesterBase ::
 
     case PassiveSerialComponentBase::PARAMID_PARAMSTRUCT: {
       S ParamStructVal;
-      _status = val.deserialize(ParamStructVal);
+      _status = val.deserializeTo(ParamStructVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -4846,7 +4846,7 @@ void PassiveSerialTesterBase ::
 
     case PassiveSerialComponentBase::PARAMID_PARAMI32EXT: {
       I32 ParamI32ExtVal;
-      _status = val.deserialize(ParamI32ExtVal);
+      _status = val.deserializeTo(ParamI32ExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -4860,7 +4860,7 @@ void PassiveSerialTesterBase ::
 
     case PassiveSerialComponentBase::PARAMID_PARAMF64EXT: {
       F64 ParamF64ExtVal;
-      _status = val.deserialize(ParamF64ExtVal);
+      _status = val.deserializeTo(ParamF64ExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -4874,7 +4874,7 @@ void PassiveSerialTesterBase ::
 
     case PassiveSerialComponentBase::PARAMID_PARAMSTRINGEXT: {
       Fw::ParamString ParamStringExtVal;
-      _status = val.deserialize(ParamStringExtVal);
+      _status = val.deserializeTo(ParamStringExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -4888,7 +4888,7 @@ void PassiveSerialTesterBase ::
 
     case PassiveSerialComponentBase::PARAMID_PARAMENUMEXT: {
       E ParamEnumExtVal;
-      _status = val.deserialize(ParamEnumExtVal);
+      _status = val.deserializeTo(ParamEnumExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -4902,7 +4902,7 @@ void PassiveSerialTesterBase ::
 
     case PassiveSerialComponentBase::PARAMID_PARAMARRAYEXT: {
       A ParamArrayExtVal;
-      _status = val.deserialize(ParamArrayExtVal);
+      _status = val.deserializeTo(ParamArrayExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -4916,7 +4916,7 @@ void PassiveSerialTesterBase ::
 
     case PassiveSerialComponentBase::PARAMID_PARAMSTRUCTEXT: {
       S ParamStructExtVal;
-      _status = val.deserialize(ParamStructExtVal);
+      _status = val.deserializeTo(ParamStructExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryTesterBase.ref.cpp
@@ -1870,7 +1870,7 @@ void PassiveTelemetryTesterBase ::
   switch (id - idBase) {
     case PassiveTelemetryComponentBase::CHANNELID_CHANNELU32FORMAT: {
       U32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelU32Format: %d\n", _status);
@@ -1883,7 +1883,7 @@ void PassiveTelemetryTesterBase ::
 
     case PassiveTelemetryComponentBase::CHANNELID_CHANNELF32FORMAT: {
       F32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelF32Format: %d\n", _status);
@@ -1896,7 +1896,7 @@ void PassiveTelemetryTesterBase ::
 
     case PassiveTelemetryComponentBase::CHANNELID_CHANNELSTRINGFORMAT: {
       Fw::TlmString arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelStringFormat: %d\n", _status);
@@ -1909,7 +1909,7 @@ void PassiveTelemetryTesterBase ::
 
     case PassiveTelemetryComponentBase::CHANNELID_CHANNELENUM: {
       E arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelEnum: %d\n", _status);
@@ -1922,7 +1922,7 @@ void PassiveTelemetryTesterBase ::
 
     case PassiveTelemetryComponentBase::CHANNELID_CHANNELARRAYFREQ: {
       A arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelArrayFreq: %d\n", _status);
@@ -1935,7 +1935,7 @@ void PassiveTelemetryTesterBase ::
 
     case PassiveTelemetryComponentBase::CHANNELID_CHANNELSTRUCTFREQ: {
       S arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelStructFreq: %d\n", _status);
@@ -1948,7 +1948,7 @@ void PassiveTelemetryTesterBase ::
 
     case PassiveTelemetryComponentBase::CHANNELID_CHANNELU32LIMITS: {
       U32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelU32Limits: %d\n", _status);
@@ -1961,7 +1961,7 @@ void PassiveTelemetryTesterBase ::
 
     case PassiveTelemetryComponentBase::CHANNELID_CHANNELF32LIMITS: {
       F32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelF32Limits: %d\n", _status);
@@ -1974,7 +1974,7 @@ void PassiveTelemetryTesterBase ::
 
     case PassiveTelemetryComponentBase::CHANNELID_CHANNELF64: {
       F64 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelF64: %d\n", _status);
@@ -1987,7 +1987,7 @@ void PassiveTelemetryTesterBase ::
 
     case PassiveTelemetryComponentBase::CHANNELID_CHANNELU32ONCHANGE: {
       U32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelU32OnChange: %d\n", _status);
@@ -2000,7 +2000,7 @@ void PassiveTelemetryTesterBase ::
 
     case PassiveTelemetryComponentBase::CHANNELID_CHANNELENUMONCHANGE: {
       E arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelEnumOnChange: %d\n", _status);

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.cpp
@@ -29,27 +29,27 @@ Fw::SerializeStatus PassiveTestTesterBase::PassiveTestComponentBaseParamExternal
   {
     // ParamI32Ext
     case PassiveTestComponentBase::PARAMID_PARAMI32EXT:
-      stat = buff.deserialize(this->m_param_ParamI32Ext);
+      stat = buff.deserializeTo(this->m_param_ParamI32Ext);
       break;
     // ParamF64Ext
     case PassiveTestComponentBase::PARAMID_PARAMF64EXT:
-      stat = buff.deserialize(this->m_param_ParamF64Ext);
+      stat = buff.deserializeTo(this->m_param_ParamF64Ext);
       break;
     // ParamStringExt
     case PassiveTestComponentBase::PARAMID_PARAMSTRINGEXT:
-      stat = buff.deserialize(this->m_param_ParamStringExt);
+      stat = buff.deserializeTo(this->m_param_ParamStringExt);
       break;
     // ParamEnumExt
     case PassiveTestComponentBase::PARAMID_PARAMENUMEXT:
-      stat = buff.deserialize(this->m_param_ParamEnumExt);
+      stat = buff.deserializeTo(this->m_param_ParamEnumExt);
       break;
     // ParamArrayExt
     case PassiveTestComponentBase::PARAMID_PARAMARRAYEXT:
-      stat = buff.deserialize(this->m_param_ParamArrayExt);
+      stat = buff.deserializeTo(this->m_param_ParamArrayExt);
       break;
     // ParamStructExt
     case PassiveTestComponentBase::PARAMID_PARAMSTRUCTEXT:
-      stat = buff.deserialize(this->m_param_ParamStructExt);
+      stat = buff.deserializeTo(this->m_param_ParamStructExt);
       break;
     default:
       // Unknown ID; should not have gotten here
@@ -74,27 +74,27 @@ Fw::SerializeStatus PassiveTestTesterBase::PassiveTestComponentBaseParamExternal
   {
     // ParamI32Ext
     case PassiveTestComponentBase::PARAMID_PARAMI32EXT:
-      stat = buff.serialize(this->m_param_ParamI32Ext);
+      stat = buff.serializeFrom(this->m_param_ParamI32Ext);
       break;
     // ParamF64Ext
     case PassiveTestComponentBase::PARAMID_PARAMF64EXT:
-      stat = buff.serialize(this->m_param_ParamF64Ext);
+      stat = buff.serializeFrom(this->m_param_ParamF64Ext);
       break;
     // ParamStringExt
     case PassiveTestComponentBase::PARAMID_PARAMSTRINGEXT:
-      stat = buff.serialize(this->m_param_ParamStringExt);
+      stat = buff.serializeFrom(this->m_param_ParamStringExt);
       break;
     // ParamEnumExt
     case PassiveTestComponentBase::PARAMID_PARAMENUMEXT:
-      stat = buff.serialize(this->m_param_ParamEnumExt);
+      stat = buff.serializeFrom(this->m_param_ParamEnumExt);
       break;
     // ParamArrayExt
     case PassiveTestComponentBase::PARAMID_PARAMARRAYEXT:
-      stat = buff.serialize(this->m_param_ParamArrayExt);
+      stat = buff.serializeFrom(this->m_param_ParamArrayExt);
       break;
     // ParamStructExt
     case PassiveTestComponentBase::PARAMID_PARAMSTRUCTEXT:
-      stat = buff.serialize(this->m_param_ParamStructExt);
+      stat = buff.serializeFrom(this->m_param_ParamStructExt);
       break;
     default:
       // Unknown ID; should not have gotten here
@@ -2353,19 +2353,19 @@ void PassiveTestTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(u32);
+  _status = buf.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(f32);
+  _status = buf.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(b);
+  _status = buf.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2400,13 +2400,13 @@ void PassiveTestTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+  _status = str1.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+  _status = str2.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2440,7 +2440,7 @@ void PassiveTestTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(e);
+  _status = buf.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2474,7 +2474,7 @@ void PassiveTestTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(a);
+  _status = buf.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2508,7 +2508,7 @@ void PassiveTestTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(s);
+  _status = buf.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2569,19 +2569,19 @@ void PassiveTestTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(u32);
+  _status = buf.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(f32);
+  _status = buf.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(b);
+  _status = buf.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2616,13 +2616,13 @@ void PassiveTestTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+  _status = str1.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+  _status = str2.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2656,7 +2656,7 @@ void PassiveTestTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(e);
+  _status = buf.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2690,7 +2690,7 @@ void PassiveTestTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(a);
+  _status = buf.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2724,7 +2724,7 @@ void PassiveTestTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(s);
+  _status = buf.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2774,7 +2774,7 @@ void PassiveTestTesterBase ::
       // For AMPCS, decode zero arguments
       Fw::SerializeStatus _zero_status = Fw::FW_SERIALIZE_OK;
       U8 _noArgs;
-      _zero_status = args.deserialize(_noArgs);
+      _zero_status = args.deserializeTo(_noArgs);
       FW_ASSERT(
         _zero_status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_zero_status)
@@ -2790,7 +2790,7 @@ void PassiveTestTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2808,7 +2808,7 @@ void PassiveTestTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2820,7 +2820,7 @@ void PassiveTestTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_u32);
+      _status = args.deserializeTo(_event_arg_u32);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2831,7 +2831,7 @@ void PassiveTestTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2843,7 +2843,7 @@ void PassiveTestTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_f32);
+      _status = args.deserializeTo(_event_arg_f32);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2854,7 +2854,7 @@ void PassiveTestTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2866,7 +2866,7 @@ void PassiveTestTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_b);
+      _status = args.deserializeTo(_event_arg_b);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2881,7 +2881,7 @@ void PassiveTestTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2899,7 +2899,7 @@ void PassiveTestTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2911,7 +2911,7 @@ void PassiveTestTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_str1);
+      _status = args.deserializeTo(_event_arg_str1);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2922,7 +2922,7 @@ void PassiveTestTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2934,7 +2934,7 @@ void PassiveTestTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_str2);
+      _status = args.deserializeTo(_event_arg_str2);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2949,7 +2949,7 @@ void PassiveTestTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2967,7 +2967,7 @@ void PassiveTestTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2979,7 +2979,7 @@ void PassiveTestTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_e);
+      _status = args.deserializeTo(_event_arg_e);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2994,7 +2994,7 @@ void PassiveTestTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3008,7 +3008,7 @@ void PassiveTestTesterBase ::
 
       // For FATAL, there is a stack size of 4 and a dummy entry
       U8 stackArgLen;
-      _status = args.deserialize(stackArgLen);
+      _status = args.deserializeTo(stackArgLen);
       FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3019,7 +3019,7 @@ void PassiveTestTesterBase ::
       );
 
       U32 dummyStackArg;
-      _status = args.deserialize(dummyStackArg);
+      _status = args.deserializeTo(dummyStackArg);
       FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3035,7 +3035,7 @@ void PassiveTestTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3047,7 +3047,7 @@ void PassiveTestTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_a);
+      _status = args.deserializeTo(_event_arg_a);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3062,7 +3062,7 @@ void PassiveTestTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3080,7 +3080,7 @@ void PassiveTestTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3092,7 +3092,7 @@ void PassiveTestTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_s);
+      _status = args.deserializeTo(_event_arg_s);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3106,7 +3106,7 @@ void PassiveTestTesterBase ::
       // For AMPCS, decode zero arguments
       Fw::SerializeStatus _zero_status = Fw::FW_SERIALIZE_OK;
       U8 _noArgs;
-      _zero_status = args.deserialize(_noArgs);
+      _zero_status = args.deserializeTo(_noArgs);
       FW_ASSERT(
         _zero_status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_zero_status)
@@ -3236,7 +3236,7 @@ void PassiveTestTesterBase ::
   switch (id - idBase) {
     case PassiveTestComponentBase::CHANNELID_CHANNELU32FORMAT: {
       U32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelU32Format: %d\n", _status);
@@ -3249,7 +3249,7 @@ void PassiveTestTesterBase ::
 
     case PassiveTestComponentBase::CHANNELID_CHANNELF32FORMAT: {
       F32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelF32Format: %d\n", _status);
@@ -3262,7 +3262,7 @@ void PassiveTestTesterBase ::
 
     case PassiveTestComponentBase::CHANNELID_CHANNELSTRINGFORMAT: {
       Fw::TlmString arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelStringFormat: %d\n", _status);
@@ -3275,7 +3275,7 @@ void PassiveTestTesterBase ::
 
     case PassiveTestComponentBase::CHANNELID_CHANNELENUM: {
       E arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelEnum: %d\n", _status);
@@ -3288,7 +3288,7 @@ void PassiveTestTesterBase ::
 
     case PassiveTestComponentBase::CHANNELID_CHANNELARRAYFREQ: {
       A arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelArrayFreq: %d\n", _status);
@@ -3301,7 +3301,7 @@ void PassiveTestTesterBase ::
 
     case PassiveTestComponentBase::CHANNELID_CHANNELSTRUCTFREQ: {
       S arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelStructFreq: %d\n", _status);
@@ -3314,7 +3314,7 @@ void PassiveTestTesterBase ::
 
     case PassiveTestComponentBase::CHANNELID_CHANNELU32LIMITS: {
       U32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelU32Limits: %d\n", _status);
@@ -3327,7 +3327,7 @@ void PassiveTestTesterBase ::
 
     case PassiveTestComponentBase::CHANNELID_CHANNELF32LIMITS: {
       F32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelF32Limits: %d\n", _status);
@@ -3340,7 +3340,7 @@ void PassiveTestTesterBase ::
 
     case PassiveTestComponentBase::CHANNELID_CHANNELF64: {
       F64 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelF64: %d\n", _status);
@@ -3353,7 +3353,7 @@ void PassiveTestTesterBase ::
 
     case PassiveTestComponentBase::CHANNELID_CHANNELU32ONCHANGE: {
       U32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelU32OnChange: %d\n", _status);
@@ -3366,7 +3366,7 @@ void PassiveTestTesterBase ::
 
     case PassiveTestComponentBase::CHANNELID_CHANNELENUMONCHANGE: {
       E arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelEnumOnChange: %d\n", _status);
@@ -3528,7 +3528,7 @@ void PassiveTestTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamU32) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamU32) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -3587,7 +3587,7 @@ void PassiveTestTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamF64) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamF64) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -3646,7 +3646,7 @@ void PassiveTestTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamString) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamString) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -3705,7 +3705,7 @@ void PassiveTestTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamEnum) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamEnum) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -3764,7 +3764,7 @@ void PassiveTestTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamArray) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamArray) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -3823,7 +3823,7 @@ void PassiveTestTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamStruct) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamStruct) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -3882,7 +3882,7 @@ void PassiveTestTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamI32Ext) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamI32Ext) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -3941,7 +3941,7 @@ void PassiveTestTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamF64Ext) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamF64Ext) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4000,7 +4000,7 @@ void PassiveTestTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamStringExt) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamStringExt) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4059,7 +4059,7 @@ void PassiveTestTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamEnumExt) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamEnumExt) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4118,7 +4118,7 @@ void PassiveTestTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamArrayExt) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamArrayExt) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4177,7 +4177,7 @@ void PassiveTestTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamStructExt) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamStructExt) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4606,7 +4606,7 @@ Fw::ParamValid PassiveTestTesterBase ::
 
   switch (id - idBase) {
     case PassiveTestComponentBase::PARAMID_PARAMU32: {
-      _status = val.serialize(_testerBase->m_param_ParamU32);
+      _status = val.serializeFrom(_testerBase->m_param_ParamU32);
       _ret = _testerBase->m_param_ParamU32_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -4616,7 +4616,7 @@ Fw::ParamValid PassiveTestTesterBase ::
     };
 
     case PassiveTestComponentBase::PARAMID_PARAMF64: {
-      _status = val.serialize(_testerBase->m_param_ParamF64);
+      _status = val.serializeFrom(_testerBase->m_param_ParamF64);
       _ret = _testerBase->m_param_ParamF64_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -4626,7 +4626,7 @@ Fw::ParamValid PassiveTestTesterBase ::
     };
 
     case PassiveTestComponentBase::PARAMID_PARAMSTRING: {
-      _status = val.serialize(_testerBase->m_param_ParamString);
+      _status = val.serializeFrom(_testerBase->m_param_ParamString);
       _ret = _testerBase->m_param_ParamString_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -4636,7 +4636,7 @@ Fw::ParamValid PassiveTestTesterBase ::
     };
 
     case PassiveTestComponentBase::PARAMID_PARAMENUM: {
-      _status = val.serialize(_testerBase->m_param_ParamEnum);
+      _status = val.serializeFrom(_testerBase->m_param_ParamEnum);
       _ret = _testerBase->m_param_ParamEnum_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -4646,7 +4646,7 @@ Fw::ParamValid PassiveTestTesterBase ::
     };
 
     case PassiveTestComponentBase::PARAMID_PARAMARRAY: {
-      _status = val.serialize(_testerBase->m_param_ParamArray);
+      _status = val.serializeFrom(_testerBase->m_param_ParamArray);
       _ret = _testerBase->m_param_ParamArray_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -4656,7 +4656,7 @@ Fw::ParamValid PassiveTestTesterBase ::
     };
 
     case PassiveTestComponentBase::PARAMID_PARAMSTRUCT: {
-      _status = val.serialize(_testerBase->m_param_ParamStruct);
+      _status = val.serializeFrom(_testerBase->m_param_ParamStruct);
       _ret = _testerBase->m_param_ParamStruct_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -4666,7 +4666,7 @@ Fw::ParamValid PassiveTestTesterBase ::
     };
 
     case PassiveTestComponentBase::PARAMID_PARAMI32EXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamI32Ext);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamI32Ext);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamI32Ext_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -4676,7 +4676,7 @@ Fw::ParamValid PassiveTestTesterBase ::
     };
 
     case PassiveTestComponentBase::PARAMID_PARAMF64EXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamF64Ext);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamF64Ext);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamF64Ext_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -4686,7 +4686,7 @@ Fw::ParamValid PassiveTestTesterBase ::
     };
 
     case PassiveTestComponentBase::PARAMID_PARAMSTRINGEXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamStringExt);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamStringExt);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamStringExt_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -4696,7 +4696,7 @@ Fw::ParamValid PassiveTestTesterBase ::
     };
 
     case PassiveTestComponentBase::PARAMID_PARAMENUMEXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamEnumExt);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamEnumExt);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamEnumExt_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -4706,7 +4706,7 @@ Fw::ParamValid PassiveTestTesterBase ::
     };
 
     case PassiveTestComponentBase::PARAMID_PARAMARRAYEXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamArrayExt);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamArrayExt);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamArrayExt_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -4716,7 +4716,7 @@ Fw::ParamValid PassiveTestTesterBase ::
     };
 
     case PassiveTestComponentBase::PARAMID_PARAMSTRUCTEXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamStructExt);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamStructExt);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamStructExt_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -4754,7 +4754,7 @@ void PassiveTestTesterBase ::
   switch (id - idBase) {
     case PassiveTestComponentBase::PARAMID_PARAMU32: {
       U32 ParamU32Val;
-      _status = val.deserialize(ParamU32Val);
+      _status = val.deserializeTo(ParamU32Val);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -4768,7 +4768,7 @@ void PassiveTestTesterBase ::
 
     case PassiveTestComponentBase::PARAMID_PARAMF64: {
       F64 ParamF64Val;
-      _status = val.deserialize(ParamF64Val);
+      _status = val.deserializeTo(ParamF64Val);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -4782,7 +4782,7 @@ void PassiveTestTesterBase ::
 
     case PassiveTestComponentBase::PARAMID_PARAMSTRING: {
       Fw::ParamString ParamStringVal;
-      _status = val.deserialize(ParamStringVal);
+      _status = val.deserializeTo(ParamStringVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -4796,7 +4796,7 @@ void PassiveTestTesterBase ::
 
     case PassiveTestComponentBase::PARAMID_PARAMENUM: {
       E ParamEnumVal;
-      _status = val.deserialize(ParamEnumVal);
+      _status = val.deserializeTo(ParamEnumVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -4810,7 +4810,7 @@ void PassiveTestTesterBase ::
 
     case PassiveTestComponentBase::PARAMID_PARAMARRAY: {
       A ParamArrayVal;
-      _status = val.deserialize(ParamArrayVal);
+      _status = val.deserializeTo(ParamArrayVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -4824,7 +4824,7 @@ void PassiveTestTesterBase ::
 
     case PassiveTestComponentBase::PARAMID_PARAMSTRUCT: {
       S ParamStructVal;
-      _status = val.deserialize(ParamStructVal);
+      _status = val.deserializeTo(ParamStructVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -4838,7 +4838,7 @@ void PassiveTestTesterBase ::
 
     case PassiveTestComponentBase::PARAMID_PARAMI32EXT: {
       I32 ParamI32ExtVal;
-      _status = val.deserialize(ParamI32ExtVal);
+      _status = val.deserializeTo(ParamI32ExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -4852,7 +4852,7 @@ void PassiveTestTesterBase ::
 
     case PassiveTestComponentBase::PARAMID_PARAMF64EXT: {
       F64 ParamF64ExtVal;
-      _status = val.deserialize(ParamF64ExtVal);
+      _status = val.deserializeTo(ParamF64ExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -4866,7 +4866,7 @@ void PassiveTestTesterBase ::
 
     case PassiveTestComponentBase::PARAMID_PARAMSTRINGEXT: {
       Fw::ParamString ParamStringExtVal;
-      _status = val.deserialize(ParamStringExtVal);
+      _status = val.deserializeTo(ParamStringExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -4880,7 +4880,7 @@ void PassiveTestTesterBase ::
 
     case PassiveTestComponentBase::PARAMID_PARAMENUMEXT: {
       E ParamEnumExtVal;
-      _status = val.deserialize(ParamEnumExtVal);
+      _status = val.deserializeTo(ParamEnumExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -4894,7 +4894,7 @@ void PassiveTestTesterBase ::
 
     case PassiveTestComponentBase::PARAMID_PARAMARRAYEXT: {
       A ParamArrayExtVal;
-      _status = val.deserialize(ParamArrayExtVal);
+      _status = val.deserializeTo(ParamArrayExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -4908,7 +4908,7 @@ void PassiveTestTesterBase ::
 
     case PassiveTestComponentBase::PARAMID_PARAMSTRUCTEXT: {
       S ParamStructExtVal;
-      _status = val.deserialize(ParamStructExtVal);
+      _status = val.deserializeTo(ParamStructExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsTesterBase.ref.cpp
@@ -2395,19 +2395,19 @@ void QueuedCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(u32);
+  _status = buf.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(f32);
+  _status = buf.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(b);
+  _status = buf.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2442,13 +2442,13 @@ void QueuedCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+  _status = str1.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+  _status = str2.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2482,7 +2482,7 @@ void QueuedCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(e);
+  _status = buf.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2516,7 +2516,7 @@ void QueuedCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(a);
+  _status = buf.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2550,7 +2550,7 @@ void QueuedCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(s);
+  _status = buf.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2611,19 +2611,19 @@ void QueuedCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(u32);
+  _status = buf.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(f32);
+  _status = buf.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(b);
+  _status = buf.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2658,13 +2658,13 @@ void QueuedCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+  _status = str1.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+  _status = str2.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2698,7 +2698,7 @@ void QueuedCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(e);
+  _status = buf.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2732,7 +2732,7 @@ void QueuedCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(a);
+  _status = buf.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2766,7 +2766,7 @@ void QueuedCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(s);
+  _status = buf.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2850,7 +2850,7 @@ void QueuedCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(u32);
+  _status = buf.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2909,7 +2909,7 @@ void QueuedCommandsTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(u32);
+  _status = buf.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsTesterBase.ref.cpp
@@ -2345,7 +2345,7 @@ void QueuedEventsTesterBase ::
       // For AMPCS, decode zero arguments
       Fw::SerializeStatus _zero_status = Fw::FW_SERIALIZE_OK;
       U8 _noArgs;
-      _zero_status = args.deserialize(_noArgs);
+      _zero_status = args.deserializeTo(_noArgs);
       FW_ASSERT(
         _zero_status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_zero_status)
@@ -2361,7 +2361,7 @@ void QueuedEventsTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2379,7 +2379,7 @@ void QueuedEventsTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2391,7 +2391,7 @@ void QueuedEventsTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_u32);
+      _status = args.deserializeTo(_event_arg_u32);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2402,7 +2402,7 @@ void QueuedEventsTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2414,7 +2414,7 @@ void QueuedEventsTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_f32);
+      _status = args.deserializeTo(_event_arg_f32);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2425,7 +2425,7 @@ void QueuedEventsTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2437,7 +2437,7 @@ void QueuedEventsTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_b);
+      _status = args.deserializeTo(_event_arg_b);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2452,7 +2452,7 @@ void QueuedEventsTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2470,7 +2470,7 @@ void QueuedEventsTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2482,7 +2482,7 @@ void QueuedEventsTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_str1);
+      _status = args.deserializeTo(_event_arg_str1);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2493,7 +2493,7 @@ void QueuedEventsTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2505,7 +2505,7 @@ void QueuedEventsTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_str2);
+      _status = args.deserializeTo(_event_arg_str2);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2520,7 +2520,7 @@ void QueuedEventsTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2538,7 +2538,7 @@ void QueuedEventsTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2550,7 +2550,7 @@ void QueuedEventsTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_e);
+      _status = args.deserializeTo(_event_arg_e);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2565,7 +2565,7 @@ void QueuedEventsTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2579,7 +2579,7 @@ void QueuedEventsTesterBase ::
 
       // For FATAL, there is a stack size of 4 and a dummy entry
       U8 stackArgLen;
-      _status = args.deserialize(stackArgLen);
+      _status = args.deserializeTo(stackArgLen);
       FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2590,7 +2590,7 @@ void QueuedEventsTesterBase ::
       );
 
       U32 dummyStackArg;
-      _status = args.deserialize(dummyStackArg);
+      _status = args.deserializeTo(dummyStackArg);
       FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2606,7 +2606,7 @@ void QueuedEventsTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2618,7 +2618,7 @@ void QueuedEventsTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_a);
+      _status = args.deserializeTo(_event_arg_a);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2633,7 +2633,7 @@ void QueuedEventsTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2651,7 +2651,7 @@ void QueuedEventsTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -2663,7 +2663,7 @@ void QueuedEventsTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_s);
+      _status = args.deserializeTo(_event_arg_s);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -2677,7 +2677,7 @@ void QueuedEventsTesterBase ::
       // For AMPCS, decode zero arguments
       Fw::SerializeStatus _zero_status = Fw::FW_SERIALIZE_OK;
       U8 _noArgs;
-      _zero_status = args.deserialize(_noArgs);
+      _zero_status = args.deserializeTo(_noArgs);
       FW_ASSERT(
         _zero_status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_zero_status)

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedExternalParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedExternalParamsTesterBase.ref.cpp
@@ -29,27 +29,27 @@ Fw::SerializeStatus QueuedExternalParamsTesterBase::QueuedExternalParamsComponen
   {
     // ParamI32Ext
     case QueuedExternalParamsComponentBase::PARAMID_PARAMI32EXT:
-      stat = buff.deserialize(this->m_param_ParamI32Ext);
+      stat = buff.deserializeTo(this->m_param_ParamI32Ext);
       break;
     // ParamF64Ext
     case QueuedExternalParamsComponentBase::PARAMID_PARAMF64EXT:
-      stat = buff.deserialize(this->m_param_ParamF64Ext);
+      stat = buff.deserializeTo(this->m_param_ParamF64Ext);
       break;
     // ParamStringExt
     case QueuedExternalParamsComponentBase::PARAMID_PARAMSTRINGEXT:
-      stat = buff.deserialize(this->m_param_ParamStringExt);
+      stat = buff.deserializeTo(this->m_param_ParamStringExt);
       break;
     // ParamEnumExt
     case QueuedExternalParamsComponentBase::PARAMID_PARAMENUMEXT:
-      stat = buff.deserialize(this->m_param_ParamEnumExt);
+      stat = buff.deserializeTo(this->m_param_ParamEnumExt);
       break;
     // ParamArrayExt
     case QueuedExternalParamsComponentBase::PARAMID_PARAMARRAYEXT:
-      stat = buff.deserialize(this->m_param_ParamArrayExt);
+      stat = buff.deserializeTo(this->m_param_ParamArrayExt);
       break;
     // ParamStructExt
     case QueuedExternalParamsComponentBase::PARAMID_PARAMSTRUCTEXT:
-      stat = buff.deserialize(this->m_param_ParamStructExt);
+      stat = buff.deserializeTo(this->m_param_ParamStructExt);
       break;
     default:
       // Unknown ID; should not have gotten here
@@ -74,27 +74,27 @@ Fw::SerializeStatus QueuedExternalParamsTesterBase::QueuedExternalParamsComponen
   {
     // ParamI32Ext
     case QueuedExternalParamsComponentBase::PARAMID_PARAMI32EXT:
-      stat = buff.serialize(this->m_param_ParamI32Ext);
+      stat = buff.serializeFrom(this->m_param_ParamI32Ext);
       break;
     // ParamF64Ext
     case QueuedExternalParamsComponentBase::PARAMID_PARAMF64EXT:
-      stat = buff.serialize(this->m_param_ParamF64Ext);
+      stat = buff.serializeFrom(this->m_param_ParamF64Ext);
       break;
     // ParamStringExt
     case QueuedExternalParamsComponentBase::PARAMID_PARAMSTRINGEXT:
-      stat = buff.serialize(this->m_param_ParamStringExt);
+      stat = buff.serializeFrom(this->m_param_ParamStringExt);
       break;
     // ParamEnumExt
     case QueuedExternalParamsComponentBase::PARAMID_PARAMENUMEXT:
-      stat = buff.serialize(this->m_param_ParamEnumExt);
+      stat = buff.serializeFrom(this->m_param_ParamEnumExt);
       break;
     // ParamArrayExt
     case QueuedExternalParamsComponentBase::PARAMID_PARAMARRAYEXT:
-      stat = buff.serialize(this->m_param_ParamArrayExt);
+      stat = buff.serializeFrom(this->m_param_ParamArrayExt);
       break;
     // ParamStructExt
     case QueuedExternalParamsComponentBase::PARAMID_PARAMSTRUCTEXT:
-      stat = buff.serialize(this->m_param_ParamStructExt);
+      stat = buff.serializeFrom(this->m_param_ParamStructExt);
       break;
     default:
       // Unknown ID; should not have gotten here
@@ -2523,7 +2523,7 @@ void QueuedExternalParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamI32Ext) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamI32Ext) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -2582,7 +2582,7 @@ void QueuedExternalParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamF64Ext) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamF64Ext) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -2641,7 +2641,7 @@ void QueuedExternalParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamStringExt) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamStringExt) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -2700,7 +2700,7 @@ void QueuedExternalParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamEnumExt) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamEnumExt) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -2759,7 +2759,7 @@ void QueuedExternalParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamArrayExt) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamArrayExt) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -2818,7 +2818,7 @@ void QueuedExternalParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamStructExt) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamStructExt) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -3080,7 +3080,7 @@ Fw::ParamValid QueuedExternalParamsTesterBase ::
 
   switch (id - idBase) {
     case QueuedExternalParamsComponentBase::PARAMID_PARAMI32EXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamI32Ext);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamI32Ext);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamI32Ext_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -3090,7 +3090,7 @@ Fw::ParamValid QueuedExternalParamsTesterBase ::
     };
 
     case QueuedExternalParamsComponentBase::PARAMID_PARAMF64EXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamF64Ext);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamF64Ext);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamF64Ext_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -3100,7 +3100,7 @@ Fw::ParamValid QueuedExternalParamsTesterBase ::
     };
 
     case QueuedExternalParamsComponentBase::PARAMID_PARAMSTRINGEXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamStringExt);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamStringExt);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamStringExt_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -3110,7 +3110,7 @@ Fw::ParamValid QueuedExternalParamsTesterBase ::
     };
 
     case QueuedExternalParamsComponentBase::PARAMID_PARAMENUMEXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamEnumExt);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamEnumExt);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamEnumExt_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -3120,7 +3120,7 @@ Fw::ParamValid QueuedExternalParamsTesterBase ::
     };
 
     case QueuedExternalParamsComponentBase::PARAMID_PARAMARRAYEXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamArrayExt);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamArrayExt);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamArrayExt_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -3130,7 +3130,7 @@ Fw::ParamValid QueuedExternalParamsTesterBase ::
     };
 
     case QueuedExternalParamsComponentBase::PARAMID_PARAMSTRUCTEXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamStructExt);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamStructExt);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamStructExt_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -3168,7 +3168,7 @@ void QueuedExternalParamsTesterBase ::
   switch (id - idBase) {
     case QueuedExternalParamsComponentBase::PARAMID_PARAMI32EXT: {
       I32 ParamI32ExtVal;
-      _status = val.deserialize(ParamI32ExtVal);
+      _status = val.deserializeTo(ParamI32ExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3182,7 +3182,7 @@ void QueuedExternalParamsTesterBase ::
 
     case QueuedExternalParamsComponentBase::PARAMID_PARAMF64EXT: {
       F64 ParamF64ExtVal;
-      _status = val.deserialize(ParamF64ExtVal);
+      _status = val.deserializeTo(ParamF64ExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3196,7 +3196,7 @@ void QueuedExternalParamsTesterBase ::
 
     case QueuedExternalParamsComponentBase::PARAMID_PARAMSTRINGEXT: {
       Fw::ParamString ParamStringExtVal;
-      _status = val.deserialize(ParamStringExtVal);
+      _status = val.deserializeTo(ParamStringExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3210,7 +3210,7 @@ void QueuedExternalParamsTesterBase ::
 
     case QueuedExternalParamsComponentBase::PARAMID_PARAMENUMEXT: {
       E ParamEnumExtVal;
-      _status = val.deserialize(ParamEnumExtVal);
+      _status = val.deserializeTo(ParamEnumExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3224,7 +3224,7 @@ void QueuedExternalParamsTesterBase ::
 
     case QueuedExternalParamsComponentBase::PARAMID_PARAMARRAYEXT: {
       A ParamArrayExtVal;
-      _status = val.deserialize(ParamArrayExtVal);
+      _status = val.deserializeTo(ParamArrayExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3238,7 +3238,7 @@ void QueuedExternalParamsTesterBase ::
 
     case QueuedExternalParamsComponentBase::PARAMID_PARAMSTRUCTEXT: {
       S ParamStructExtVal;
-      _status = val.deserialize(ParamStructExtVal);
+      _status = val.deserializeTo(ParamStructExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsTesterBase.ref.cpp
@@ -2434,7 +2434,7 @@ void QueuedParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamU32) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamU32) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -2493,7 +2493,7 @@ void QueuedParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamF64) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamF64) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -2552,7 +2552,7 @@ void QueuedParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamString) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamString) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -2611,7 +2611,7 @@ void QueuedParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamEnum) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamEnum) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -2670,7 +2670,7 @@ void QueuedParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamArray) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamArray) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -2729,7 +2729,7 @@ void QueuedParamsTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamStruct) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamStruct) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -2991,7 +2991,7 @@ Fw::ParamValid QueuedParamsTesterBase ::
 
   switch (id - idBase) {
     case QueuedParamsComponentBase::PARAMID_PARAMU32: {
-      _status = val.serialize(_testerBase->m_param_ParamU32);
+      _status = val.serializeFrom(_testerBase->m_param_ParamU32);
       _ret = _testerBase->m_param_ParamU32_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -3001,7 +3001,7 @@ Fw::ParamValid QueuedParamsTesterBase ::
     };
 
     case QueuedParamsComponentBase::PARAMID_PARAMF64: {
-      _status = val.serialize(_testerBase->m_param_ParamF64);
+      _status = val.serializeFrom(_testerBase->m_param_ParamF64);
       _ret = _testerBase->m_param_ParamF64_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -3011,7 +3011,7 @@ Fw::ParamValid QueuedParamsTesterBase ::
     };
 
     case QueuedParamsComponentBase::PARAMID_PARAMSTRING: {
-      _status = val.serialize(_testerBase->m_param_ParamString);
+      _status = val.serializeFrom(_testerBase->m_param_ParamString);
       _ret = _testerBase->m_param_ParamString_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -3021,7 +3021,7 @@ Fw::ParamValid QueuedParamsTesterBase ::
     };
 
     case QueuedParamsComponentBase::PARAMID_PARAMENUM: {
-      _status = val.serialize(_testerBase->m_param_ParamEnum);
+      _status = val.serializeFrom(_testerBase->m_param_ParamEnum);
       _ret = _testerBase->m_param_ParamEnum_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -3031,7 +3031,7 @@ Fw::ParamValid QueuedParamsTesterBase ::
     };
 
     case QueuedParamsComponentBase::PARAMID_PARAMARRAY: {
-      _status = val.serialize(_testerBase->m_param_ParamArray);
+      _status = val.serializeFrom(_testerBase->m_param_ParamArray);
       _ret = _testerBase->m_param_ParamArray_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -3041,7 +3041,7 @@ Fw::ParamValid QueuedParamsTesterBase ::
     };
 
     case QueuedParamsComponentBase::PARAMID_PARAMSTRUCT: {
-      _status = val.serialize(_testerBase->m_param_ParamStruct);
+      _status = val.serializeFrom(_testerBase->m_param_ParamStruct);
       _ret = _testerBase->m_param_ParamStruct_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -3079,7 +3079,7 @@ void QueuedParamsTesterBase ::
   switch (id - idBase) {
     case QueuedParamsComponentBase::PARAMID_PARAMU32: {
       U32 ParamU32Val;
-      _status = val.deserialize(ParamU32Val);
+      _status = val.deserializeTo(ParamU32Val);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3093,7 +3093,7 @@ void QueuedParamsTesterBase ::
 
     case QueuedParamsComponentBase::PARAMID_PARAMF64: {
       F64 ParamF64Val;
-      _status = val.deserialize(ParamF64Val);
+      _status = val.deserializeTo(ParamF64Val);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3107,7 +3107,7 @@ void QueuedParamsTesterBase ::
 
     case QueuedParamsComponentBase::PARAMID_PARAMSTRING: {
       Fw::ParamString ParamStringVal;
-      _status = val.deserialize(ParamStringVal);
+      _status = val.deserializeTo(ParamStringVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3121,7 +3121,7 @@ void QueuedParamsTesterBase ::
 
     case QueuedParamsComponentBase::PARAMID_PARAMENUM: {
       E ParamEnumVal;
-      _status = val.deserialize(ParamEnumVal);
+      _status = val.deserializeTo(ParamEnumVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3135,7 +3135,7 @@ void QueuedParamsTesterBase ::
 
     case QueuedParamsComponentBase::PARAMID_PARAMARRAY: {
       A ParamArrayVal;
-      _status = val.deserialize(ParamArrayVal);
+      _status = val.deserializeTo(ParamArrayVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3149,7 +3149,7 @@ void QueuedParamsTesterBase ::
 
     case QueuedParamsComponentBase::PARAMID_PARAMSTRUCT: {
       S ParamStructVal;
-      _status = val.deserialize(ParamStructVal);
+      _status = val.deserializeTo(ParamStructVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.cpp
@@ -29,27 +29,27 @@ Fw::SerializeStatus QueuedSerialTesterBase::QueuedSerialComponentBaseParamExtern
   {
     // ParamI32Ext
     case QueuedSerialComponentBase::PARAMID_PARAMI32EXT:
-      stat = buff.deserialize(this->m_param_ParamI32Ext);
+      stat = buff.deserializeTo(this->m_param_ParamI32Ext);
       break;
     // ParamF64Ext
     case QueuedSerialComponentBase::PARAMID_PARAMF64EXT:
-      stat = buff.deserialize(this->m_param_ParamF64Ext);
+      stat = buff.deserializeTo(this->m_param_ParamF64Ext);
       break;
     // ParamStringExt
     case QueuedSerialComponentBase::PARAMID_PARAMSTRINGEXT:
-      stat = buff.deserialize(this->m_param_ParamStringExt);
+      stat = buff.deserializeTo(this->m_param_ParamStringExt);
       break;
     // ParamEnumExt
     case QueuedSerialComponentBase::PARAMID_PARAMENUMEXT:
-      stat = buff.deserialize(this->m_param_ParamEnumExt);
+      stat = buff.deserializeTo(this->m_param_ParamEnumExt);
       break;
     // ParamArrayExt
     case QueuedSerialComponentBase::PARAMID_PARAMARRAYEXT:
-      stat = buff.deserialize(this->m_param_ParamArrayExt);
+      stat = buff.deserializeTo(this->m_param_ParamArrayExt);
       break;
     // ParamStructExt
     case QueuedSerialComponentBase::PARAMID_PARAMSTRUCTEXT:
-      stat = buff.deserialize(this->m_param_ParamStructExt);
+      stat = buff.deserializeTo(this->m_param_ParamStructExt);
       break;
     default:
       // Unknown ID; should not have gotten here
@@ -74,27 +74,27 @@ Fw::SerializeStatus QueuedSerialTesterBase::QueuedSerialComponentBaseParamExtern
   {
     // ParamI32Ext
     case QueuedSerialComponentBase::PARAMID_PARAMI32EXT:
-      stat = buff.serialize(this->m_param_ParamI32Ext);
+      stat = buff.serializeFrom(this->m_param_ParamI32Ext);
       break;
     // ParamF64Ext
     case QueuedSerialComponentBase::PARAMID_PARAMF64EXT:
-      stat = buff.serialize(this->m_param_ParamF64Ext);
+      stat = buff.serializeFrom(this->m_param_ParamF64Ext);
       break;
     // ParamStringExt
     case QueuedSerialComponentBase::PARAMID_PARAMSTRINGEXT:
-      stat = buff.serialize(this->m_param_ParamStringExt);
+      stat = buff.serializeFrom(this->m_param_ParamStringExt);
       break;
     // ParamEnumExt
     case QueuedSerialComponentBase::PARAMID_PARAMENUMEXT:
-      stat = buff.serialize(this->m_param_ParamEnumExt);
+      stat = buff.serializeFrom(this->m_param_ParamEnumExt);
       break;
     // ParamArrayExt
     case QueuedSerialComponentBase::PARAMID_PARAMARRAYEXT:
-      stat = buff.serialize(this->m_param_ParamArrayExt);
+      stat = buff.serializeFrom(this->m_param_ParamArrayExt);
       break;
     // ParamStructExt
     case QueuedSerialComponentBase::PARAMID_PARAMSTRUCTEXT:
-      stat = buff.serialize(this->m_param_ParamStructExt);
+      stat = buff.serializeFrom(this->m_param_ParamStructExt);
       break;
     default:
       // Unknown ID; should not have gotten here
@@ -3132,19 +3132,19 @@ void QueuedSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(u32);
+  _status = buf.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(f32);
+  _status = buf.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(b);
+  _status = buf.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3179,13 +3179,13 @@ void QueuedSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+  _status = str1.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+  _status = str2.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3219,7 +3219,7 @@ void QueuedSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(e);
+  _status = buf.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3253,7 +3253,7 @@ void QueuedSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(a);
+  _status = buf.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3287,7 +3287,7 @@ void QueuedSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(s);
+  _status = buf.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3348,19 +3348,19 @@ void QueuedSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(u32);
+  _status = buf.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(f32);
+  _status = buf.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(b);
+  _status = buf.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3395,13 +3395,13 @@ void QueuedSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+  _status = str1.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+  _status = str2.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3435,7 +3435,7 @@ void QueuedSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(e);
+  _status = buf.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3469,7 +3469,7 @@ void QueuedSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(a);
+  _status = buf.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3503,7 +3503,7 @@ void QueuedSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(s);
+  _status = buf.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3587,7 +3587,7 @@ void QueuedSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(u32);
+  _status = buf.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3646,7 +3646,7 @@ void QueuedSerialTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(u32);
+  _status = buf.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3696,7 +3696,7 @@ void QueuedSerialTesterBase ::
       // For AMPCS, decode zero arguments
       Fw::SerializeStatus _zero_status = Fw::FW_SERIALIZE_OK;
       U8 _noArgs;
-      _zero_status = args.deserialize(_noArgs);
+      _zero_status = args.deserializeTo(_noArgs);
       FW_ASSERT(
         _zero_status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_zero_status)
@@ -3712,7 +3712,7 @@ void QueuedSerialTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3730,7 +3730,7 @@ void QueuedSerialTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3742,7 +3742,7 @@ void QueuedSerialTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_u32);
+      _status = args.deserializeTo(_event_arg_u32);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3753,7 +3753,7 @@ void QueuedSerialTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3765,7 +3765,7 @@ void QueuedSerialTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_f32);
+      _status = args.deserializeTo(_event_arg_f32);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3776,7 +3776,7 @@ void QueuedSerialTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3788,7 +3788,7 @@ void QueuedSerialTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_b);
+      _status = args.deserializeTo(_event_arg_b);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3803,7 +3803,7 @@ void QueuedSerialTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3821,7 +3821,7 @@ void QueuedSerialTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3833,7 +3833,7 @@ void QueuedSerialTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_str1);
+      _status = args.deserializeTo(_event_arg_str1);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3844,7 +3844,7 @@ void QueuedSerialTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3856,7 +3856,7 @@ void QueuedSerialTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_str2);
+      _status = args.deserializeTo(_event_arg_str2);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3871,7 +3871,7 @@ void QueuedSerialTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3889,7 +3889,7 @@ void QueuedSerialTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3901,7 +3901,7 @@ void QueuedSerialTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_e);
+      _status = args.deserializeTo(_event_arg_e);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3916,7 +3916,7 @@ void QueuedSerialTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3930,7 +3930,7 @@ void QueuedSerialTesterBase ::
 
       // For FATAL, there is a stack size of 4 and a dummy entry
       U8 stackArgLen;
-      _status = args.deserialize(stackArgLen);
+      _status = args.deserializeTo(stackArgLen);
       FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3941,7 +3941,7 @@ void QueuedSerialTesterBase ::
       );
 
       U32 dummyStackArg;
-      _status = args.deserialize(dummyStackArg);
+      _status = args.deserializeTo(dummyStackArg);
       FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3957,7 +3957,7 @@ void QueuedSerialTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3969,7 +3969,7 @@ void QueuedSerialTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_a);
+      _status = args.deserializeTo(_event_arg_a);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3984,7 +3984,7 @@ void QueuedSerialTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -4002,7 +4002,7 @@ void QueuedSerialTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -4014,7 +4014,7 @@ void QueuedSerialTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_s);
+      _status = args.deserializeTo(_event_arg_s);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -4028,7 +4028,7 @@ void QueuedSerialTesterBase ::
       // For AMPCS, decode zero arguments
       Fw::SerializeStatus _zero_status = Fw::FW_SERIALIZE_OK;
       U8 _noArgs;
-      _zero_status = args.deserialize(_noArgs);
+      _zero_status = args.deserializeTo(_noArgs);
       FW_ASSERT(
         _zero_status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_zero_status)
@@ -4158,7 +4158,7 @@ void QueuedSerialTesterBase ::
   switch (id - idBase) {
     case QueuedSerialComponentBase::CHANNELID_CHANNELU32FORMAT: {
       U32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelU32Format: %d\n", _status);
@@ -4171,7 +4171,7 @@ void QueuedSerialTesterBase ::
 
     case QueuedSerialComponentBase::CHANNELID_CHANNELF32FORMAT: {
       F32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelF32Format: %d\n", _status);
@@ -4184,7 +4184,7 @@ void QueuedSerialTesterBase ::
 
     case QueuedSerialComponentBase::CHANNELID_CHANNELSTRINGFORMAT: {
       Fw::TlmString arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelStringFormat: %d\n", _status);
@@ -4197,7 +4197,7 @@ void QueuedSerialTesterBase ::
 
     case QueuedSerialComponentBase::CHANNELID_CHANNELENUM: {
       E arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelEnum: %d\n", _status);
@@ -4210,7 +4210,7 @@ void QueuedSerialTesterBase ::
 
     case QueuedSerialComponentBase::CHANNELID_CHANNELARRAYFREQ: {
       A arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelArrayFreq: %d\n", _status);
@@ -4223,7 +4223,7 @@ void QueuedSerialTesterBase ::
 
     case QueuedSerialComponentBase::CHANNELID_CHANNELSTRUCTFREQ: {
       S arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelStructFreq: %d\n", _status);
@@ -4236,7 +4236,7 @@ void QueuedSerialTesterBase ::
 
     case QueuedSerialComponentBase::CHANNELID_CHANNELU32LIMITS: {
       U32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelU32Limits: %d\n", _status);
@@ -4249,7 +4249,7 @@ void QueuedSerialTesterBase ::
 
     case QueuedSerialComponentBase::CHANNELID_CHANNELF32LIMITS: {
       F32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelF32Limits: %d\n", _status);
@@ -4262,7 +4262,7 @@ void QueuedSerialTesterBase ::
 
     case QueuedSerialComponentBase::CHANNELID_CHANNELF64: {
       F64 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelF64: %d\n", _status);
@@ -4275,7 +4275,7 @@ void QueuedSerialTesterBase ::
 
     case QueuedSerialComponentBase::CHANNELID_CHANNELU32ONCHANGE: {
       U32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelU32OnChange: %d\n", _status);
@@ -4288,7 +4288,7 @@ void QueuedSerialTesterBase ::
 
     case QueuedSerialComponentBase::CHANNELID_CHANNELENUMONCHANGE: {
       E arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelEnumOnChange: %d\n", _status);
@@ -4450,7 +4450,7 @@ void QueuedSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamU32) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamU32) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4509,7 +4509,7 @@ void QueuedSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamF64) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamF64) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4568,7 +4568,7 @@ void QueuedSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamString) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamString) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4627,7 +4627,7 @@ void QueuedSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamEnum) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamEnum) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4686,7 +4686,7 @@ void QueuedSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamArray) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamArray) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4745,7 +4745,7 @@ void QueuedSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamStruct) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamStruct) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4804,7 +4804,7 @@ void QueuedSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamI32Ext) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamI32Ext) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4863,7 +4863,7 @@ void QueuedSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamF64Ext) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamF64Ext) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4922,7 +4922,7 @@ void QueuedSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamStringExt) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamStringExt) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4981,7 +4981,7 @@ void QueuedSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamEnumExt) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamEnumExt) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -5040,7 +5040,7 @@ void QueuedSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamArrayExt) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamArrayExt) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -5099,7 +5099,7 @@ void QueuedSerialTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamStructExt) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamStructExt) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -5472,7 +5472,7 @@ Fw::ParamValid QueuedSerialTesterBase ::
 
   switch (id - idBase) {
     case QueuedSerialComponentBase::PARAMID_PARAMU32: {
-      _status = val.serialize(_testerBase->m_param_ParamU32);
+      _status = val.serializeFrom(_testerBase->m_param_ParamU32);
       _ret = _testerBase->m_param_ParamU32_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5482,7 +5482,7 @@ Fw::ParamValid QueuedSerialTesterBase ::
     };
 
     case QueuedSerialComponentBase::PARAMID_PARAMF64: {
-      _status = val.serialize(_testerBase->m_param_ParamF64);
+      _status = val.serializeFrom(_testerBase->m_param_ParamF64);
       _ret = _testerBase->m_param_ParamF64_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5492,7 +5492,7 @@ Fw::ParamValid QueuedSerialTesterBase ::
     };
 
     case QueuedSerialComponentBase::PARAMID_PARAMSTRING: {
-      _status = val.serialize(_testerBase->m_param_ParamString);
+      _status = val.serializeFrom(_testerBase->m_param_ParamString);
       _ret = _testerBase->m_param_ParamString_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5502,7 +5502,7 @@ Fw::ParamValid QueuedSerialTesterBase ::
     };
 
     case QueuedSerialComponentBase::PARAMID_PARAMENUM: {
-      _status = val.serialize(_testerBase->m_param_ParamEnum);
+      _status = val.serializeFrom(_testerBase->m_param_ParamEnum);
       _ret = _testerBase->m_param_ParamEnum_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5512,7 +5512,7 @@ Fw::ParamValid QueuedSerialTesterBase ::
     };
 
     case QueuedSerialComponentBase::PARAMID_PARAMARRAY: {
-      _status = val.serialize(_testerBase->m_param_ParamArray);
+      _status = val.serializeFrom(_testerBase->m_param_ParamArray);
       _ret = _testerBase->m_param_ParamArray_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5522,7 +5522,7 @@ Fw::ParamValid QueuedSerialTesterBase ::
     };
 
     case QueuedSerialComponentBase::PARAMID_PARAMSTRUCT: {
-      _status = val.serialize(_testerBase->m_param_ParamStruct);
+      _status = val.serializeFrom(_testerBase->m_param_ParamStruct);
       _ret = _testerBase->m_param_ParamStruct_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5532,7 +5532,7 @@ Fw::ParamValid QueuedSerialTesterBase ::
     };
 
     case QueuedSerialComponentBase::PARAMID_PARAMI32EXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamI32Ext);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamI32Ext);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamI32Ext_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5542,7 +5542,7 @@ Fw::ParamValid QueuedSerialTesterBase ::
     };
 
     case QueuedSerialComponentBase::PARAMID_PARAMF64EXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamF64Ext);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamF64Ext);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamF64Ext_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5552,7 +5552,7 @@ Fw::ParamValid QueuedSerialTesterBase ::
     };
 
     case QueuedSerialComponentBase::PARAMID_PARAMSTRINGEXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamStringExt);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamStringExt);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamStringExt_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5562,7 +5562,7 @@ Fw::ParamValid QueuedSerialTesterBase ::
     };
 
     case QueuedSerialComponentBase::PARAMID_PARAMENUMEXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamEnumExt);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamEnumExt);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamEnumExt_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5572,7 +5572,7 @@ Fw::ParamValid QueuedSerialTesterBase ::
     };
 
     case QueuedSerialComponentBase::PARAMID_PARAMARRAYEXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamArrayExt);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamArrayExt);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamArrayExt_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5582,7 +5582,7 @@ Fw::ParamValid QueuedSerialTesterBase ::
     };
 
     case QueuedSerialComponentBase::PARAMID_PARAMSTRUCTEXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamStructExt);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamStructExt);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamStructExt_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5620,7 +5620,7 @@ void QueuedSerialTesterBase ::
   switch (id - idBase) {
     case QueuedSerialComponentBase::PARAMID_PARAMU32: {
       U32 ParamU32Val;
-      _status = val.deserialize(ParamU32Val);
+      _status = val.deserializeTo(ParamU32Val);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5634,7 +5634,7 @@ void QueuedSerialTesterBase ::
 
     case QueuedSerialComponentBase::PARAMID_PARAMF64: {
       F64 ParamF64Val;
-      _status = val.deserialize(ParamF64Val);
+      _status = val.deserializeTo(ParamF64Val);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5648,7 +5648,7 @@ void QueuedSerialTesterBase ::
 
     case QueuedSerialComponentBase::PARAMID_PARAMSTRING: {
       Fw::ParamString ParamStringVal;
-      _status = val.deserialize(ParamStringVal);
+      _status = val.deserializeTo(ParamStringVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5662,7 +5662,7 @@ void QueuedSerialTesterBase ::
 
     case QueuedSerialComponentBase::PARAMID_PARAMENUM: {
       E ParamEnumVal;
-      _status = val.deserialize(ParamEnumVal);
+      _status = val.deserializeTo(ParamEnumVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5676,7 +5676,7 @@ void QueuedSerialTesterBase ::
 
     case QueuedSerialComponentBase::PARAMID_PARAMARRAY: {
       A ParamArrayVal;
-      _status = val.deserialize(ParamArrayVal);
+      _status = val.deserializeTo(ParamArrayVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5690,7 +5690,7 @@ void QueuedSerialTesterBase ::
 
     case QueuedSerialComponentBase::PARAMID_PARAMSTRUCT: {
       S ParamStructVal;
-      _status = val.deserialize(ParamStructVal);
+      _status = val.deserializeTo(ParamStructVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5704,7 +5704,7 @@ void QueuedSerialTesterBase ::
 
     case QueuedSerialComponentBase::PARAMID_PARAMI32EXT: {
       I32 ParamI32ExtVal;
-      _status = val.deserialize(ParamI32ExtVal);
+      _status = val.deserializeTo(ParamI32ExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5718,7 +5718,7 @@ void QueuedSerialTesterBase ::
 
     case QueuedSerialComponentBase::PARAMID_PARAMF64EXT: {
       F64 ParamF64ExtVal;
-      _status = val.deserialize(ParamF64ExtVal);
+      _status = val.deserializeTo(ParamF64ExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5732,7 +5732,7 @@ void QueuedSerialTesterBase ::
 
     case QueuedSerialComponentBase::PARAMID_PARAMSTRINGEXT: {
       Fw::ParamString ParamStringExtVal;
-      _status = val.deserialize(ParamStringExtVal);
+      _status = val.deserializeTo(ParamStringExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5746,7 +5746,7 @@ void QueuedSerialTesterBase ::
 
     case QueuedSerialComponentBase::PARAMID_PARAMENUMEXT: {
       E ParamEnumExtVal;
-      _status = val.deserialize(ParamEnumExtVal);
+      _status = val.deserializeTo(ParamEnumExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5760,7 +5760,7 @@ void QueuedSerialTesterBase ::
 
     case QueuedSerialComponentBase::PARAMID_PARAMARRAYEXT: {
       A ParamArrayExtVal;
-      _status = val.deserialize(ParamArrayExtVal);
+      _status = val.deserializeTo(ParamArrayExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5774,7 +5774,7 @@ void QueuedSerialTesterBase ::
 
     case QueuedSerialComponentBase::PARAMID_PARAMSTRUCTEXT: {
       S ParamStructExtVal;
-      _status = val.deserialize(ParamStructExtVal);
+      _status = val.deserializeTo(ParamStructExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryTesterBase.ref.cpp
@@ -2321,7 +2321,7 @@ void QueuedTelemetryTesterBase ::
   switch (id - idBase) {
     case QueuedTelemetryComponentBase::CHANNELID_CHANNELU32FORMAT: {
       U32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelU32Format: %d\n", _status);
@@ -2334,7 +2334,7 @@ void QueuedTelemetryTesterBase ::
 
     case QueuedTelemetryComponentBase::CHANNELID_CHANNELF32FORMAT: {
       F32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelF32Format: %d\n", _status);
@@ -2347,7 +2347,7 @@ void QueuedTelemetryTesterBase ::
 
     case QueuedTelemetryComponentBase::CHANNELID_CHANNELSTRINGFORMAT: {
       Fw::TlmString arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelStringFormat: %d\n", _status);
@@ -2360,7 +2360,7 @@ void QueuedTelemetryTesterBase ::
 
     case QueuedTelemetryComponentBase::CHANNELID_CHANNELENUM: {
       E arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelEnum: %d\n", _status);
@@ -2373,7 +2373,7 @@ void QueuedTelemetryTesterBase ::
 
     case QueuedTelemetryComponentBase::CHANNELID_CHANNELARRAYFREQ: {
       A arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelArrayFreq: %d\n", _status);
@@ -2386,7 +2386,7 @@ void QueuedTelemetryTesterBase ::
 
     case QueuedTelemetryComponentBase::CHANNELID_CHANNELSTRUCTFREQ: {
       S arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelStructFreq: %d\n", _status);
@@ -2399,7 +2399,7 @@ void QueuedTelemetryTesterBase ::
 
     case QueuedTelemetryComponentBase::CHANNELID_CHANNELU32LIMITS: {
       U32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelU32Limits: %d\n", _status);
@@ -2412,7 +2412,7 @@ void QueuedTelemetryTesterBase ::
 
     case QueuedTelemetryComponentBase::CHANNELID_CHANNELF32LIMITS: {
       F32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelF32Limits: %d\n", _status);
@@ -2425,7 +2425,7 @@ void QueuedTelemetryTesterBase ::
 
     case QueuedTelemetryComponentBase::CHANNELID_CHANNELF64: {
       F64 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelF64: %d\n", _status);
@@ -2438,7 +2438,7 @@ void QueuedTelemetryTesterBase ::
 
     case QueuedTelemetryComponentBase::CHANNELID_CHANNELU32ONCHANGE: {
       U32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelU32OnChange: %d\n", _status);
@@ -2451,7 +2451,7 @@ void QueuedTelemetryTesterBase ::
 
     case QueuedTelemetryComponentBase::CHANNELID_CHANNELENUMONCHANGE: {
       E arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelEnumOnChange: %d\n", _status);

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.cpp
@@ -29,27 +29,27 @@ Fw::SerializeStatus QueuedTestTesterBase::QueuedTestComponentBaseParamExternalDe
   {
     // ParamI32Ext
     case QueuedTestComponentBase::PARAMID_PARAMI32EXT:
-      stat = buff.deserialize(this->m_param_ParamI32Ext);
+      stat = buff.deserializeTo(this->m_param_ParamI32Ext);
       break;
     // ParamF64Ext
     case QueuedTestComponentBase::PARAMID_PARAMF64EXT:
-      stat = buff.deserialize(this->m_param_ParamF64Ext);
+      stat = buff.deserializeTo(this->m_param_ParamF64Ext);
       break;
     // ParamStringExt
     case QueuedTestComponentBase::PARAMID_PARAMSTRINGEXT:
-      stat = buff.deserialize(this->m_param_ParamStringExt);
+      stat = buff.deserializeTo(this->m_param_ParamStringExt);
       break;
     // ParamEnumExt
     case QueuedTestComponentBase::PARAMID_PARAMENUMEXT:
-      stat = buff.deserialize(this->m_param_ParamEnumExt);
+      stat = buff.deserializeTo(this->m_param_ParamEnumExt);
       break;
     // ParamArrayExt
     case QueuedTestComponentBase::PARAMID_PARAMARRAYEXT:
-      stat = buff.deserialize(this->m_param_ParamArrayExt);
+      stat = buff.deserializeTo(this->m_param_ParamArrayExt);
       break;
     // ParamStructExt
     case QueuedTestComponentBase::PARAMID_PARAMSTRUCTEXT:
-      stat = buff.deserialize(this->m_param_ParamStructExt);
+      stat = buff.deserializeTo(this->m_param_ParamStructExt);
       break;
     default:
       // Unknown ID; should not have gotten here
@@ -74,27 +74,27 @@ Fw::SerializeStatus QueuedTestTesterBase::QueuedTestComponentBaseParamExternalDe
   {
     // ParamI32Ext
     case QueuedTestComponentBase::PARAMID_PARAMI32EXT:
-      stat = buff.serialize(this->m_param_ParamI32Ext);
+      stat = buff.serializeFrom(this->m_param_ParamI32Ext);
       break;
     // ParamF64Ext
     case QueuedTestComponentBase::PARAMID_PARAMF64EXT:
-      stat = buff.serialize(this->m_param_ParamF64Ext);
+      stat = buff.serializeFrom(this->m_param_ParamF64Ext);
       break;
     // ParamStringExt
     case QueuedTestComponentBase::PARAMID_PARAMSTRINGEXT:
-      stat = buff.serialize(this->m_param_ParamStringExt);
+      stat = buff.serializeFrom(this->m_param_ParamStringExt);
       break;
     // ParamEnumExt
     case QueuedTestComponentBase::PARAMID_PARAMENUMEXT:
-      stat = buff.serialize(this->m_param_ParamEnumExt);
+      stat = buff.serializeFrom(this->m_param_ParamEnumExt);
       break;
     // ParamArrayExt
     case QueuedTestComponentBase::PARAMID_PARAMARRAYEXT:
-      stat = buff.serialize(this->m_param_ParamArrayExt);
+      stat = buff.serializeFrom(this->m_param_ParamArrayExt);
       break;
     // ParamStructExt
     case QueuedTestComponentBase::PARAMID_PARAMSTRUCTEXT:
-      stat = buff.serialize(this->m_param_ParamStructExt);
+      stat = buff.serializeFrom(this->m_param_ParamStructExt);
       break;
     default:
       // Unknown ID; should not have gotten here
@@ -2804,19 +2804,19 @@ void QueuedTestTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(u32);
+  _status = buf.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(f32);
+  _status = buf.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(b);
+  _status = buf.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2851,13 +2851,13 @@ void QueuedTestTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+  _status = str1.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+  _status = str2.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2891,7 +2891,7 @@ void QueuedTestTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(e);
+  _status = buf.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2925,7 +2925,7 @@ void QueuedTestTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(a);
+  _status = buf.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -2959,7 +2959,7 @@ void QueuedTestTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(s);
+  _status = buf.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3020,19 +3020,19 @@ void QueuedTestTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(u32);
+  _status = buf.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(f32);
+  _status = buf.serializeFrom(f32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = buf.serialize(b);
+  _status = buf.serializeFrom(b);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3067,13 +3067,13 @@ void QueuedTestTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = str1.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+  _status = str1.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
   );
 
-  _status = str2.serialize(buf, FW_CMD_STRING_MAX_SIZE);
+  _status = str2.serializeTo(buf, FW_CMD_STRING_MAX_SIZE);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3107,7 +3107,7 @@ void QueuedTestTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(e);
+  _status = buf.serializeFrom(e);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3141,7 +3141,7 @@ void QueuedTestTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(a);
+  _status = buf.serializeFrom(a);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3175,7 +3175,7 @@ void QueuedTestTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(s);
+  _status = buf.serializeFrom(s);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3259,7 +3259,7 @@ void QueuedTestTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(u32);
+  _status = buf.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3318,7 +3318,7 @@ void QueuedTestTesterBase ::
   Fw::CmdArgBuffer buf;
   Fw::SerializeStatus _status;
 
-  _status = buf.serialize(u32);
+  _status = buf.serializeFrom(u32);
   FW_ASSERT(
     _status == Fw::FW_SERIALIZE_OK,
     static_cast<FwAssertArgType>(_status)
@@ -3368,7 +3368,7 @@ void QueuedTestTesterBase ::
       // For AMPCS, decode zero arguments
       Fw::SerializeStatus _zero_status = Fw::FW_SERIALIZE_OK;
       U8 _noArgs;
-      _zero_status = args.deserialize(_noArgs);
+      _zero_status = args.deserializeTo(_noArgs);
       FW_ASSERT(
         _zero_status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_zero_status)
@@ -3384,7 +3384,7 @@ void QueuedTestTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3402,7 +3402,7 @@ void QueuedTestTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3414,7 +3414,7 @@ void QueuedTestTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_u32);
+      _status = args.deserializeTo(_event_arg_u32);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3425,7 +3425,7 @@ void QueuedTestTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3437,7 +3437,7 @@ void QueuedTestTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_f32);
+      _status = args.deserializeTo(_event_arg_f32);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3448,7 +3448,7 @@ void QueuedTestTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3460,7 +3460,7 @@ void QueuedTestTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_b);
+      _status = args.deserializeTo(_event_arg_b);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3475,7 +3475,7 @@ void QueuedTestTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3493,7 +3493,7 @@ void QueuedTestTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3505,7 +3505,7 @@ void QueuedTestTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_str1);
+      _status = args.deserializeTo(_event_arg_str1);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3516,7 +3516,7 @@ void QueuedTestTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3528,7 +3528,7 @@ void QueuedTestTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_str2);
+      _status = args.deserializeTo(_event_arg_str2);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3543,7 +3543,7 @@ void QueuedTestTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3561,7 +3561,7 @@ void QueuedTestTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3573,7 +3573,7 @@ void QueuedTestTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_e);
+      _status = args.deserializeTo(_event_arg_e);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3588,7 +3588,7 @@ void QueuedTestTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3602,7 +3602,7 @@ void QueuedTestTesterBase ::
 
       // For FATAL, there is a stack size of 4 and a dummy entry
       U8 stackArgLen;
-      _status = args.deserialize(stackArgLen);
+      _status = args.deserializeTo(stackArgLen);
       FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3613,7 +3613,7 @@ void QueuedTestTesterBase ::
       );
 
       U32 dummyStackArg;
-      _status = args.deserialize(dummyStackArg);
+      _status = args.deserializeTo(dummyStackArg);
       FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3629,7 +3629,7 @@ void QueuedTestTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3641,7 +3641,7 @@ void QueuedTestTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_a);
+      _status = args.deserializeTo(_event_arg_a);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3656,7 +3656,7 @@ void QueuedTestTesterBase ::
 #if FW_AMPCS_COMPATIBLE
       // Deserialize the number of arguments.
       U8 _numArgs;
-      _status = args.deserialize(_numArgs);
+      _status = args.deserializeTo(_numArgs);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3674,7 +3674,7 @@ void QueuedTestTesterBase ::
       {
         // Deserialize the argument size
         U8 _argSize;
-        _status = args.deserialize(_argSize);
+        _status = args.deserializeTo(_argSize);
         FW_ASSERT(
           _status == Fw::FW_SERIALIZE_OK,
           static_cast<FwAssertArgType>(_status)
@@ -3686,7 +3686,7 @@ void QueuedTestTesterBase ::
         );
       }
 #endif
-      _status = args.deserialize(_event_arg_s);
+      _status = args.deserializeTo(_event_arg_s);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -3700,7 +3700,7 @@ void QueuedTestTesterBase ::
       // For AMPCS, decode zero arguments
       Fw::SerializeStatus _zero_status = Fw::FW_SERIALIZE_OK;
       U8 _noArgs;
-      _zero_status = args.deserialize(_noArgs);
+      _zero_status = args.deserializeTo(_noArgs);
       FW_ASSERT(
         _zero_status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_zero_status)
@@ -3830,7 +3830,7 @@ void QueuedTestTesterBase ::
   switch (id - idBase) {
     case QueuedTestComponentBase::CHANNELID_CHANNELU32FORMAT: {
       U32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelU32Format: %d\n", _status);
@@ -3843,7 +3843,7 @@ void QueuedTestTesterBase ::
 
     case QueuedTestComponentBase::CHANNELID_CHANNELF32FORMAT: {
       F32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelF32Format: %d\n", _status);
@@ -3856,7 +3856,7 @@ void QueuedTestTesterBase ::
 
     case QueuedTestComponentBase::CHANNELID_CHANNELSTRINGFORMAT: {
       Fw::TlmString arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelStringFormat: %d\n", _status);
@@ -3869,7 +3869,7 @@ void QueuedTestTesterBase ::
 
     case QueuedTestComponentBase::CHANNELID_CHANNELENUM: {
       E arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelEnum: %d\n", _status);
@@ -3882,7 +3882,7 @@ void QueuedTestTesterBase ::
 
     case QueuedTestComponentBase::CHANNELID_CHANNELARRAYFREQ: {
       A arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelArrayFreq: %d\n", _status);
@@ -3895,7 +3895,7 @@ void QueuedTestTesterBase ::
 
     case QueuedTestComponentBase::CHANNELID_CHANNELSTRUCTFREQ: {
       S arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelStructFreq: %d\n", _status);
@@ -3908,7 +3908,7 @@ void QueuedTestTesterBase ::
 
     case QueuedTestComponentBase::CHANNELID_CHANNELU32LIMITS: {
       U32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelU32Limits: %d\n", _status);
@@ -3921,7 +3921,7 @@ void QueuedTestTesterBase ::
 
     case QueuedTestComponentBase::CHANNELID_CHANNELF32LIMITS: {
       F32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelF32Limits: %d\n", _status);
@@ -3934,7 +3934,7 @@ void QueuedTestTesterBase ::
 
     case QueuedTestComponentBase::CHANNELID_CHANNELF64: {
       F64 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelF64: %d\n", _status);
@@ -3947,7 +3947,7 @@ void QueuedTestTesterBase ::
 
     case QueuedTestComponentBase::CHANNELID_CHANNELU32ONCHANGE: {
       U32 arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelU32OnChange: %d\n", _status);
@@ -3960,7 +3960,7 @@ void QueuedTestTesterBase ::
 
     case QueuedTestComponentBase::CHANNELID_CHANNELENUMONCHANGE: {
       E arg;
-      const Fw::SerializeStatus _status = val.deserialize(arg);
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
 
       if (_status != Fw::FW_SERIALIZE_OK) {
         printf("Error deserializing ChannelEnumOnChange: %d\n", _status);
@@ -4122,7 +4122,7 @@ void QueuedTestTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamU32) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamU32) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4181,7 +4181,7 @@ void QueuedTestTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamF64) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamF64) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4240,7 +4240,7 @@ void QueuedTestTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamString) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamString) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4299,7 +4299,7 @@ void QueuedTestTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamEnum) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamEnum) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4358,7 +4358,7 @@ void QueuedTestTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamArray) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamArray) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4417,7 +4417,7 @@ void QueuedTestTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->m_param_ParamStruct) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->m_param_ParamStruct) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4476,7 +4476,7 @@ void QueuedTestTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamI32Ext) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamI32Ext) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4535,7 +4535,7 @@ void QueuedTestTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamF64Ext) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamF64Ext) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4594,7 +4594,7 @@ void QueuedTestTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamStringExt) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamStringExt) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4653,7 +4653,7 @@ void QueuedTestTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamEnumExt) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamEnumExt) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4712,7 +4712,7 @@ void QueuedTestTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamArrayExt) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamArrayExt) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -4771,7 +4771,7 @@ void QueuedTestTesterBase ::
   // Build command for parameter set
   Fw::CmdArgBuffer args;
   FW_ASSERT(
-    args.serialize(this->paramTesterDelegate.m_param_ParamStructExt) == Fw::FW_SERIALIZE_OK
+    args.serializeFrom(this->paramTesterDelegate.m_param_ParamStructExt) == Fw::FW_SERIALIZE_OK
   );
 
   const U32 idBase = this->getIdBase();
@@ -5200,7 +5200,7 @@ Fw::ParamValid QueuedTestTesterBase ::
 
   switch (id - idBase) {
     case QueuedTestComponentBase::PARAMID_PARAMU32: {
-      _status = val.serialize(_testerBase->m_param_ParamU32);
+      _status = val.serializeFrom(_testerBase->m_param_ParamU32);
       _ret = _testerBase->m_param_ParamU32_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5210,7 +5210,7 @@ Fw::ParamValid QueuedTestTesterBase ::
     };
 
     case QueuedTestComponentBase::PARAMID_PARAMF64: {
-      _status = val.serialize(_testerBase->m_param_ParamF64);
+      _status = val.serializeFrom(_testerBase->m_param_ParamF64);
       _ret = _testerBase->m_param_ParamF64_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5220,7 +5220,7 @@ Fw::ParamValid QueuedTestTesterBase ::
     };
 
     case QueuedTestComponentBase::PARAMID_PARAMSTRING: {
-      _status = val.serialize(_testerBase->m_param_ParamString);
+      _status = val.serializeFrom(_testerBase->m_param_ParamString);
       _ret = _testerBase->m_param_ParamString_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5230,7 +5230,7 @@ Fw::ParamValid QueuedTestTesterBase ::
     };
 
     case QueuedTestComponentBase::PARAMID_PARAMENUM: {
-      _status = val.serialize(_testerBase->m_param_ParamEnum);
+      _status = val.serializeFrom(_testerBase->m_param_ParamEnum);
       _ret = _testerBase->m_param_ParamEnum_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5240,7 +5240,7 @@ Fw::ParamValid QueuedTestTesterBase ::
     };
 
     case QueuedTestComponentBase::PARAMID_PARAMARRAY: {
-      _status = val.serialize(_testerBase->m_param_ParamArray);
+      _status = val.serializeFrom(_testerBase->m_param_ParamArray);
       _ret = _testerBase->m_param_ParamArray_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5250,7 +5250,7 @@ Fw::ParamValid QueuedTestTesterBase ::
     };
 
     case QueuedTestComponentBase::PARAMID_PARAMSTRUCT: {
-      _status = val.serialize(_testerBase->m_param_ParamStruct);
+      _status = val.serializeFrom(_testerBase->m_param_ParamStruct);
       _ret = _testerBase->m_param_ParamStruct_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5260,7 +5260,7 @@ Fw::ParamValid QueuedTestTesterBase ::
     };
 
     case QueuedTestComponentBase::PARAMID_PARAMI32EXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamI32Ext);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamI32Ext);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamI32Ext_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5270,7 +5270,7 @@ Fw::ParamValid QueuedTestTesterBase ::
     };
 
     case QueuedTestComponentBase::PARAMID_PARAMF64EXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamF64Ext);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamF64Ext);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamF64Ext_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5280,7 +5280,7 @@ Fw::ParamValid QueuedTestTesterBase ::
     };
 
     case QueuedTestComponentBase::PARAMID_PARAMSTRINGEXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamStringExt);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamStringExt);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamStringExt_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5290,7 +5290,7 @@ Fw::ParamValid QueuedTestTesterBase ::
     };
 
     case QueuedTestComponentBase::PARAMID_PARAMENUMEXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamEnumExt);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamEnumExt);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamEnumExt_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5300,7 +5300,7 @@ Fw::ParamValid QueuedTestTesterBase ::
     };
 
     case QueuedTestComponentBase::PARAMID_PARAMARRAYEXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamArrayExt);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamArrayExt);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamArrayExt_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5310,7 +5310,7 @@ Fw::ParamValid QueuedTestTesterBase ::
     };
 
     case QueuedTestComponentBase::PARAMID_PARAMSTRUCTEXT: {
-      _status = val.serialize(_testerBase->paramTesterDelegate.m_param_ParamStructExt);
+      _status = val.serializeFrom(_testerBase->paramTesterDelegate.m_param_ParamStructExt);
       _ret = _testerBase->paramTesterDelegate.m_param_ParamStructExt_valid;
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
@@ -5348,7 +5348,7 @@ void QueuedTestTesterBase ::
   switch (id - idBase) {
     case QueuedTestComponentBase::PARAMID_PARAMU32: {
       U32 ParamU32Val;
-      _status = val.deserialize(ParamU32Val);
+      _status = val.deserializeTo(ParamU32Val);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5362,7 +5362,7 @@ void QueuedTestTesterBase ::
 
     case QueuedTestComponentBase::PARAMID_PARAMF64: {
       F64 ParamF64Val;
-      _status = val.deserialize(ParamF64Val);
+      _status = val.deserializeTo(ParamF64Val);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5376,7 +5376,7 @@ void QueuedTestTesterBase ::
 
     case QueuedTestComponentBase::PARAMID_PARAMSTRING: {
       Fw::ParamString ParamStringVal;
-      _status = val.deserialize(ParamStringVal);
+      _status = val.deserializeTo(ParamStringVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5390,7 +5390,7 @@ void QueuedTestTesterBase ::
 
     case QueuedTestComponentBase::PARAMID_PARAMENUM: {
       E ParamEnumVal;
-      _status = val.deserialize(ParamEnumVal);
+      _status = val.deserializeTo(ParamEnumVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5404,7 +5404,7 @@ void QueuedTestTesterBase ::
 
     case QueuedTestComponentBase::PARAMID_PARAMARRAY: {
       A ParamArrayVal;
-      _status = val.deserialize(ParamArrayVal);
+      _status = val.deserializeTo(ParamArrayVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5418,7 +5418,7 @@ void QueuedTestTesterBase ::
 
     case QueuedTestComponentBase::PARAMID_PARAMSTRUCT: {
       S ParamStructVal;
-      _status = val.deserialize(ParamStructVal);
+      _status = val.deserializeTo(ParamStructVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5432,7 +5432,7 @@ void QueuedTestTesterBase ::
 
     case QueuedTestComponentBase::PARAMID_PARAMI32EXT: {
       I32 ParamI32ExtVal;
-      _status = val.deserialize(ParamI32ExtVal);
+      _status = val.deserializeTo(ParamI32ExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5446,7 +5446,7 @@ void QueuedTestTesterBase ::
 
     case QueuedTestComponentBase::PARAMID_PARAMF64EXT: {
       F64 ParamF64ExtVal;
-      _status = val.deserialize(ParamF64ExtVal);
+      _status = val.deserializeTo(ParamF64ExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5460,7 +5460,7 @@ void QueuedTestTesterBase ::
 
     case QueuedTestComponentBase::PARAMID_PARAMSTRINGEXT: {
       Fw::ParamString ParamStringExtVal;
-      _status = val.deserialize(ParamStringExtVal);
+      _status = val.deserializeTo(ParamStringExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5474,7 +5474,7 @@ void QueuedTestTesterBase ::
 
     case QueuedTestComponentBase::PARAMID_PARAMENUMEXT: {
       E ParamEnumExtVal;
-      _status = val.deserialize(ParamEnumExtVal);
+      _status = val.deserializeTo(ParamEnumExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5488,7 +5488,7 @@ void QueuedTestTesterBase ::
 
     case QueuedTestComponentBase::PARAMID_PARAMARRAYEXT: {
       A ParamArrayExtVal;
-      _status = val.deserialize(ParamArrayExtVal);
+      _status = val.deserializeTo(ParamArrayExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)
@@ -5502,7 +5502,7 @@ void QueuedTestTesterBase ::
 
     case QueuedTestComponentBase::PARAMID_PARAMSTRUCTEXT: {
       S ParamStructExtVal;
-      _status = val.deserialize(ParamStructExtVal);
+      _status = val.deserializeTo(ParamStructExtVal);
       FW_ASSERT(
         _status == Fw::FW_SERIALIZE_OK,
         static_cast<FwAssertArgType>(_status)

--- a/compiler/tools/fpp-to-cpp/test/enum/AliasSerialTypeEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/AliasSerialTypeEnumAc.ref.cpp
@@ -50,19 +50,19 @@ bool AliasSerialType ::
 }
 
 Fw::SerializeStatus AliasSerialType ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
-  const Fw::SerializeStatus status = buffer.serialize(
+  const Fw::SerializeStatus status = buffer.serializeFrom(
       static_cast<SerialType>(this->e)
   );
   return status;
 }
 
 Fw::SerializeStatus AliasSerialType ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   SerialType es;
-  Fw::SerializeStatus status = buffer.deserialize(es);
+  Fw::SerializeStatus status = buffer.deserializeTo(es);
   if (status == Fw::FW_SERIALIZE_OK) {
     this->e = static_cast<T>(es);
     if (!this->isValid()) {

--- a/compiler/tools/fpp-to-cpp/test/enum/AliasSerialTypeEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/AliasSerialTypeEnumAc.ref.hpp
@@ -129,12 +129,12 @@ class AliasSerialType :
     bool isValid() const;
 
     //! Serialize raw enum value to SerialType
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialize raw enum value from SerialType
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/enum/C_EEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/C_EEnumAc.ref.cpp
@@ -50,19 +50,19 @@ bool C_E ::
 }
 
 Fw::SerializeStatus C_E ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
-  const Fw::SerializeStatus status = buffer.serialize(
+  const Fw::SerializeStatus status = buffer.serializeFrom(
       static_cast<SerialType>(this->e)
   );
   return status;
 }
 
 Fw::SerializeStatus C_E ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   SerialType es;
-  Fw::SerializeStatus status = buffer.deserialize(es);
+  Fw::SerializeStatus status = buffer.deserializeTo(es);
   if (status == Fw::FW_SERIALIZE_OK) {
     this->e = static_cast<T>(es);
     if (!this->isValid()) {

--- a/compiler/tools/fpp-to-cpp/test/enum/C_EEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/C_EEnumAc.ref.hpp
@@ -128,12 +128,12 @@ class C_E :
     bool isValid() const;
 
     //! Serialize raw enum value to SerialType
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialize raw enum value from SerialType
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/enum/DefaultEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/DefaultEnumAc.ref.cpp
@@ -52,19 +52,19 @@ namespace M {
   }
 
   Fw::SerializeStatus Default ::
-    serialize(Fw::SerializeBufferBase& buffer) const
+    serializeTo(Fw::SerializeBufferBase& buffer) const
   {
-    const Fw::SerializeStatus status = buffer.serialize(
+    const Fw::SerializeStatus status = buffer.serializeFrom(
         static_cast<SerialType>(this->e)
     );
     return status;
   }
 
   Fw::SerializeStatus Default ::
-    deserialize(Fw::SerializeBufferBase& buffer)
+    deserializeFrom(Fw::SerializeBufferBase& buffer)
   {
     SerialType es;
-    Fw::SerializeStatus status = buffer.deserialize(es);
+    Fw::SerializeStatus status = buffer.deserializeTo(es);
     if (status == Fw::FW_SERIALIZE_OK) {
       this->e = static_cast<T>(es);
       if (!this->isValid()) {

--- a/compiler/tools/fpp-to-cpp/test/enum/DefaultEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/DefaultEnumAc.ref.hpp
@@ -132,12 +132,12 @@ namespace M {
       bool isValid() const;
 
       //! Serialize raw enum value to SerialType
-      Fw::SerializeStatus serialize(
+      Fw::SerializeStatus serializeTo(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       ) const;
 
       //! Deserialize raw enum value from SerialType
-      Fw::SerializeStatus deserialize(
+      Fw::SerializeStatus deserializeFrom(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 

--- a/compiler/tools/fpp-to-cpp/test/enum/EEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/EEnumAc.ref.cpp
@@ -50,19 +50,19 @@ bool E ::
 }
 
 Fw::SerializeStatus E ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
-  const Fw::SerializeStatus status = buffer.serialize(
+  const Fw::SerializeStatus status = buffer.serializeFrom(
       static_cast<SerialType>(this->e)
   );
   return status;
 }
 
 Fw::SerializeStatus E ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   SerialType es;
-  Fw::SerializeStatus status = buffer.deserialize(es);
+  Fw::SerializeStatus status = buffer.deserializeTo(es);
   if (status == Fw::FW_SERIALIZE_OK) {
     this->e = static_cast<T>(es);
     if (!this->isValid()) {

--- a/compiler/tools/fpp-to-cpp/test/enum/EEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/EEnumAc.ref.hpp
@@ -129,12 +129,12 @@ class E :
     bool isValid() const;
 
     //! Serialize raw enum value to SerialType
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialize raw enum value from SerialType
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/enum/ExplicitEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/ExplicitEnumAc.ref.cpp
@@ -52,19 +52,19 @@ namespace M {
   }
 
   Fw::SerializeStatus Explicit ::
-    serialize(Fw::SerializeBufferBase& buffer) const
+    serializeTo(Fw::SerializeBufferBase& buffer) const
   {
-    const Fw::SerializeStatus status = buffer.serialize(
+    const Fw::SerializeStatus status = buffer.serializeFrom(
         static_cast<SerialType>(this->e)
     );
     return status;
   }
 
   Fw::SerializeStatus Explicit ::
-    deserialize(Fw::SerializeBufferBase& buffer)
+    deserializeFrom(Fw::SerializeBufferBase& buffer)
   {
     SerialType es;
-    Fw::SerializeStatus status = buffer.deserialize(es);
+    Fw::SerializeStatus status = buffer.deserializeTo(es);
     if (status == Fw::FW_SERIALIZE_OK) {
       this->e = static_cast<T>(es);
       if (!this->isValid()) {

--- a/compiler/tools/fpp-to-cpp/test/enum/ExplicitEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/ExplicitEnumAc.ref.hpp
@@ -132,12 +132,12 @@ namespace M {
       bool isValid() const;
 
       //! Serialize raw enum value to SerialType
-      Fw::SerializeStatus serialize(
+      Fw::SerializeStatus serializeTo(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       ) const;
 
       //! Deserialize raw enum value from SerialType
-      Fw::SerializeStatus deserialize(
+      Fw::SerializeStatus deserializeFrom(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 

--- a/compiler/tools/fpp-to-cpp/test/enum/ImplicitEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/ImplicitEnumAc.ref.cpp
@@ -52,19 +52,19 @@ namespace M {
   }
 
   Fw::SerializeStatus Implicit ::
-    serialize(Fw::SerializeBufferBase& buffer) const
+    serializeTo(Fw::SerializeBufferBase& buffer) const
   {
-    const Fw::SerializeStatus status = buffer.serialize(
+    const Fw::SerializeStatus status = buffer.serializeFrom(
         static_cast<SerialType>(this->e)
     );
     return status;
   }
 
   Fw::SerializeStatus Implicit ::
-    deserialize(Fw::SerializeBufferBase& buffer)
+    deserializeFrom(Fw::SerializeBufferBase& buffer)
   {
     SerialType es;
-    Fw::SerializeStatus status = buffer.deserialize(es);
+    Fw::SerializeStatus status = buffer.deserializeTo(es);
     if (status == Fw::FW_SERIALIZE_OK) {
       this->e = static_cast<T>(es);
       if (!this->isValid()) {

--- a/compiler/tools/fpp-to-cpp/test/enum/ImplicitEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/ImplicitEnumAc.ref.hpp
@@ -132,12 +132,12 @@ namespace M {
       bool isValid() const;
 
       //! Serialize raw enum value to SerialType
-      Fw::SerializeStatus serialize(
+      Fw::SerializeStatus serializeTo(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       ) const;
 
       //! Deserialize raw enum value from SerialType
-      Fw::SerializeStatus deserialize(
+      Fw::SerializeStatus deserializeFrom(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 

--- a/compiler/tools/fpp-to-cpp/test/enum/SerializeTypeEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/SerializeTypeEnumAc.ref.cpp
@@ -52,19 +52,19 @@ namespace M {
   }
 
   Fw::SerializeStatus SerializeType ::
-    serialize(Fw::SerializeBufferBase& buffer) const
+    serializeTo(Fw::SerializeBufferBase& buffer) const
   {
-    const Fw::SerializeStatus status = buffer.serialize(
+    const Fw::SerializeStatus status = buffer.serializeFrom(
         static_cast<SerialType>(this->e)
     );
     return status;
   }
 
   Fw::SerializeStatus SerializeType ::
-    deserialize(Fw::SerializeBufferBase& buffer)
+    deserializeFrom(Fw::SerializeBufferBase& buffer)
   {
     SerialType es;
-    Fw::SerializeStatus status = buffer.deserialize(es);
+    Fw::SerializeStatus status = buffer.deserializeTo(es);
     if (status == Fw::FW_SERIALIZE_OK) {
       this->e = static_cast<T>(es);
       if (!this->isValid()) {

--- a/compiler/tools/fpp-to-cpp/test/enum/SerializeTypeEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/SerializeTypeEnumAc.ref.hpp
@@ -132,12 +132,12 @@ namespace M {
       bool isValid() const;
 
       //! Serialize raw enum value to SerialType
-      Fw::SerializeStatus serialize(
+      Fw::SerializeStatus serializeTo(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       ) const;
 
       //! Deserialize raw enum value from SerialType
-      Fw::SerializeStatus deserialize(
+      Fw::SerializeStatus deserializeFrom(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 

--- a/compiler/tools/fpp-to-cpp/test/fprime/Fw/Buffer/Buffer.cpp
+++ b/compiler/tools/fpp-to-cpp/test/fprime/Fw/Buffer/Buffer.cpp
@@ -113,36 +113,36 @@ Fw::ExternalSerializeBufferWithMemberCopy Buffer::getDeserializer() {
     }
 }
 
-Fw::SerializeStatus Buffer::serialize(Fw::SerializeBufferBase& buffer) const {
+Fw::SerializeStatus Buffer::serializeFrom(Fw::SerializeBufferBase& buffer) const {
     Fw::SerializeStatus stat;
 #if FW_SERIALIZATION_TYPE_ID
-    stat = buffer.serialize(static_cast<U32>(Buffer::TYPE_ID));
+    stat = buffer.serializeFrom(static_cast<U32>(Buffer::TYPE_ID));
     if (stat != Fw::FW_SERIALIZE_OK) {
         return stat;
     }
 #endif
-    stat = buffer.serialize(reinterpret_cast<PlatformPointerCastType>(this->m_bufferData));
+    stat = buffer.serializeFrom(reinterpret_cast<PlatformPointerCastType>(this->m_bufferData));
     if (stat != Fw::FW_SERIALIZE_OK) {
         return stat;
     }
-    stat = buffer.serialize(this->m_size);
+    stat = buffer.serializeFrom(this->m_size);
     if (stat != Fw::FW_SERIALIZE_OK) {
         return stat;
     }
-    stat = buffer.serialize(this->m_context);
+    stat = buffer.serializeFrom(this->m_context);
     if (stat != Fw::FW_SERIALIZE_OK) {
         return stat;
     }
     return stat;
 }
 
-Fw::SerializeStatus Buffer::deserialize(Fw::SerializeBufferBase& buffer) {
+Fw::SerializeStatus Buffer::deserializeTo(Fw::SerializeBufferBase& buffer) {
     Fw::SerializeStatus stat;
 
 #if FW_SERIALIZATION_TYPE_ID
     U32 typeId;
 
-    stat = buffer.deserialize(typeId);
+    stat = buffer.deserializeTo(typeId);
     if (stat != Fw::FW_SERIALIZE_OK) {
         return stat;
     }
@@ -152,17 +152,17 @@ Fw::SerializeStatus Buffer::deserialize(Fw::SerializeBufferBase& buffer) {
     }
 #endif
     PlatformPointerCastType pointer;
-    stat = buffer.deserialize(pointer);
+    stat = buffer.deserializeTo(pointer);
     if (stat != Fw::FW_SERIALIZE_OK) {
         return stat;
     }
     this->m_bufferData = reinterpret_cast<U8*>(pointer);
 
-    stat = buffer.deserialize(this->m_size);
+    stat = buffer.deserializeTo(this->m_size);
     if (stat != Fw::FW_SERIALIZE_OK) {
         return stat;
     }
-    stat = buffer.deserialize(this->m_context);
+    stat = buffer.deserializeTo(this->m_context);
     if (stat != Fw::FW_SERIALIZE_OK) {
         return stat;
     }

--- a/compiler/tools/fpp-to-cpp/test/fprime/Fw/Dp/DpContainer.cpp
+++ b/compiler/tools/fpp-to-cpp/test/fprime/Fw/Dp/DpContainer.cpp
@@ -45,39 +45,39 @@ Fw::SerializeStatus DpContainer::deserializeHeader() {
     // Deserialize the packet type
     if (status == Fw::FW_SERIALIZE_OK) {
         FwPacketDescriptorType packetDescriptor;
-        status = deserializer.deserialize(packetDescriptor);
+        status = deserializer.deserializeTo(packetDescriptor);
         if (packetDescriptor != ComPacketType::FW_PACKET_DP) {
             status = Fw::FW_SERIALIZE_FORMAT_ERROR;
         }
     }
     // Deserialize the container id
     if (status == Fw::FW_SERIALIZE_OK) {
-        status = deserializer.deserialize(this->m_id);
+        status = deserializer.deserializeTo(this->m_id);
     }
     // Deserialize the priority
     if (status == Fw::FW_SERIALIZE_OK) {
-        status = deserializer.deserialize(this->m_priority);
+        status = deserializer.deserializeTo(this->m_priority);
     }
     // Deserialize the time tag
     if (status == Fw::FW_SERIALIZE_OK) {
-        status = deserializer.deserialize(this->m_timeTag);
+        status = deserializer.deserializeTo(this->m_timeTag);
     }
     // Deserialize the processing types
     if (status == Fw::FW_SERIALIZE_OK) {
-        status = deserializer.deserialize(this->m_procTypes);
+        status = deserializer.deserializeTo(this->m_procTypes);
     }
     // Deserialize the user data
     if (status == Fw::FW_SERIALIZE_OK) {
         const FwSizeType requestedSize = sizeof this->m_userData;
         FwSizeType receivedSize = requestedSize;
-        status = deserializer.deserialize(this->m_userData, receivedSize, Fw::Serialization::OMIT_LENGTH);
+        status = deserializer.deserializeTo(this->m_userData, receivedSize, Fw::Serialization::OMIT_LENGTH);
         if (receivedSize != requestedSize) {
             status = Fw::FW_DESERIALIZE_SIZE_MISMATCH;
         }
     }
     // Deserialize the data product state
     if (status == Fw::FW_SERIALIZE_OK) {
-        status = deserializer.deserialize(this->m_dpState);
+        status = deserializer.deserializeTo(this->m_dpState);
     }
     // Deserialize the data size
     if (status == Fw::FW_SERIALIZE_OK) {
@@ -91,26 +91,26 @@ void DpContainer::serializeHeader() {
     auto serializer = this->m_buffer.getSerializer();
     // Serialize the packet type
     Fw::SerializeStatus status =
-        serializer.serialize(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_DP));
+        serializer.serializeFrom(static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_DP));
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Serialize the container id
-    status = serializer.serialize(this->m_id);
+    status = serializer.serializeFrom(this->m_id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Serialize the priority
-    status = serializer.serialize(this->m_priority);
+    status = serializer.serializeFrom(this->m_priority);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Serialize the time tag
-    status = serializer.serialize(this->m_timeTag);
+    status = serializer.serializeFrom(this->m_timeTag);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Serialize the processing types
-    status = serializer.serialize(this->m_procTypes);
+    status = serializer.serializeFrom(this->m_procTypes);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Serialize the user data
-    status = serializer.serialize(this->m_userData, static_cast<FwSizeType>(sizeof this->m_userData),
+    status = serializer.serializeFrom(this->m_userData, static_cast<FwSizeType>(sizeof this->m_userData),
                                      Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Serialize the data product state
-    status = serializer.serialize(this->m_dpState);
+    status = serializer.serializeFrom(this->m_dpState);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(status));
     // Serialize the data size
     status = serializer.serializeSize(this->m_dataSize);

--- a/compiler/tools/fpp-to-cpp/test/port/AbsTypePortAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/port/AbsTypePortAc.ref.cpp
@@ -101,13 +101,13 @@ Fw::SerializeStatus InputAbsTypePort ::
   FW_ASSERT(this->m_func != nullptr);
 
   T t;
-  _status = _buffer.deserialize(t);
+  _status = _buffer.deserializeTo(t);
   if (_status != Fw::FW_SERIALIZE_OK) {
     return _status;
   }
 
   T tRef;
-  _status = _buffer.deserialize(tRef);
+  _status = _buffer.deserializeTo(tRef);
   if (_status != Fw::FW_SERIALIZE_OK) {
     return _status;
   }
@@ -170,10 +170,10 @@ void OutputAbsTypePort ::
     Fw::SerializeStatus _status;
     AbsTypePortBuffer _buffer;
 
-    _status = _buffer.serialize(t);
+    _status = _buffer.serializeFrom(t);
     FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-    _status = _buffer.serialize(tRef);
+    _status = _buffer.serializeFrom(tRef);
     FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = this->m_serPort->invokeSerial(_buffer);

--- a/compiler/tools/fpp-to-cpp/test/port/FppTypePortAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/port/FppTypePortAc.ref.cpp
@@ -105,37 +105,37 @@ Fw::SerializeStatus InputFppTypePort ::
   FW_ASSERT(this->m_func != nullptr);
 
   E e;
-  _status = _buffer.deserialize(e);
+  _status = _buffer.deserializeTo(e);
   if (_status != Fw::FW_SERIALIZE_OK) {
     return _status;
   }
 
   E eRef;
-  _status = _buffer.deserialize(eRef);
+  _status = _buffer.deserializeTo(eRef);
   if (_status != Fw::FW_SERIALIZE_OK) {
     return _status;
   }
 
   A a;
-  _status = _buffer.deserialize(a);
+  _status = _buffer.deserializeTo(a);
   if (_status != Fw::FW_SERIALIZE_OK) {
     return _status;
   }
 
   A aRef;
-  _status = _buffer.deserialize(aRef);
+  _status = _buffer.deserializeTo(aRef);
   if (_status != Fw::FW_SERIALIZE_OK) {
     return _status;
   }
 
   S s;
-  _status = _buffer.deserialize(s);
+  _status = _buffer.deserializeTo(s);
   if (_status != Fw::FW_SERIALIZE_OK) {
     return _status;
   }
 
   S sRef;
-  _status = _buffer.deserialize(sRef);
+  _status = _buffer.deserializeTo(sRef);
   if (_status != Fw::FW_SERIALIZE_OK) {
     return _status;
   }
@@ -202,22 +202,22 @@ void OutputFppTypePort ::
     Fw::SerializeStatus _status;
     FppTypePortBuffer _buffer;
 
-    _status = _buffer.serialize(e);
+    _status = _buffer.serializeFrom(e);
     FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-    _status = _buffer.serialize(eRef);
+    _status = _buffer.serializeFrom(eRef);
     FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-    _status = _buffer.serialize(a);
+    _status = _buffer.serializeFrom(a);
     FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-    _status = _buffer.serialize(aRef);
+    _status = _buffer.serializeFrom(aRef);
     FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-    _status = _buffer.serialize(s);
+    _status = _buffer.serializeFrom(s);
     FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-    _status = _buffer.serialize(sRef);
+    _status = _buffer.serializeFrom(sRef);
     FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = this->m_serPort->invokeSerial(_buffer);

--- a/compiler/tools/fpp-to-cpp/test/port/KwdNamePortAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/port/KwdNamePortAc.ref.cpp
@@ -98,7 +98,7 @@ Fw::SerializeStatus InputKwdNamePort ::
   FW_ASSERT(this->m_func != nullptr);
 
   U32 time;
-  _status = _buffer.deserialize(time);
+  _status = _buffer.deserializeTo(time);
   if (_status != Fw::FW_SERIALIZE_OK) {
     return _status;
   }
@@ -158,7 +158,7 @@ void OutputKwdNamePort ::
     Fw::SerializeStatus _status;
     KwdNamePortBuffer _buffer;
 
-    _status = _buffer.serialize(time);
+    _status = _buffer.serializeFrom(time);
     FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = this->m_serPort->invokeSerial(_buffer);

--- a/compiler/tools/fpp-to-cpp/test/port/PrimitivePortAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/port/PrimitivePortAc.ref.cpp
@@ -105,37 +105,37 @@ Fw::SerializeStatus InputPrimitivePort ::
   FW_ASSERT(this->m_func != nullptr);
 
   U32 u32;
-  _status = _buffer.deserialize(u32);
+  _status = _buffer.deserializeTo(u32);
   if (_status != Fw::FW_SERIALIZE_OK) {
     return _status;
   }
 
   U32 u32Ref;
-  _status = _buffer.deserialize(u32Ref);
+  _status = _buffer.deserializeTo(u32Ref);
   if (_status != Fw::FW_SERIALIZE_OK) {
     return _status;
   }
 
   F32 f32;
-  _status = _buffer.deserialize(f32);
+  _status = _buffer.deserializeTo(f32);
   if (_status != Fw::FW_SERIALIZE_OK) {
     return _status;
   }
 
   F32 f32Ref;
-  _status = _buffer.deserialize(f32Ref);
+  _status = _buffer.deserializeTo(f32Ref);
   if (_status != Fw::FW_SERIALIZE_OK) {
     return _status;
   }
 
   bool b;
-  _status = _buffer.deserialize(b);
+  _status = _buffer.deserializeTo(b);
   if (_status != Fw::FW_SERIALIZE_OK) {
     return _status;
   }
 
   bool bRef;
-  _status = _buffer.deserialize(bRef);
+  _status = _buffer.deserializeTo(bRef);
   if (_status != Fw::FW_SERIALIZE_OK) {
     return _status;
   }
@@ -202,22 +202,22 @@ void OutputPrimitivePort ::
     Fw::SerializeStatus _status;
     PrimitivePortBuffer _buffer;
 
-    _status = _buffer.serialize(u32);
+    _status = _buffer.serializeFrom(u32);
     FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-    _status = _buffer.serialize(u32Ref);
+    _status = _buffer.serializeFrom(u32Ref);
     FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-    _status = _buffer.serialize(f32);
+    _status = _buffer.serializeFrom(f32);
     FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-    _status = _buffer.serialize(f32Ref);
+    _status = _buffer.serializeFrom(f32Ref);
     FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-    _status = _buffer.serialize(b);
+    _status = _buffer.serializeFrom(b);
     FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-    _status = _buffer.serialize(bRef);
+    _status = _buffer.serializeFrom(bRef);
     FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = this->m_serPort->invokeSerial(_buffer);

--- a/compiler/tools/fpp-to-cpp/test/port/StringPortAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/port/StringPortAc.ref.cpp
@@ -104,28 +104,28 @@ Fw::SerializeStatus InputStringPort ::
 
   char __fprime_ac_str80_buffer[Fw::StringBase::BUFFER_SIZE(80)];
   Fw::ExternalString str80(__fprime_ac_str80_buffer, sizeof __fprime_ac_str80_buffer);
-  _status = _buffer.deserialize(str80);
+  _status = _buffer.deserializeTo(str80);
   if (_status != Fw::FW_SERIALIZE_OK) {
     return _status;
   }
 
   char __fprime_ac_str80Ref_buffer[Fw::StringBase::BUFFER_SIZE(80)];
   Fw::ExternalString str80Ref(__fprime_ac_str80Ref_buffer, sizeof __fprime_ac_str80Ref_buffer);
-  _status = _buffer.deserialize(str80Ref);
+  _status = _buffer.deserializeTo(str80Ref);
   if (_status != Fw::FW_SERIALIZE_OK) {
     return _status;
   }
 
   char __fprime_ac_str100_buffer[Fw::StringBase::BUFFER_SIZE(100)];
   Fw::ExternalString str100(__fprime_ac_str100_buffer, sizeof __fprime_ac_str100_buffer);
-  _status = _buffer.deserialize(str100);
+  _status = _buffer.deserializeTo(str100);
   if (_status != Fw::FW_SERIALIZE_OK) {
     return _status;
   }
 
   char __fprime_ac_str100Ref_buffer[Fw::StringBase::BUFFER_SIZE(100)];
   Fw::ExternalString str100Ref(__fprime_ac_str100Ref_buffer, sizeof __fprime_ac_str100Ref_buffer);
-  _status = _buffer.deserialize(str100Ref);
+  _status = _buffer.deserializeTo(str100Ref);
   if (_status != Fw::FW_SERIALIZE_OK) {
     return _status;
   }
@@ -190,16 +190,16 @@ void OutputStringPort ::
     Fw::SerializeStatus _status;
     StringPortBuffer _buffer;
 
-    _status = _buffer.serialize(str80);
+    _status = _buffer.serializeFrom(str80);
     FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-    _status = _buffer.serialize(str80Ref);
+    _status = _buffer.serializeFrom(str80Ref);
     FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-    _status = _buffer.serialize(str100);
+    _status = _buffer.serializeFrom(str100);
     FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-    _status = _buffer.serialize(str100Ref);
+    _status = _buffer.serializeFrom(str100Ref);
     FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = this->m_serPort->invokeSerial(_buffer);

--- a/compiler/tools/fpp-to-cpp/test/struct/AbsTypeSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/AbsTypeSerializableAc.ref.cpp
@@ -78,11 +78,11 @@ std::ostream& operator<<(std::ostream& os, const AbsType& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus AbsType ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status;
 
-  status = buffer.serialize(this->m_t);
+  status = buffer.serializeFrom(this->m_t);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
@@ -91,11 +91,11 @@ Fw::SerializeStatus AbsType ::
 }
 
 Fw::SerializeStatus AbsType ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status;
 
-  status = buffer.deserialize(this->m_t);
+  status = buffer.deserializeTo(this->m_t);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }

--- a/compiler/tools/fpp-to-cpp/test/struct/AbsTypeSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/AbsTypeSerializableAc.ref.hpp
@@ -84,12 +84,12 @@ class AbsType :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/struct/AliasTypeSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/AliasTypeSerializableAc.ref.cpp
@@ -135,20 +135,20 @@ std::ostream& operator<<(std::ostream& os, const AliasType& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus AliasType ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status;
 
-  status = buffer.serialize(this->m_x);
+  status = buffer.serializeFrom(this->m_x);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_y);
+  status = buffer.serializeFrom(this->m_y);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
   for (FwSizeType i = 0; i < 10; i++) {
-    status = buffer.serialize(this->m_z[i]);
+    status = buffer.serializeFrom(this->m_z[i]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
@@ -158,20 +158,20 @@ Fw::SerializeStatus AliasType ::
 }
 
 Fw::SerializeStatus AliasType ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status;
 
-  status = buffer.deserialize(this->m_x);
+  status = buffer.deserializeTo(this->m_x);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_y);
+  status = buffer.deserializeTo(this->m_y);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
   for (FwSizeType i = 0; i < 10; i++) {
-    status = buffer.deserialize(this->m_z[i]);
+    status = buffer.deserializeTo(this->m_z[i]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }

--- a/compiler/tools/fpp-to-cpp/test/struct/AliasTypeSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/AliasTypeSerializableAc.ref.hpp
@@ -108,12 +108,12 @@ class AliasType :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/struct/C_SSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/C_SSerializableAc.ref.cpp
@@ -78,11 +78,11 @@ std::ostream& operator<<(std::ostream& os, const C_S& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus C_S ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status;
 
-  status = buffer.serialize(this->m_x);
+  status = buffer.serializeFrom(this->m_x);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
@@ -91,11 +91,11 @@ Fw::SerializeStatus C_S ::
 }
 
 Fw::SerializeStatus C_S ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status;
 
-  status = buffer.deserialize(this->m_x);
+  status = buffer.deserializeTo(this->m_x);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }

--- a/compiler/tools/fpp-to-cpp/test/struct/C_SSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/C_SSerializableAc.ref.hpp
@@ -83,12 +83,12 @@ class C_S :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/struct/DefaultSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/DefaultSerializableAc.ref.cpp
@@ -93,19 +93,19 @@ std::ostream& operator<<(std::ostream& os, const Default& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus Default ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status;
 
-  status = buffer.serialize(this->m_mU32);
+  status = buffer.serializeFrom(this->m_mU32);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_mS1);
+  status = buffer.serializeFrom(this->m_mS1);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_mF64);
+  status = buffer.serializeFrom(this->m_mF64);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
@@ -114,19 +114,19 @@ Fw::SerializeStatus Default ::
 }
 
 Fw::SerializeStatus Default ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status;
 
-  status = buffer.deserialize(this->m_mU32);
+  status = buffer.deserializeTo(this->m_mU32);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_mS1);
+  status = buffer.deserializeTo(this->m_mS1);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_mF64);
+  status = buffer.deserializeTo(this->m_mF64);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }

--- a/compiler/tools/fpp-to-cpp/test/struct/DefaultSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/DefaultSerializableAc.ref.hpp
@@ -89,12 +89,12 @@ class Default :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/struct/EEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/EEnumAc.ref.cpp
@@ -52,19 +52,19 @@ namespace M {
   }
 
   Fw::SerializeStatus E ::
-    serialize(Fw::SerializeBufferBase& buffer) const
+    serializeTo(Fw::SerializeBufferBase& buffer) const
   {
-    const Fw::SerializeStatus status = buffer.serialize(
+    const Fw::SerializeStatus status = buffer.serializeFrom(
         static_cast<SerialType>(this->e)
     );
     return status;
   }
 
   Fw::SerializeStatus E ::
-    deserialize(Fw::SerializeBufferBase& buffer)
+    deserializeFrom(Fw::SerializeBufferBase& buffer)
   {
     SerialType es;
-    Fw::SerializeStatus status = buffer.deserialize(es);
+    Fw::SerializeStatus status = buffer.deserializeTo(es);
     if (status == Fw::FW_SERIALIZE_OK) {
       this->e = static_cast<T>(es);
       if (!this->isValid()) {

--- a/compiler/tools/fpp-to-cpp/test/struct/EEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/EEnumAc.ref.hpp
@@ -130,12 +130,12 @@ namespace M {
       bool isValid() const;
 
       //! Serialize raw enum value to SerialType
-      Fw::SerializeStatus serialize(
+      Fw::SerializeStatus serializeTo(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       ) const;
 
       //! Deserialize raw enum value from SerialType
-      Fw::SerializeStatus deserialize(
+      Fw::SerializeStatus deserializeFrom(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 

--- a/compiler/tools/fpp-to-cpp/test/struct/EnumSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/EnumSerializableAc.ref.cpp
@@ -114,16 +114,16 @@ std::ostream& operator<<(std::ostream& os, const Enum& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus Enum ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status;
 
-  status = buffer.serialize(this->m_e);
+  status = buffer.serializeFrom(this->m_e);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
   for (FwSizeType i = 0; i < 3; i++) {
-    status = buffer.serialize(this->m_eArr[i]);
+    status = buffer.serializeFrom(this->m_eArr[i]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
@@ -133,16 +133,16 @@ Fw::SerializeStatus Enum ::
 }
 
 Fw::SerializeStatus Enum ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status;
 
-  status = buffer.deserialize(this->m_e);
+  status = buffer.deserializeTo(this->m_e);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
   for (FwSizeType i = 0; i < 3; i++) {
-    status = buffer.deserialize(this->m_eArr[i]);
+    status = buffer.deserializeTo(this->m_eArr[i]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }

--- a/compiler/tools/fpp-to-cpp/test/struct/EnumSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/EnumSerializableAc.ref.hpp
@@ -103,12 +103,12 @@ class Enum :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/struct/FormatSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/FormatSerializableAc.ref.cpp
@@ -163,75 +163,75 @@ std::ostream& operator<<(std::ostream& os, const Format& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus Format ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status;
 
-  status = buffer.serialize(this->m_m1);
+  status = buffer.serializeFrom(this->m_m1);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_m2);
+  status = buffer.serializeFrom(this->m_m2);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_m3);
+  status = buffer.serializeFrom(this->m_m3);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_m4);
+  status = buffer.serializeFrom(this->m_m4);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_m5);
+  status = buffer.serializeFrom(this->m_m5);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_m6);
+  status = buffer.serializeFrom(this->m_m6);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_m7);
+  status = buffer.serializeFrom(this->m_m7);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_m8);
+  status = buffer.serializeFrom(this->m_m8);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_m9);
+  status = buffer.serializeFrom(this->m_m9);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_m10);
+  status = buffer.serializeFrom(this->m_m10);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_m11);
+  status = buffer.serializeFrom(this->m_m11);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_m12);
+  status = buffer.serializeFrom(this->m_m12);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_m13);
+  status = buffer.serializeFrom(this->m_m13);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_m14);
+  status = buffer.serializeFrom(this->m_m14);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_m15);
+  status = buffer.serializeFrom(this->m_m15);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_m16);
+  status = buffer.serializeFrom(this->m_m16);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_m17);
+  status = buffer.serializeFrom(this->m_m17);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
@@ -240,75 +240,75 @@ Fw::SerializeStatus Format ::
 }
 
 Fw::SerializeStatus Format ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status;
 
-  status = buffer.deserialize(this->m_m1);
+  status = buffer.deserializeTo(this->m_m1);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_m2);
+  status = buffer.deserializeTo(this->m_m2);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_m3);
+  status = buffer.deserializeTo(this->m_m3);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_m4);
+  status = buffer.deserializeTo(this->m_m4);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_m5);
+  status = buffer.deserializeTo(this->m_m5);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_m6);
+  status = buffer.deserializeTo(this->m_m6);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_m7);
+  status = buffer.deserializeTo(this->m_m7);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_m8);
+  status = buffer.deserializeTo(this->m_m8);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_m9);
+  status = buffer.deserializeTo(this->m_m9);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_m10);
+  status = buffer.deserializeTo(this->m_m10);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_m11);
+  status = buffer.deserializeTo(this->m_m11);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_m12);
+  status = buffer.deserializeTo(this->m_m12);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_m13);
+  status = buffer.deserializeTo(this->m_m13);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_m14);
+  status = buffer.deserializeTo(this->m_m14);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_m15);
+  status = buffer.deserializeTo(this->m_m15);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_m16);
+  status = buffer.deserializeTo(this->m_m16);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_m17);
+  status = buffer.deserializeTo(this->m_m17);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }

--- a/compiler/tools/fpp-to-cpp/test/struct/FormatSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/FormatSerializableAc.ref.hpp
@@ -117,12 +117,12 @@ class Format :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/struct/IncludedSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/IncludedSerializableAc.ref.cpp
@@ -78,11 +78,11 @@ std::ostream& operator<<(std::ostream& os, const Included& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus Included ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status;
 
-  status = buffer.serialize(this->m_x);
+  status = buffer.serializeFrom(this->m_x);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
@@ -91,11 +91,11 @@ Fw::SerializeStatus Included ::
 }
 
 Fw::SerializeStatus Included ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status;
 
-  status = buffer.deserialize(this->m_x);
+  status = buffer.deserializeTo(this->m_x);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }

--- a/compiler/tools/fpp-to-cpp/test/struct/IncludedSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/IncludedSerializableAc.ref.hpp
@@ -83,12 +83,12 @@ class Included :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/struct/IncludingSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/IncludingSerializableAc.ref.cpp
@@ -78,11 +78,11 @@ std::ostream& operator<<(std::ostream& os, const Including& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus Including ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status;
 
-  status = buffer.serialize(this->m_x);
+  status = buffer.serializeFrom(this->m_x);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
@@ -91,11 +91,11 @@ Fw::SerializeStatus Including ::
 }
 
 Fw::SerializeStatus Including ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status;
 
-  status = buffer.deserialize(this->m_x);
+  status = buffer.deserializeTo(this->m_x);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }

--- a/compiler/tools/fpp-to-cpp/test/struct/IncludingSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/IncludingSerializableAc.ref.hpp
@@ -84,12 +84,12 @@ class Including :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules1SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules1SerializableAc.ref.cpp
@@ -90,15 +90,15 @@ namespace M {
   // ----------------------------------------------------------------------
 
   Fw::SerializeStatus Modules1 ::
-    serialize(Fw::SerializeBufferBase& buffer) const
+    serializeTo(Fw::SerializeBufferBase& buffer) const
   {
     Fw::SerializeStatus status;
 
-    status = buffer.serialize(this->m_x);
+    status = buffer.serializeFrom(this->m_x);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
-    status = buffer.serialize(this->m_y);
+    status = buffer.serializeFrom(this->m_y);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
@@ -107,15 +107,15 @@ namespace M {
   }
 
   Fw::SerializeStatus Modules1 ::
-    deserialize(Fw::SerializeBufferBase& buffer)
+    deserializeFrom(Fw::SerializeBufferBase& buffer)
   {
     Fw::SerializeStatus status;
 
-    status = buffer.deserialize(this->m_x);
+    status = buffer.deserializeTo(this->m_x);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
-    status = buffer.deserialize(this->m_y);
+    status = buffer.deserializeTo(this->m_y);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules1SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules1SerializableAc.ref.hpp
@@ -89,12 +89,12 @@ namespace M {
       // ----------------------------------------------------------------------
 
       //! Serialization
-      Fw::SerializeStatus serialize(
+      Fw::SerializeStatus serializeTo(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       ) const;
 
       //! Deserialization
-      Fw::SerializeStatus deserialize(
+      Fw::SerializeStatus deserializeFrom(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules2SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules2SerializableAc.ref.cpp
@@ -80,11 +80,11 @@ namespace M {
   // ----------------------------------------------------------------------
 
   Fw::SerializeStatus Modules2 ::
-    serialize(Fw::SerializeBufferBase& buffer) const
+    serializeTo(Fw::SerializeBufferBase& buffer) const
   {
     Fw::SerializeStatus status;
 
-    status = buffer.serialize(this->m_x);
+    status = buffer.serializeFrom(this->m_x);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
@@ -93,11 +93,11 @@ namespace M {
   }
 
   Fw::SerializeStatus Modules2 ::
-    deserialize(Fw::SerializeBufferBase& buffer)
+    deserializeFrom(Fw::SerializeBufferBase& buffer)
   {
     Fw::SerializeStatus status;
 
-    status = buffer.deserialize(this->m_x);
+    status = buffer.deserializeTo(this->m_x);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules2SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules2SerializableAc.ref.hpp
@@ -86,12 +86,12 @@ namespace M {
       // ----------------------------------------------------------------------
 
       //! Serialization
-      Fw::SerializeStatus serialize(
+      Fw::SerializeStatus serializeTo(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       ) const;
 
       //! Deserialization
-      Fw::SerializeStatus deserialize(
+      Fw::SerializeStatus deserializeFrom(
           Fw::SerializeBufferBase& buffer //!< The serial buffer
       );
 

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules3SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules3SerializableAc.ref.cpp
@@ -114,16 +114,16 @@ std::ostream& operator<<(std::ostream& os, const Modules3& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus Modules3 ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status;
 
-  status = buffer.serialize(this->m_x);
+  status = buffer.serializeFrom(this->m_x);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
   for (FwSizeType i = 0; i < 3; i++) {
-    status = buffer.serialize(this->m_arr[i]);
+    status = buffer.serializeFrom(this->m_arr[i]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
@@ -133,16 +133,16 @@ Fw::SerializeStatus Modules3 ::
 }
 
 Fw::SerializeStatus Modules3 ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status;
 
-  status = buffer.deserialize(this->m_x);
+  status = buffer.deserializeTo(this->m_x);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
   for (FwSizeType i = 0; i < 3; i++) {
-    status = buffer.deserialize(this->m_arr[i]);
+    status = buffer.deserializeTo(this->m_arr[i]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules3SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules3SerializableAc.ref.hpp
@@ -103,12 +103,12 @@ class Modules3 :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules4SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules4SerializableAc.ref.cpp
@@ -124,18 +124,18 @@ std::ostream& operator<<(std::ostream& os, const Modules4& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus Modules4 ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status;
 
   for (FwSizeType i = 0; i < 3; i++) {
-    status = buffer.serialize(this->m_arr1[i]);
+    status = buffer.serializeFrom(this->m_arr1[i]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
   }
   for (FwSizeType i = 0; i < 6; i++) {
-    status = buffer.serialize(this->m_arr2[i]);
+    status = buffer.serializeFrom(this->m_arr2[i]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
@@ -145,18 +145,18 @@ Fw::SerializeStatus Modules4 ::
 }
 
 Fw::SerializeStatus Modules4 ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status;
 
   for (FwSizeType i = 0; i < 3; i++) {
-    status = buffer.deserialize(this->m_arr1[i]);
+    status = buffer.deserializeTo(this->m_arr1[i]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
   }
   for (FwSizeType i = 0; i < 6; i++) {
-    status = buffer.deserialize(this->m_arr2[i]);
+    status = buffer.deserializeTo(this->m_arr2[i]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules4SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules4SerializableAc.ref.hpp
@@ -106,12 +106,12 @@ class Modules4 :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/struct/PrimitiveSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/PrimitiveSerializableAc.ref.cpp
@@ -186,57 +186,57 @@ std::ostream& operator<<(std::ostream& os, const Primitive& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus Primitive ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status;
 
   for (FwSizeType i = 0; i < 3; i++) {
-    status = buffer.serialize(this->m_mF32[i]);
+    status = buffer.serializeFrom(this->m_mF32[i]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
   }
-  status = buffer.serialize(this->m_mF64);
+  status = buffer.serializeFrom(this->m_mF64);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_mI16);
+  status = buffer.serializeFrom(this->m_mI16);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_mI32);
+  status = buffer.serializeFrom(this->m_mI32);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_mI64);
+  status = buffer.serializeFrom(this->m_mI64);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_mI8);
+  status = buffer.serializeFrom(this->m_mI8);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_mU16);
+  status = buffer.serializeFrom(this->m_mU16);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_mU32);
+  status = buffer.serializeFrom(this->m_mU32);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_mU64);
+  status = buffer.serializeFrom(this->m_mU64);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_mU8);
+  status = buffer.serializeFrom(this->m_mU8);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_m_bool);
+  status = buffer.serializeFrom(this->m_m_bool);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_m_string);
+  status = buffer.serializeFrom(this->m_m_string);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
@@ -245,57 +245,57 @@ Fw::SerializeStatus Primitive ::
 }
 
 Fw::SerializeStatus Primitive ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status;
 
   for (FwSizeType i = 0; i < 3; i++) {
-    status = buffer.deserialize(this->m_mF32[i]);
+    status = buffer.deserializeTo(this->m_mF32[i]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
   }
-  status = buffer.deserialize(this->m_mF64);
+  status = buffer.deserializeTo(this->m_mF64);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_mI16);
+  status = buffer.deserializeTo(this->m_mI16);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_mI32);
+  status = buffer.deserializeTo(this->m_mI32);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_mI64);
+  status = buffer.deserializeTo(this->m_mI64);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_mI8);
+  status = buffer.deserializeTo(this->m_mI8);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_mU16);
+  status = buffer.deserializeTo(this->m_mU16);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_mU32);
+  status = buffer.deserializeTo(this->m_mU32);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_mU64);
+  status = buffer.deserializeTo(this->m_mU64);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_mU8);
+  status = buffer.deserializeTo(this->m_mU8);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_m_bool);
+  status = buffer.deserializeTo(this->m_m_bool);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_m_string);
+  status = buffer.deserializeTo(this->m_m_string);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }

--- a/compiler/tools/fpp-to-cpp/test/struct/PrimitiveSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/PrimitiveSerializableAc.ref.hpp
@@ -134,12 +134,12 @@ class Primitive :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/struct/PrimitiveStructSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/PrimitiveStructSerializableAc.ref.cpp
@@ -78,11 +78,11 @@ std::ostream& operator<<(std::ostream& os, const PrimitiveStruct& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus PrimitiveStruct ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status;
 
-  status = buffer.serialize(this->m_s1);
+  status = buffer.serializeFrom(this->m_s1);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
@@ -91,11 +91,11 @@ Fw::SerializeStatus PrimitiveStruct ::
 }
 
 Fw::SerializeStatus PrimitiveStruct ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status;
 
-  status = buffer.deserialize(this->m_s1);
+  status = buffer.deserializeTo(this->m_s1);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }

--- a/compiler/tools/fpp-to-cpp/test/struct/PrimitiveStructSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/PrimitiveStructSerializableAc.ref.hpp
@@ -84,12 +84,12 @@ class PrimitiveStruct :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/struct/SSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/SSerializableAc.ref.cpp
@@ -78,11 +78,11 @@ std::ostream& operator<<(std::ostream& os, const S& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus S ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status;
 
-  status = buffer.serialize(this->m_x);
+  status = buffer.serializeFrom(this->m_x);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
@@ -91,11 +91,11 @@ Fw::SerializeStatus S ::
 }
 
 Fw::SerializeStatus S ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status;
 
-  status = buffer.deserialize(this->m_x);
+  status = buffer.deserializeTo(this->m_x);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }

--- a/compiler/tools/fpp-to-cpp/test/struct/SSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/SSerializableAc.ref.hpp
@@ -84,12 +84,12 @@ class S :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/struct/StringArraySerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/StringArraySerializableAc.ref.cpp
@@ -126,16 +126,16 @@ std::ostream& operator<<(std::ostream& os, const StringArray& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus StringArray ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status;
 
-  status = buffer.serialize(this->m_s1);
+  status = buffer.serializeFrom(this->m_s1);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
   for (FwSizeType i = 0; i < 16; i++) {
-    status = buffer.serialize(this->m_s2[i]);
+    status = buffer.serializeFrom(this->m_s2[i]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }
@@ -145,16 +145,16 @@ Fw::SerializeStatus StringArray ::
 }
 
 Fw::SerializeStatus StringArray ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status;
 
-  status = buffer.deserialize(this->m_s1);
+  status = buffer.deserializeTo(this->m_s1);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
   for (FwSizeType i = 0; i < 16; i++) {
-    status = buffer.deserialize(this->m_s2[i]);
+    status = buffer.deserializeTo(this->m_s2[i]);
     if (status != Fw::FW_SERIALIZE_OK) {
       return status;
     }

--- a/compiler/tools/fpp-to-cpp/test/struct/StringArraySerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/StringArraySerializableAc.ref.hpp
@@ -102,12 +102,12 @@ class StringArray :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/compiler/tools/fpp-to-cpp/test/struct/StringSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/StringSerializableAc.ref.cpp
@@ -88,15 +88,15 @@ std::ostream& operator<<(std::ostream& os, const String& obj) {
 // ----------------------------------------------------------------------
 
 Fw::SerializeStatus String ::
-  serialize(Fw::SerializeBufferBase& buffer) const
+  serializeTo(Fw::SerializeBufferBase& buffer) const
 {
   Fw::SerializeStatus status;
 
-  status = buffer.serialize(this->m_s1);
+  status = buffer.serializeFrom(this->m_s1);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.serialize(this->m_s2);
+  status = buffer.serializeFrom(this->m_s2);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
@@ -105,15 +105,15 @@ Fw::SerializeStatus String ::
 }
 
 Fw::SerializeStatus String ::
-  deserialize(Fw::SerializeBufferBase& buffer)
+  deserializeFrom(Fw::SerializeBufferBase& buffer)
 {
   Fw::SerializeStatus status;
 
-  status = buffer.deserialize(this->m_s1);
+  status = buffer.deserializeTo(this->m_s1);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
-  status = buffer.deserialize(this->m_s2);
+  status = buffer.deserializeTo(this->m_s2);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }

--- a/compiler/tools/fpp-to-cpp/test/struct/StringSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/StringSerializableAc.ref.hpp
@@ -87,12 +87,12 @@ class String :
     // ----------------------------------------------------------------------
 
     //! Serialization
-    Fw::SerializeStatus serialize(
+    Fw::SerializeStatus serializeTo(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     ) const;
 
     //! Deserialization
-    Fw::SerializeStatus deserialize(
+    Fw::SerializeStatus deserializeFrom(
         Fw::SerializeBufferBase& buffer //!< The serial buffer
     );
 

--- a/docs/fpp-spec.html
+++ b/docs/fpp-spec.html
@@ -11571,7 +11571,7 @@ equivalent.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2025-07-07 16:26:39 -0700
+Last updated 2025-07-30 19:11:21 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-users-guide.html
+++ b/docs/fpp-users-guide.html
@@ -15271,12 +15271,12 @@ Your class definition should include the following:</p>
 <p>An implementation of the virtual function</p>
 <div class="listingblock">
 <div class="content">
-<pre>Fw::SerializeStatus T::serialize(Fw::SerializeBufferBase&amp;) const</pre>
+<pre>Fw::SerializeStatus T::serializeTo(Fw::SerializeBufferBase&amp;) const</pre>
 </div>
 </div>
 <div class="paragraph">
-<p>that specifies how to <strong>serialize</strong> a class instance (i.e., convert a class
-instance to a byte string).</p>
+<p>that specifies a class instance should <strong>serializeTo</strong> a buffer
+(i.e., convert a class instance to a byte string).</p>
 </div>
 </li>
 <li>
@@ -15874,7 +15874,7 @@ serialized according to its
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2025-07-30 19:12:08 -0700
+Last updated 2025-07-30 19:20:40 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-users-guide.html
+++ b/docs/fpp-users-guide.html
@@ -15283,12 +15283,12 @@ instance to a byte string).</p>
 <p>An implementation of the function</p>
 <div class="listingblock">
 <div class="content">
-<pre>Fw::SerializeStatus T::deserialize(Fw::SerializeBufferBase&amp;)</pre>
+<pre>Fw::SerializeStatus T::deserializeFrom(Fw::SerializeBufferBase&amp;)</pre>
 </div>
 </div>
 <div class="paragraph">
-<p>that specifies how to <strong>deserialize</strong> a class instance (i.e., reconstruct a class
-instance from a byte string).</p>
+<p>that specifies a class instance should <strong>deserializeFrom</strong> a
+buffer (i.e., reconstruct a class instance from a byte string).</p>
 </div>
 </li>
 <li>
@@ -15344,11 +15344,11 @@ struct T final : public Fw::Serializable { // Extend Fw::Serializable
   // Define a comparison operator
   bool operator==(const T&amp; that) const { return this-&gt;x == that.x; }
 
-  // Define the virtual serialize method
-  SS serialize(B&amp; b) const final { return b.serialize(x); }
+  // Define the virtual serializeTo method
+  SS serializeTo(B&amp; b) const final { return b.serializeFrom(x); }
 
-  // Define the virtual deserialize method
-  SS deserialize(B&amp; b) final { return b.deserialize(x); }
+  // Define the virtual deserializeFrom method
+  SS deserializeFrom(B&amp; b) final { return b.deserializeTo(x); }
 
   // Provide some data
   U32 x;
@@ -15364,10 +15364,10 @@ In some cases, you may want to define an abstract type <code>T</code> that repre
 a data buffer and that is used only in <a href="#Defining-Ports">port definitions</a>.
 In this case you can implement
 <code>T</code> as a class that extends <code>Fw::SerializeBufferBase</code>.
-Instead of implementing the <code>serialize</code> and <code>deserialize</code> functions
+Instead of implementing the <code>serializeTo</code> and <code>deserializeFrom</code> functions
 directly, you override functions that get the address and the capacity
 (allocated size) of the buffer; the base class <code>Fw::SerializeBufferBase</code>
-uses these functions to implement <code>serialize</code> and <code>deserialize</code>.
+uses these functions to implement <code>serializeTo</code> and <code>deserializeFrom</code>.
 For an example of how to do this, see the files <code>Fw/Cmd/CmdArgBuffer.hpp</code>
 and <code>Fw/Cmd/CmdArgBuffer.cpp</code> in the F Prime repository.
 Be careful, though: if you implement an abstract type <code>T</code> this way
@@ -15874,7 +15874,7 @@ serialized according to its
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2025-07-07 16:39:05 -0700
+Last updated 2025-07-30 19:12:08 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.20">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>F Prime Prime (FPP)</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
@@ -140,7 +140,7 @@ p a>code:hover{color:rgba(0,0,0,.9)}
 #content::before{content:none}
 #header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
 #header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
-#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
+#header>h1:only-child{border-bottom:1px solid #dddddf;padding-bottom:8px}
 #header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
 #header .details span:first-child{margin-left:-.125em}
 #header .details span.email a{color:rgba(0,0,0,.85)}
@@ -162,6 +162,7 @@ p a>code:hover{color:rgba(0,0,0,.9)}
 #toctitle{color:#7a2518;font-size:1.2em}
 @media screen and (min-width:768px){#toctitle{font-size:1.375em}
 body.toc2{padding-left:15em;padding-right:0}
+body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
 #toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
 #toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
 #toc.toc2>ul{font-size:.9em;margin-bottom:0}
@@ -327,7 +328,7 @@ a.image{text-decoration:none;display:inline-block}
 a.image object{pointer-events:none}
 sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
 sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+sup.footnote a:active,sup.footnoteref a:active,#footnotes .footnote a:first-of-type:active{text-decoration:underline}
 #footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
 #footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
 #footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
@@ -463,7 +464,7 @@ generated code.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2025-02-18 09:43:03 -0800
+Last updated 2025-01-28 17:09:18 -0800
 </div>
 </div>
 </body>

--- a/docs/users-guide/Writing-C-Plus-Plus-Implementations.adoc
+++ b/docs/users-guide/Writing-C-Plus-Plus-Implementations.adoc
@@ -88,11 +88,11 @@ instance to a byte string).
 * An implementation of the function
 +
 ----
-Fw::SerializeStatus T::deserialize(Fw::SerializeBufferBase&)
+Fw::SerializeStatus T::deserializeFrom(Fw::SerializeBufferBase&)
 ----
 +
-that specifies how to *deserialize* a class instance (i.e., reconstruct a class
-instance from a byte string).
+that specifies a class instance should *deserializeFrom* a
+buffer (i.e., reconstruct a class instance from a byte string).
 
 * A constant `T::SERIALIZED_SIZE` that specifies the size in bytes
 of a byte string serialized from the class.
@@ -139,11 +139,11 @@ struct T final : public Fw::Serializable { // Extend Fw::Serializable
   // Define a comparison operator
   bool operator==(const T& that) const { return this->x == that.x; }
 
-  // Define the virtual serialize method
-  SS serialize(B& b) const final { return b.serialize(x); }
+  // Define the virtual serializeTo method
+  SS serializeTo(B& b) const final { return b.serializeFrom(x); }
 
-  // Define the virtual deserialize method
-  SS deserialize(B& b) final { return b.deserialize(x); }
+  // Define the virtual deserializeFrom method
+  SS deserializeFrom(B& b) final { return b.deserializeTo(x); }
 
   // Provide some data
   U32 x;
@@ -158,10 +158,10 @@ In some cases, you may want to define an abstract type `T` that represents
 a data buffer and that is used only in <<Defining-Ports,port definitions>>.
 In this case you can implement
 `T` as a class that extends `Fw::SerializeBufferBase`.
-Instead of implementing the `serialize` and `deserialize` functions
+Instead of implementing the `serializeTo` and `deserializeFrom` functions
 directly, you override functions that get the address and the capacity
 (allocated size) of the buffer; the base class `Fw::SerializeBufferBase`
-uses these functions to implement `serialize` and `deserialize`.
+uses these functions to implement `serializeTo` and `deserializeFrom`.
 For an example of how to do this, see the files `Fw/Cmd/CmdArgBuffer.hpp`
 and `Fw/Cmd/CmdArgBuffer.cpp` in the F Prime repository.
 Be careful, though: if you implement an abstract type `T` this way

--- a/docs/users-guide/Writing-C-Plus-Plus-Implementations.adoc
+++ b/docs/users-guide/Writing-C-Plus-Plus-Implementations.adoc
@@ -79,11 +79,11 @@ Your class definition should include the following:
 * An implementation of the virtual function
 +
 ----
-Fw::SerializeStatus T::serialize(Fw::SerializeBufferBase&) const
+Fw::SerializeStatus T::serializeTo(Fw::SerializeBufferBase&) const
 ----
 +
-that specifies how to *serialize* a class instance (i.e., convert a class
-instance to a byte string).
+that specifies a class instance should *serializeTo* a buffer
+(i.e., convert a class instance to a byte string).
 
 * An implementation of the function
 +


### PR DESCRIPTION
- [x] cpp-check
- [x] FppTest
- [x] Updated docs that reference `deserialize`/`serialize`