### PR TITLE
Fix interface resolution & use def-cycles

### DIFF
--- a/compiler/lib/src/main/scala/analysis/CheckSemantics/CheckInterfaceDefs.scala
+++ b/compiler/lib/src/main/scala/analysis/CheckSemantics/CheckInterfaceDefs.scala
@@ -24,7 +24,7 @@ object CheckInterfaceDefs
           iface <- Right(a.interface.get)
           a <- {
             // Resolve interfaces directly imported by iface, updating a
-            val ifaces = iface.directImportMap.toList
+            val ifaces = iface.importMap.toList
             Result.foldLeft (ifaces) (a) ((a, tl) => {
               defInterfaceAnnotatedNode(a, tl._1.node)
             })

--- a/compiler/lib/src/main/scala/analysis/CheckSemantics/CheckUseDefCycles.scala
+++ b/compiler/lib/src/main/scala/analysis/CheckSemantics/CheckUseDefCycles.scala
@@ -49,6 +49,9 @@ object CheckUseDefCycles extends UseAnalyzer {
     visitDefPost(a, symbol, node, super.defInterfaceAnnotatedNode)
   }
 
+  override def interfaceUse(a: Analysis, node: AstNode[Ast.QualIdent], use: Name.Qualified) =
+    visitUse(a, node, use)
+
   override def topologyUse(a: Analysis, node: AstNode[Ast.QualIdent], use: Name.Qualified) =
     visitUse(a, node, use)
 
@@ -71,6 +74,7 @@ object CheckUseDefCycles extends UseAnalyzer {
       case Symbol.Constant(node) => defConstantAnnotatedNode(a, node)
       case Symbol.Enum(node) => defEnumAnnotatedNode(a, node)
       case Symbol.EnumConstant(node) => defEnumConstantAnnotatedNode(a, node)
+      case Symbol.Interface(node) => defInterfaceAnnotatedNode(a, node)
       case Symbol.Struct(node) => defStructAnnotatedNode(a, node)
       case Symbol.Topology(node) => defTopologyAnnotatedNode(a, node)
       case _ => Right(a)

--- a/compiler/lib/src/main/scala/analysis/Semantics/Interface.scala
+++ b/compiler/lib/src/main/scala/analysis/Semantics/Interface.scala
@@ -5,10 +5,10 @@ import fpp.compiler.util.*
 
 /** An FPP interface */
 case class Interface(
-  /** The AST node defining the component */
+  /** The AST node defining the interface */
   aNode: Ast.Annotated[AstNode[Ast.DefInterface]],
-  /** The directly imported topologies */
-  directImportMap: Map[Symbol.Interface, (AstNode.Id, Location)] = Map(),
+  /** The imported interfaces */
+  importMap: Map[Symbol.Interface, (AstNode.Id, Location)] = Map(),
   /** The map from port names to port instances */
   portMap: Map[Name.Unqualified, PortInstance] = Map(),
   /** The map from special port kinds to special port instances */
@@ -25,7 +25,7 @@ case class Interface(
     symbol: Symbol.Interface,
     importNodeId: AstNode.Id
   ): Result.Result[Interface] = {
-    directImportMap.get(symbol) match {
+    importMap.get(symbol) match {
       case Some((_, prevLoc)) => Left(
         SemanticError.DuplicateInterface(
           symbol.getUnqualifiedName,
@@ -34,8 +34,8 @@ case class Interface(
         )
       )
       case None =>
-        val map = directImportMap + (symbol -> (importNodeId, Locations.get(importNodeId)))
-        Right(this.copy(directImportMap = map))
+        val map = importMap + (symbol -> (importNodeId, Locations.get(importNodeId)))
+        Right(this.copy(importMap = map))
     }
   }
 }

--- a/compiler/lib/src/main/scala/analysis/Semantics/ResolveTopology/ResolveInterface.scala
+++ b/compiler/lib/src/main/scala/analysis/Semantics/ResolveTopology/ResolveInterface.scala
@@ -10,7 +10,7 @@ object ResolveInterface {
     def resolveImport(i: Interface, ii: (Symbol.Interface, (AstNode.Id, Location))) =
       i.addImportedInterface(a.interfaceMap(ii._1), ii._2._1)
 
-    Result.foldLeft(List.from(i.directImportMap.iterator)) (i) (resolveImport)
+    Result.foldLeft(List.from(i.importMap)) (i) (resolveImport)
   }
 
 }

--- a/compiler/lib/src/main/scala/analysis/Semantics/ResolveTopology/ResolveInterface.scala
+++ b/compiler/lib/src/main/scala/analysis/Semantics/ResolveTopology/ResolveInterface.scala
@@ -1,0 +1,16 @@
+package fpp.compiler.analysis
+
+import fpp.compiler.ast._
+import fpp.compiler.util._
+
+object ResolveInterface {
+
+  /** Resolve an interface */
+  def resolve(a: Analysis, i: Interface): Result.Result[Interface] = {
+    def resolveImport(i: Interface, ii: (Symbol.Interface, (AstNode.Id, Location))) =
+      i.addImportedInterface(a.interfaceMap(ii._1), ii._2._1)
+
+    Result.foldLeft(List.from(i.directImportMap.iterator)) (i) (resolveImport)
+  }
+
+}

--- a/compiler/lib/src/main/scala/util/Error.scala
+++ b/compiler/lib/src/main/scala/util/Error.scala
@@ -126,6 +126,9 @@ sealed trait Error {
       case SemanticError.DuplicateTopology(name, loc, prevLoc) =>
         Error.print (Some(loc)) (s"duplicate topology ${name}")
         printPrevLoc(prevLoc)
+      case SemanticError.DuplicateInterface(name, loc, prevLoc) =>
+        Error.print (Some(loc)) (s"duplicate interface ${name}")
+        printPrevLoc(prevLoc)
       case SemanticError.EmptyArray(loc) =>
         Error.print (Some(loc)) ("array expression may not be empty")
       case SemanticError.ImplicitDuplicateConnectionAtMatchedPort(
@@ -492,6 +495,12 @@ object SemanticError {
   ) extends Error
   /** Duplicate topology */
   final case class DuplicateTopology(
+    name: String,
+    loc: Location,
+    prevLoc: Location
+  ) extends Error
+  /** Duplicate interface */
+  final case class DuplicateInterface(
     name: String,
     loc: Location,
     prevLoc: Location

--- a/compiler/lib/src/main/scala/util/Result.scala
+++ b/compiler/lib/src/main/scala/util/Result.scala
@@ -16,7 +16,7 @@ object Result {
   
   /** Left fold with a function that returns a result */
   @tailrec
-  def foldLeft[A,B]
+  def foldLeft[A, B]
     (as: List[A])
     (b: B)
     (f: (B, A) => Result.Result[B]): Result.Result[B] =

--- a/compiler/tools/fpp-check/test/interface/cycles.fpp
+++ b/compiler/tools/fpp-check/test/interface/cycles.fpp
@@ -1,0 +1,3 @@
+interface I {
+    import I
+}

--- a/compiler/tools/fpp-check/test/interface/cycles.ref.txt
+++ b/compiler/tools/fpp-check/test/interface/cycles.ref.txt
@@ -1,0 +1,6 @@
+fpp-check
+[ local path prefix ]/compiler/tools/fpp-check/test/interface/cycles.fpp:1.1
+interface I {
+^
+error: encountered a use-def cycle:
+  use I at [ local path prefix ]/compiler/tools/fpp-check/test/interface/cycles.fpp:2.12 refers to definition I at [ local path prefix ]/compiler/tools/fpp-check/test/interface/cycles.fpp:1.1

--- a/compiler/tools/fpp-check/test/interface/duplicate_import.fpp
+++ b/compiler/tools/fpp-check/test/interface/duplicate_import.fpp
@@ -1,0 +1,7 @@
+interface I {
+}
+
+interface I2 {
+    import I
+    import I
+}

--- a/compiler/tools/fpp-check/test/interface/duplicate_import.ref.txt
+++ b/compiler/tools/fpp-check/test/interface/duplicate_import.ref.txt
@@ -1,0 +1,9 @@
+fpp-check
+[ local path prefix ]/compiler/tools/fpp-check/test/interface/duplicate_import.fpp:6.5
+    import I
+    ^
+error: duplicate interface I
+previous occurrence is here:
+[ local path prefix ]/compiler/tools/fpp-check/test/interface/duplicate_import.fpp:5.5
+    import I
+    ^

--- a/compiler/tools/fpp-check/test/interface/ok.fpp
+++ b/compiler/tools/fpp-check/test/interface/ok.fpp
@@ -1,5 +1,12 @@
 port P()
 
+interface I1 {
+  import I2
+}
+
+interface I2 {
+}
+
 module Fw {
   port Cmd
   port CmdReg
@@ -27,4 +34,9 @@ interface I {
 active component C {
     import Cmd
     import I
+    import I3
+}
+
+interface I3 {
+    async input port pAsync2: P
 }

--- a/compiler/tools/fpp-check/test/interface/tests.sh
+++ b/compiler/tools/fpp-check/test/interface/tests.sh
@@ -1,6 +1,8 @@
 tests="
 async_port_in_passive
 conflict_name
+cycles
+duplicate_import
 duplicate_name
 empty_ok
 ok


### PR DESCRIPTION
Added three missing tests:
- Use-def cycle checks for interfaces
- Out of order resolution (added to `ok.fpp`)
- Duplicate symbol import

Updated the wiki here https://github.com/nasa/fpp/wiki/Check-Interface-Definitions/4b8dbc9ad330fb4787e356badb86f6889dd36b1b

Fixes #829 