### PR TITLE
Fix incorrect link in spec

### DIFF
--- a/docs/fpp-spec.html
+++ b/docs/fpp-spec.html
@@ -8378,7 +8378,7 @@ elements to the common type.</p>
 that refers to a
 <a href="#Definitions_Constant-Definitions">constant definition</a>
 or
-<a href="#Definitions_Constant-Definitions">enumerated constant definition</a>.</p>
+<a href="#Definitions_Enumerated-Constant-Definitions">enumerated constant definition</a>.</p>
 </div>
 <div class="sect3">
 <h4 id="Expressions_Dot-Expressions_Syntax">10.4.1. Syntax</h4>
@@ -11571,7 +11571,7 @@ equivalent.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2025-08-04 20:26:03 -0700
+Last updated 2025-08-13 12:59:51 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-users-guide.html
+++ b/docs/fpp-users-guide.html
@@ -15721,7 +15721,7 @@ serialized according to its
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2025-08-04 20:26:39 -0700
+Last updated 2025-08-13 13:01:49 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.20">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>F Prime Prime (FPP)</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
@@ -140,7 +140,7 @@ p a>code:hover{color:rgba(0,0,0,.9)}
 #content::before{content:none}
 #header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
 #header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
-#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
+#header>h1:only-child{border-bottom:1px solid #dddddf;padding-bottom:8px}
 #header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
 #header .details span:first-child{margin-left:-.125em}
 #header .details span.email a{color:rgba(0,0,0,.85)}
@@ -162,6 +162,7 @@ p a>code:hover{color:rgba(0,0,0,.9)}
 #toctitle{color:#7a2518;font-size:1.2em}
 @media screen and (min-width:768px){#toctitle{font-size:1.375em}
 body.toc2{padding-left:15em;padding-right:0}
+body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
 #toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
 #toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
 #toc.toc2>ul{font-size:.9em;margin-bottom:0}
@@ -327,7 +328,7 @@ a.image{text-decoration:none;display:inline-block}
 a.image object{pointer-events:none}
 sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
 sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+sup.footnote a:active,sup.footnoteref a:active,#footnotes .footnote a:first-of-type:active{text-decoration:underline}
 #footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
 #footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
 #footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
@@ -463,7 +464,7 @@ generated code.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2025-02-18 09:43:03 -0800
+Last updated 2025-01-28 17:09:18 -0800
 </div>
 </div>
 </body>

--- a/docs/spec/Expressions/Dot-Expressions.adoc
+++ b/docs/spec/Expressions/Dot-Expressions.adoc
@@ -5,7 +5,7 @@ A *dot expression* is a
 that refers to a
 <<Definitions_Constant-Definitions,constant definition>>
 or
-<<Definitions_Constant-Definitions,enumerated constant definition>>.
+<<Definitions_Enumerated-Constant-Definitions,enumerated constant definition>>.
 
 ==== Syntax
 


### PR DESCRIPTION
Fixes a link pointing to the wrong spot in `Dot-Expressions`.