### PR TITLE
Revise error checking for dot expressions

### DIFF
--- a/compiler/lib/src/main/scala/analysis/Analyzers/UseAnalyzer.scala
+++ b/compiler/lib/src/main/scala/analysis/Analyzers/UseAnalyzer.scala
@@ -61,7 +61,10 @@ trait UseAnalyzer extends TypeExpressionAnalyzer {
     }
     nameOpt(e, Nil) match {
       case Some(use) => constantUse(a, node, use)
-      case None => Right(a)
+      case None => Left(SemanticError.InvalidExpression(
+        Locations.get(node.id),
+        "expression does not refer to a definition"
+      ))
     }
   }
 

--- a/compiler/lib/src/main/scala/util/Error.scala
+++ b/compiler/lib/src/main/scala/util/Error.scala
@@ -177,6 +177,8 @@ sealed trait Error {
         Error.print (Some(loc)) (s"invalid component instance definition $name: $msg")
       case SemanticError.InvalidEnumConstants(loc) =>
         Error.print (Some(loc)) ("enum constants must be all explicit or all implied")
+      case SemanticError.InvalidExpression(loc, msg) =>
+        Error.print (Some(loc)) (s"invalid expression: $msg")
       case SemanticError.InvalidEvent(loc, msg) =>
         Error.print (Some(loc)) (msg)
       case SemanticError.InvalidFormatString(loc, msg) =>
@@ -537,6 +539,8 @@ object SemanticError {
   ) extends Error
   /** Invalid enum constants */
   final case class InvalidEnumConstants(loc: Location) extends Error
+  /** Invalid expression */
+  final case class InvalidExpression(loc: Location, msg: String) extends Error
   /** Invalid event */
   final case class InvalidEvent(loc: Location, msg: String) extends Error
   /** Invalid format string  */

--- a/compiler/tools/fpp-check/test/expr/dot_bad_expr.fpp
+++ b/compiler/tools/fpp-check/test/expr/dot_bad_expr.fpp
@@ -1,0 +1,1 @@
+constant a = { x = 1 }.x

--- a/compiler/tools/fpp-check/test/expr/dot_bad_expr.ref.txt
+++ b/compiler/tools/fpp-check/test/expr/dot_bad_expr.ref.txt
@@ -1,0 +1,5 @@
+fpp-check
+[ local path prefix ]/compiler/tools/fpp-check/test/expr/dot_bad_expr.fpp:1.14
+constant a = { x = 1 }.x
+             ^
+error: invalid expression: expression does not refer to a definition

--- a/compiler/tools/fpp-check/test/expr/tests.sh
+++ b/compiler/tools/fpp-check/test/expr/tests.sh
@@ -4,6 +4,7 @@ array_empty
 array_error
 array_ok
 div_by_zero
+dot_bad_expr
 literal_ok
 neg_error
 neg_ok


### PR DESCRIPTION
Properly handle the case where the prefix expression is not a use of a definition. See &sect; 10.4 of the FPP Language Specification, v3.0.0.

Closes #781.
