### PR TITLE
Revise code gen for on-change telemetry

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriter.scala
@@ -510,21 +510,12 @@ case class ComponentCppWriter (
   }
 
   private def getProtectedComponentFunctionMembers: List[CppDoc.Class.Member] = {
-    def writeChannelInit(channel: TlmChannel) = {
-      List(
-        lines(
-          s"""|// Write telemetry channel ${channel.getName}
-              |this->${channelUpdateFlagName(channel.getName)} = true;
-              |"""
-        ),
-        channel.channelType match {
-          case t if s.isPrimitive(t, writeChannelType(t)) => lines(
-            s"this->${channelStorageName(channel.getName)} = 0;"
-          )
-          case _ => Nil
-        }
-      ).flatten
-    }
+    def writeChannelInit(channel: TlmChannel) = lines(
+      s"""|// Write telemetry channel ${channel.getName}
+          |this->${channelUpdateFlagName(channel.getName)} = true;
+          |this->${channelStorageName(channel.getName)} = {};
+          |"""
+    )
 
     addAccessTagAndComment(
     "protected",
@@ -541,7 +532,7 @@ case class ComponentCppWriter (
             )
           ),
           List(s"Fw::${kindStr}ComponentBase(compName)") :::
-            (if (hasExternalParameters) List("paramDelegatePtr(NULL)") else Nil) :::
+            (if (hasExternalParameters) List("paramDelegatePtr(nullptr)") else Nil) :::
             smInstancesByName.map { (name, smi) =>
               val sm = s.a.stateMachineMap(smi.symbol)
               val hasActionsOrGuards = sm.hasActions || sm.hasGuards

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentParameters.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentParameters.scala
@@ -169,7 +169,7 @@ case class ComponentParameters (
                           s"""|// Pass the local ID to the delegate
                               |_id = ${paramIdConstantName(param.getName)};
                               |
-                              |FW_ASSERT(this->paramDelegatePtr != NULL);
+                              |FW_ASSERT(this->paramDelegatePtr != nullptr);
                               |// Call the delegate deserialize function for ${paramVariableName(param.getName)}
                               |_stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
                               |"""
@@ -321,7 +321,7 @@ case class ComponentParameters (
                   |// Get the local ID to pass to the delegate
                   |const FwPrmIdType _localId = ${paramIdConstantName(param.getName)};
                   |
-                  |FW_ASSERT(this->paramDelegatePtr != NULL);
+                  |FW_ASSERT(this->paramDelegatePtr != nullptr);
                   |// Get the external parameter from the delegate
                   |Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
                   |if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -378,7 +378,7 @@ case class ComponentParameters (
               s"""|const FwPrmIdType _localId = ${paramIdConstantName(param.getName)};
                   |const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
                   |
-                  |FW_ASSERT(this->paramDelegatePtr != NULL);
+                  |FW_ASSERT(this->paramDelegatePtr != nullptr);
                   |// Call the delegate serialize function for ${paramVariableName(param.getName)}
                   |const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
                   |  _baseId,
@@ -452,7 +452,7 @@ case class ComponentParameters (
                         |_id = ${paramIdConstantName(param.getName)};
                         |const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
                         |
-                        |FW_ASSERT(this->paramDelegatePtr != NULL);
+                        |FW_ASSERT(this->paramDelegatePtr != nullptr);
                         |_stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
                         |"""
                   )
@@ -508,7 +508,7 @@ case class ComponentParameters (
             ),
             CppDoc.Type("void"),
             lines(
-              """|FW_ASSERT(paramExternalDelegatePtr != NULL);
+              """|FW_ASSERT(paramExternalDelegatePtr != nullptr);
                  |this->paramDelegatePtr = paramExternalDelegatePtr;
                  |"""
             )

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentTelemetry.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentTelemetry.scala
@@ -36,7 +36,7 @@ case class ComponentTelemetry (
   }
 
   def getVariableMembers: List[CppDoc.Class.Member] = {
-    List(
+    List.concat(
       addAccessTagAndComment(
         "private",
         "First update flags for telemetry channels",
@@ -70,7 +70,7 @@ case class ComponentTelemetry (
         }),
         CppDoc.Lines.Hpp
       )
-    ).flatten
+    )
   }
 
   private def getWriteFunctions: List[CppDoc.Class.Member] = {

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveExternalParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveExternalParamsComponentAc.ref.cpp
@@ -1592,7 +1592,7 @@ void ActiveExternalParamsComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMI32EXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamI32Ext
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -1618,7 +1618,7 @@ void ActiveExternalParamsComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMF64EXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamF64Ext
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -1644,7 +1644,7 @@ void ActiveExternalParamsComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMSTRINGEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamStringExt
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -1670,7 +1670,7 @@ void ActiveExternalParamsComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMENUMEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamEnumExt
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -1696,7 +1696,7 @@ void ActiveExternalParamsComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMARRAYEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamArrayExt
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -1722,7 +1722,7 @@ void ActiveExternalParamsComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMSTRUCTEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamStructExt
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -1744,7 +1744,7 @@ void ActiveExternalParamsComponentBase ::
 ActiveExternalParamsComponentBase ::
   ActiveExternalParamsComponentBase(const char* compName) :
     Fw::ActiveComponentBase(compName),
-    paramDelegatePtr(NULL)
+    paramDelegatePtr(nullptr)
 {
 
 }
@@ -3465,7 +3465,7 @@ I32 ActiveExternalParamsComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMI32EXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -3488,7 +3488,7 @@ F64 ActiveExternalParamsComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMF64EXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -3511,7 +3511,7 @@ Fw::ParamString ActiveExternalParamsComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMSTRINGEXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -3534,7 +3534,7 @@ E ActiveExternalParamsComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMENUMEXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -3557,7 +3557,7 @@ A ActiveExternalParamsComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMARRAYEXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -3580,7 +3580,7 @@ S ActiveExternalParamsComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMSTRUCTEXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -3600,7 +3600,7 @@ S ActiveExternalParamsComponentBase ::
 void ActiveExternalParamsComponentBase ::
   registerExternalParameters(Fw::ParamExternalDelegate* paramExternalDelegatePtr)
 {
-  FW_ASSERT(paramExternalDelegatePtr != NULL);
+  FW_ASSERT(paramExternalDelegatePtr != nullptr);
   this->paramDelegatePtr = paramExternalDelegatePtr;
 }
 
@@ -4622,7 +4622,7 @@ Fw::CmdResponse ActiveExternalParamsComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMI32EXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamI32Ext
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -4645,7 +4645,7 @@ Fw::CmdResponse ActiveExternalParamsComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMF64EXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamF64Ext
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -4668,7 +4668,7 @@ Fw::CmdResponse ActiveExternalParamsComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMSTRINGEXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamStringExt
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -4691,7 +4691,7 @@ Fw::CmdResponse ActiveExternalParamsComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMENUMEXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamEnumExt
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -4714,7 +4714,7 @@ Fw::CmdResponse ActiveExternalParamsComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMARRAYEXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamArrayExt
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -4737,7 +4737,7 @@ Fw::CmdResponse ActiveExternalParamsComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMSTRUCTEXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamStructExt
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -4769,7 +4769,7 @@ Fw::CmdResponse ActiveExternalParamsComponentBase ::
     _id = PARAMID_PARAMI32EXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -4800,7 +4800,7 @@ Fw::CmdResponse ActiveExternalParamsComponentBase ::
     _id = PARAMID_PARAMF64EXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -4831,7 +4831,7 @@ Fw::CmdResponse ActiveExternalParamsComponentBase ::
     _id = PARAMID_PARAMSTRINGEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -4862,7 +4862,7 @@ Fw::CmdResponse ActiveExternalParamsComponentBase ::
     _id = PARAMID_PARAMENUMEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -4893,7 +4893,7 @@ Fw::CmdResponse ActiveExternalParamsComponentBase ::
     _id = PARAMID_PARAMARRAYEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -4924,7 +4924,7 @@ Fw::CmdResponse ActiveExternalParamsComponentBase ::
     _id = PARAMID_PARAMSTRUCTEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
@@ -2165,7 +2165,7 @@ void ActiveSerialComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMI32EXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamI32Ext
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -2191,7 +2191,7 @@ void ActiveSerialComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMF64EXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamF64Ext
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -2217,7 +2217,7 @@ void ActiveSerialComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMSTRINGEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamStringExt
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -2243,7 +2243,7 @@ void ActiveSerialComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMENUMEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamEnumExt
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -2269,7 +2269,7 @@ void ActiveSerialComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMARRAYEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamArrayExt
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -2295,7 +2295,7 @@ void ActiveSerialComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMSTRUCTEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamStructExt
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -2317,14 +2317,19 @@ void ActiveSerialComponentBase ::
 ActiveSerialComponentBase ::
   ActiveSerialComponentBase(const char* compName) :
     Fw::ActiveComponentBase(compName),
-    paramDelegatePtr(NULL)
+    paramDelegatePtr(nullptr)
 {
   // Write telemetry channel ChannelU32OnChange
   this->m_first_update_ChannelU32OnChange = true;
-  this->m_last_ChannelU32OnChange = 0;
+  this->m_last_ChannelU32OnChange = {};
 
   // Write telemetry channel ChannelEnumOnChange
   this->m_first_update_ChannelEnumOnChange = true;
+  this->m_last_ChannelEnumOnChange = {};
+
+  // Write telemetry channel ChannelBoolOnChange
+  this->m_first_update_ChannelBoolOnChange = true;
+  this->m_last_ChannelBoolOnChange = {};
 
   this->m_EventActivityLowThrottledThrottle = 0;
   this->m_EventFatalThrottledThrottle = 0;
@@ -6725,6 +6730,54 @@ void ActiveSerialComponentBase ::
   }
 }
 
+void ActiveSerialComponentBase ::
+  tlmWrite_ChannelBoolOnChange(
+      bool arg,
+      Fw::Time _tlmTime
+  )
+{
+  // Check to see if it is the first time
+  if (not this->m_first_update_ChannelBoolOnChange) {
+    // Check to see if value has changed. If not, don't write it.
+    if (arg == this->m_last_ChannelBoolOnChange) {
+      return;
+    }
+    else {
+      this->m_last_ChannelBoolOnChange = arg;
+    }
+  }
+  else {
+    this->m_first_update_ChannelBoolOnChange = false;
+    this->m_last_ChannelBoolOnChange = arg;
+  }
+
+  if (this->m_tlmOut_OutputPort[0].isConnected()) {
+    if (
+      this->m_timeGetOut_OutputPort[0].isConnected() &&
+      (_tlmTime ==  Fw::ZERO_TIME)
+    ) {
+      this->m_timeGetOut_OutputPort[0].invoke(_tlmTime);
+    }
+
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
+
+    FwChanIdType _id;
+
+    _id = this->getIdBase() + CHANNELID_CHANNELBOOLONCHANGE;
+
+    this->m_tlmOut_OutputPort[0].invoke(
+      _id,
+      _tlmTime,
+      _tlmBuff
+    );
+  }
+}
+
 // ----------------------------------------------------------------------
 // Parameter update hook
 // ----------------------------------------------------------------------
@@ -6821,7 +6874,7 @@ I32 ActiveSerialComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMI32EXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -6844,7 +6897,7 @@ F64 ActiveSerialComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMF64EXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -6867,7 +6920,7 @@ Fw::ParamString ActiveSerialComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMSTRINGEXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -6890,7 +6943,7 @@ E ActiveSerialComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMENUMEXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -6913,7 +6966,7 @@ A ActiveSerialComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMARRAYEXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -6936,7 +6989,7 @@ S ActiveSerialComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMSTRUCTEXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -6956,7 +7009,7 @@ S ActiveSerialComponentBase ::
 void ActiveSerialComponentBase ::
   registerExternalParameters(Fw::ParamExternalDelegate* paramExternalDelegatePtr)
 {
-  FW_ASSERT(paramExternalDelegatePtr != NULL);
+  FW_ASSERT(paramExternalDelegatePtr != nullptr);
   this->paramDelegatePtr = paramExternalDelegatePtr;
 }
 
@@ -8991,7 +9044,7 @@ Fw::CmdResponse ActiveSerialComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMI32EXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamI32Ext
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -9014,7 +9067,7 @@ Fw::CmdResponse ActiveSerialComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMF64EXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamF64Ext
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -9037,7 +9090,7 @@ Fw::CmdResponse ActiveSerialComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMSTRINGEXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamStringExt
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -9060,7 +9113,7 @@ Fw::CmdResponse ActiveSerialComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMENUMEXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamEnumExt
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -9083,7 +9136,7 @@ Fw::CmdResponse ActiveSerialComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMARRAYEXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamArrayExt
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -9106,7 +9159,7 @@ Fw::CmdResponse ActiveSerialComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMSTRUCTEXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamStructExt
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -9318,7 +9371,7 @@ Fw::CmdResponse ActiveSerialComponentBase ::
     _id = PARAMID_PARAMI32EXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -9349,7 +9402,7 @@ Fw::CmdResponse ActiveSerialComponentBase ::
     _id = PARAMID_PARAMF64EXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -9380,7 +9433,7 @@ Fw::CmdResponse ActiveSerialComponentBase ::
     _id = PARAMID_PARAMSTRINGEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -9411,7 +9464,7 @@ Fw::CmdResponse ActiveSerialComponentBase ::
     _id = PARAMID_PARAMENUMEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -9442,7 +9495,7 @@ Fw::CmdResponse ActiveSerialComponentBase ::
     _id = PARAMID_PARAMARRAYEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -9473,7 +9526,7 @@ Fw::CmdResponse ActiveSerialComponentBase ::
     _id = PARAMID_PARAMSTRUCTEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.hpp
@@ -215,6 +215,7 @@ class ActiveSerialComponentBase :
       CHANNELID_CHANNELF64 = 0x15, //!< Channel ID for ChannelF64
       CHANNELID_CHANNELU32ONCHANGE = 0x16, //!< Channel ID for ChannelU32OnChange
       CHANNELID_CHANNELENUMONCHANGE = 0x17, //!< Channel ID for ChannelEnumOnChange
+      CHANNELID_CHANNELBOOLONCHANGE = 0x18, //!< Channel ID for ChannelBoolOnChange
     };
 
     //! Parameter IDs
@@ -2363,6 +2364,14 @@ class ActiveSerialComponentBase :
         Fw::Time _tlmTime = Fw::Time() //!< Timestamp. Default: unspecified, request from getTime port
     );
 
+    //! Write telemetry channel ChannelBoolOnChange
+    //!
+    //! A telemetry channel with Boolean data and update on change frequency
+    void tlmWrite_ChannelBoolOnChange(
+        bool arg, //!< The telemetry value
+        Fw::Time _tlmTime = Fw::Time() //!< Timestamp. Default: unspecified, request from getTime port
+    );
+
   protected:
 
     // ----------------------------------------------------------------------
@@ -3170,6 +3179,9 @@ class ActiveSerialComponentBase :
     //! Initialized to true; cleared when channel ChannelEnumOnChange is first updated
     bool m_first_update_ChannelEnumOnChange;
 
+    //! Initialized to true; cleared when channel ChannelBoolOnChange is first updated
+    bool m_first_update_ChannelBoolOnChange;
+
   private:
 
     // ----------------------------------------------------------------------
@@ -3181,6 +3193,9 @@ class ActiveSerialComponentBase :
 
     //! Records the last emitted value for channel ChannelEnumOnChange
     E m_last_ChannelEnumOnChange;
+
+    //! Records the last emitted value for channel ChannelBoolOnChange
+    bool m_last_ChannelBoolOnChange;
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.cpp
@@ -1513,10 +1513,15 @@ ActiveTelemetryComponentBase ::
 {
   // Write telemetry channel ChannelU32OnChange
   this->m_first_update_ChannelU32OnChange = true;
-  this->m_last_ChannelU32OnChange = 0;
+  this->m_last_ChannelU32OnChange = {};
 
   // Write telemetry channel ChannelEnumOnChange
   this->m_first_update_ChannelEnumOnChange = true;
+  this->m_last_ChannelEnumOnChange = {};
+
+  // Write telemetry channel ChannelBoolOnChange
+  this->m_first_update_ChannelBoolOnChange = true;
+  this->m_last_ChannelBoolOnChange = {};
 }
 
 ActiveTelemetryComponentBase ::
@@ -3578,6 +3583,54 @@ void ActiveTelemetryComponentBase ::
     FwChanIdType _id;
 
     _id = this->getIdBase() + CHANNELID_CHANNELENUMONCHANGE;
+
+    this->m_tlmOut_OutputPort[0].invoke(
+      _id,
+      _tlmTime,
+      _tlmBuff
+    );
+  }
+}
+
+void ActiveTelemetryComponentBase ::
+  tlmWrite_ChannelBoolOnChange(
+      bool arg,
+      Fw::Time _tlmTime
+  )
+{
+  // Check to see if it is the first time
+  if (not this->m_first_update_ChannelBoolOnChange) {
+    // Check to see if value has changed. If not, don't write it.
+    if (arg == this->m_last_ChannelBoolOnChange) {
+      return;
+    }
+    else {
+      this->m_last_ChannelBoolOnChange = arg;
+    }
+  }
+  else {
+    this->m_first_update_ChannelBoolOnChange = false;
+    this->m_last_ChannelBoolOnChange = arg;
+  }
+
+  if (this->m_tlmOut_OutputPort[0].isConnected()) {
+    if (
+      this->m_timeGetOut_OutputPort[0].isConnected() &&
+      (_tlmTime ==  Fw::ZERO_TIME)
+    ) {
+      this->m_timeGetOut_OutputPort[0].invoke(_tlmTime);
+    }
+
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
+
+    FwChanIdType _id;
+
+    _id = this->getIdBase() + CHANNELID_CHANNELBOOLONCHANGE;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.hpp
@@ -125,6 +125,7 @@ class ActiveTelemetryComponentBase :
       CHANNELID_CHANNELF64 = 0x15, //!< Channel ID for ChannelF64
       CHANNELID_CHANNELU32ONCHANGE = 0x16, //!< Channel ID for ChannelU32OnChange
       CHANNELID_CHANNELENUMONCHANGE = 0x17, //!< Channel ID for ChannelEnumOnChange
+      CHANNELID_CHANNELBOOLONCHANGE = 0x18, //!< Channel ID for ChannelBoolOnChange
     };
 
   public:
@@ -1459,6 +1460,14 @@ class ActiveTelemetryComponentBase :
         Fw::Time _tlmTime = Fw::Time() //!< Timestamp. Default: unspecified, request from getTime port
     );
 
+    //! Write telemetry channel ChannelBoolOnChange
+    //!
+    //! A telemetry channel with Boolean data and update on change frequency
+    void tlmWrite_ChannelBoolOnChange(
+        bool arg, //!< The telemetry value
+        Fw::Time _tlmTime = Fw::Time() //!< Timestamp. Default: unspecified, request from getTime port
+    );
+
   protected:
 
     // ----------------------------------------------------------------------
@@ -1861,6 +1870,9 @@ class ActiveTelemetryComponentBase :
     //! Initialized to true; cleared when channel ChannelEnumOnChange is first updated
     bool m_first_update_ChannelEnumOnChange;
 
+    //! Initialized to true; cleared when channel ChannelBoolOnChange is first updated
+    bool m_first_update_ChannelBoolOnChange;
+
   private:
 
     // ----------------------------------------------------------------------
@@ -1872,6 +1884,9 @@ class ActiveTelemetryComponentBase :
 
     //! Records the last emitted value for channel ChannelEnumOnChange
     E m_last_ChannelEnumOnChange;
+
+    //! Records the last emitted value for channel ChannelBoolOnChange
+    bool m_last_ChannelBoolOnChange;
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
@@ -2255,7 +2255,7 @@ namespace M {
       // Pass the local ID to the delegate
       _id = PARAMID_PARAMI32EXT;
 
-      FW_ASSERT(this->paramDelegatePtr != NULL);
+      FW_ASSERT(this->paramDelegatePtr != nullptr);
       // Call the delegate deserialize function for m_ParamI32Ext
       _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
       if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -2281,7 +2281,7 @@ namespace M {
       // Pass the local ID to the delegate
       _id = PARAMID_PARAMF64EXT;
 
-      FW_ASSERT(this->paramDelegatePtr != NULL);
+      FW_ASSERT(this->paramDelegatePtr != nullptr);
       // Call the delegate deserialize function for m_ParamF64Ext
       _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
       if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -2307,7 +2307,7 @@ namespace M {
       // Pass the local ID to the delegate
       _id = PARAMID_PARAMSTRINGEXT;
 
-      FW_ASSERT(this->paramDelegatePtr != NULL);
+      FW_ASSERT(this->paramDelegatePtr != nullptr);
       // Call the delegate deserialize function for m_ParamStringExt
       _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
       if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -2333,7 +2333,7 @@ namespace M {
       // Pass the local ID to the delegate
       _id = PARAMID_PARAMENUMEXT;
 
-      FW_ASSERT(this->paramDelegatePtr != NULL);
+      FW_ASSERT(this->paramDelegatePtr != nullptr);
       // Call the delegate deserialize function for m_ParamEnumExt
       _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
       if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -2359,7 +2359,7 @@ namespace M {
       // Pass the local ID to the delegate
       _id = PARAMID_PARAMARRAYEXT;
 
-      FW_ASSERT(this->paramDelegatePtr != NULL);
+      FW_ASSERT(this->paramDelegatePtr != nullptr);
       // Call the delegate deserialize function for m_ParamArrayExt
       _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
       if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -2385,7 +2385,7 @@ namespace M {
       // Pass the local ID to the delegate
       _id = PARAMID_PARAMSTRUCTEXT;
 
-      FW_ASSERT(this->paramDelegatePtr != NULL);
+      FW_ASSERT(this->paramDelegatePtr != nullptr);
       // Call the delegate deserialize function for m_ParamStructExt
       _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
       if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -2407,14 +2407,19 @@ namespace M {
   ActiveTestComponentBase ::
     ActiveTestComponentBase(const char* compName) :
       Fw::ActiveComponentBase(compName),
-      paramDelegatePtr(NULL)
+      paramDelegatePtr(nullptr)
   {
     // Write telemetry channel ChannelU32OnChange
     this->m_first_update_ChannelU32OnChange = true;
-    this->m_last_ChannelU32OnChange = 0;
+    this->m_last_ChannelU32OnChange = {};
 
     // Write telemetry channel ChannelEnumOnChange
     this->m_first_update_ChannelEnumOnChange = true;
+    this->m_last_ChannelEnumOnChange = {};
+
+    // Write telemetry channel ChannelBoolOnChange
+    this->m_first_update_ChannelBoolOnChange = true;
+    this->m_last_ChannelBoolOnChange = {};
 
     this->m_EventActivityLowThrottledThrottle = 0;
     this->m_EventFatalThrottledThrottle = 0;
@@ -6599,6 +6604,54 @@ namespace M {
     }
   }
 
+  void ActiveTestComponentBase ::
+    tlmWrite_ChannelBoolOnChange(
+        bool arg,
+        Fw::Time _tlmTime
+    )
+  {
+    // Check to see if it is the first time
+    if (not this->m_first_update_ChannelBoolOnChange) {
+      // Check to see if value has changed. If not, don't write it.
+      if (arg == this->m_last_ChannelBoolOnChange) {
+        return;
+      }
+      else {
+        this->m_last_ChannelBoolOnChange = arg;
+      }
+    }
+    else {
+      this->m_first_update_ChannelBoolOnChange = false;
+      this->m_last_ChannelBoolOnChange = arg;
+    }
+
+    if (this->m_tlmOut_OutputPort[0].isConnected()) {
+      if (
+        this->m_timeGetOut_OutputPort[0].isConnected() &&
+        (_tlmTime ==  Fw::ZERO_TIME)
+      ) {
+        this->m_timeGetOut_OutputPort[0].invoke(_tlmTime);
+      }
+
+      Fw::TlmBuffer _tlmBuff;
+      Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+      FW_ASSERT(
+        _stat == Fw::FW_SERIALIZE_OK,
+        static_cast<FwAssertArgType>(_stat)
+      );
+
+      FwChanIdType _id;
+
+      _id = this->getIdBase() + CHANNELID_CHANNELBOOLONCHANGE;
+
+      this->m_tlmOut_OutputPort[0].invoke(
+        _id,
+        _tlmTime,
+        _tlmBuff
+      );
+    }
+  }
+
   // ----------------------------------------------------------------------
   // Parameter update hook
   // ----------------------------------------------------------------------
@@ -6695,7 +6748,7 @@ namespace M {
     // Get the local ID to pass to the delegate
     const FwPrmIdType _localId = PARAMID_PARAMI32EXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Get the external parameter from the delegate
     Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
     if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -6718,7 +6771,7 @@ namespace M {
     // Get the local ID to pass to the delegate
     const FwPrmIdType _localId = PARAMID_PARAMF64EXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Get the external parameter from the delegate
     Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
     if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -6741,7 +6794,7 @@ namespace M {
     // Get the local ID to pass to the delegate
     const FwPrmIdType _localId = PARAMID_PARAMSTRINGEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Get the external parameter from the delegate
     Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
     if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -6764,7 +6817,7 @@ namespace M {
     // Get the local ID to pass to the delegate
     const FwPrmIdType _localId = PARAMID_PARAMENUMEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Get the external parameter from the delegate
     Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
     if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -6787,7 +6840,7 @@ namespace M {
     // Get the local ID to pass to the delegate
     const FwPrmIdType _localId = PARAMID_PARAMARRAYEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Get the external parameter from the delegate
     Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
     if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -6810,7 +6863,7 @@ namespace M {
     // Get the local ID to pass to the delegate
     const FwPrmIdType _localId = PARAMID_PARAMSTRUCTEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Get the external parameter from the delegate
     Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
     if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -6830,7 +6883,7 @@ namespace M {
   void ActiveTestComponentBase ::
     registerExternalParameters(Fw::ParamExternalDelegate* paramExternalDelegatePtr)
   {
-    FW_ASSERT(paramExternalDelegatePtr != NULL);
+    FW_ASSERT(paramExternalDelegatePtr != nullptr);
     this->paramDelegatePtr = paramExternalDelegatePtr;
   }
 
@@ -8778,7 +8831,7 @@ namespace M {
     const FwPrmIdType _localId = PARAMID_PARAMI32EXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate serialize function for m_ParamI32Ext
     const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
       _baseId,
@@ -8801,7 +8854,7 @@ namespace M {
     const FwPrmIdType _localId = PARAMID_PARAMF64EXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate serialize function for m_ParamF64Ext
     const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
       _baseId,
@@ -8824,7 +8877,7 @@ namespace M {
     const FwPrmIdType _localId = PARAMID_PARAMSTRINGEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate serialize function for m_ParamStringExt
     const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
       _baseId,
@@ -8847,7 +8900,7 @@ namespace M {
     const FwPrmIdType _localId = PARAMID_PARAMENUMEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate serialize function for m_ParamEnumExt
     const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
       _baseId,
@@ -8870,7 +8923,7 @@ namespace M {
     const FwPrmIdType _localId = PARAMID_PARAMARRAYEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate serialize function for m_ParamArrayExt
     const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
       _baseId,
@@ -8893,7 +8946,7 @@ namespace M {
     const FwPrmIdType _localId = PARAMID_PARAMSTRUCTEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate serialize function for m_ParamStructExt
     const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
       _baseId,
@@ -9105,7 +9158,7 @@ namespace M {
       _id = PARAMID_PARAMI32EXT;
       const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-      FW_ASSERT(this->paramDelegatePtr != NULL);
+      FW_ASSERT(this->paramDelegatePtr != nullptr);
       _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
       if (_stat != Fw::FW_SERIALIZE_OK) {
         return Fw::CmdResponse::VALIDATION_ERROR;
@@ -9136,7 +9189,7 @@ namespace M {
       _id = PARAMID_PARAMF64EXT;
       const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-      FW_ASSERT(this->paramDelegatePtr != NULL);
+      FW_ASSERT(this->paramDelegatePtr != nullptr);
       _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
       if (_stat != Fw::FW_SERIALIZE_OK) {
         return Fw::CmdResponse::VALIDATION_ERROR;
@@ -9167,7 +9220,7 @@ namespace M {
       _id = PARAMID_PARAMSTRINGEXT;
       const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-      FW_ASSERT(this->paramDelegatePtr != NULL);
+      FW_ASSERT(this->paramDelegatePtr != nullptr);
       _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
       if (_stat != Fw::FW_SERIALIZE_OK) {
         return Fw::CmdResponse::VALIDATION_ERROR;
@@ -9198,7 +9251,7 @@ namespace M {
       _id = PARAMID_PARAMENUMEXT;
       const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-      FW_ASSERT(this->paramDelegatePtr != NULL);
+      FW_ASSERT(this->paramDelegatePtr != nullptr);
       _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
       if (_stat != Fw::FW_SERIALIZE_OK) {
         return Fw::CmdResponse::VALIDATION_ERROR;
@@ -9229,7 +9282,7 @@ namespace M {
       _id = PARAMID_PARAMARRAYEXT;
       const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-      FW_ASSERT(this->paramDelegatePtr != NULL);
+      FW_ASSERT(this->paramDelegatePtr != nullptr);
       _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
       if (_stat != Fw::FW_SERIALIZE_OK) {
         return Fw::CmdResponse::VALIDATION_ERROR;
@@ -9260,7 +9313,7 @@ namespace M {
       _id = PARAMID_PARAMSTRUCTEXT;
       const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-      FW_ASSERT(this->paramDelegatePtr != NULL);
+      FW_ASSERT(this->paramDelegatePtr != nullptr);
       _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
       if (_stat != Fw::FW_SERIALIZE_OK) {
         return Fw::CmdResponse::VALIDATION_ERROR;

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.hpp
@@ -205,6 +205,7 @@ namespace M {
         CHANNELID_CHANNELF64 = 0x15, //!< Channel ID for ChannelF64
         CHANNELID_CHANNELU32ONCHANGE = 0x16, //!< Channel ID for ChannelU32OnChange
         CHANNELID_CHANNELENUMONCHANGE = 0x17, //!< Channel ID for ChannelEnumOnChange
+        CHANNELID_CHANNELBOOLONCHANGE = 0x18, //!< Channel ID for ChannelBoolOnChange
       };
 
       //! Parameter IDs
@@ -2347,6 +2348,14 @@ namespace M {
           Fw::Time _tlmTime = Fw::Time() //!< Timestamp. Default: unspecified, request from getTime port
       );
 
+      //! Write telemetry channel ChannelBoolOnChange
+      //!
+      //! A telemetry channel with Boolean data and update on change frequency
+      void tlmWrite_ChannelBoolOnChange(
+          bool arg, //!< The telemetry value
+          Fw::Time _tlmTime = Fw::Time() //!< Timestamp. Default: unspecified, request from getTime port
+      );
+
     protected:
 
       // ----------------------------------------------------------------------
@@ -3190,6 +3199,9 @@ namespace M {
       //! Initialized to true; cleared when channel ChannelEnumOnChange is first updated
       bool m_first_update_ChannelEnumOnChange;
 
+      //! Initialized to true; cleared when channel ChannelBoolOnChange is first updated
+      bool m_first_update_ChannelBoolOnChange;
+
     private:
 
       // ----------------------------------------------------------------------
@@ -3201,6 +3213,9 @@ namespace M {
 
       //! Records the last emitted value for channel ChannelEnumOnChange
       E m_last_ChannelEnumOnChange;
+
+      //! Records the last emitted value for channel ChannelBoolOnChange
+      bool m_last_ChannelBoolOnChange;
 
     private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveExternalParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveExternalParamsComponentAc.ref.cpp
@@ -1311,7 +1311,7 @@ void PassiveExternalParamsComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMI32EXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamI32Ext
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -1337,7 +1337,7 @@ void PassiveExternalParamsComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMF64EXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamF64Ext
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -1363,7 +1363,7 @@ void PassiveExternalParamsComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMSTRINGEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamStringExt
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -1389,7 +1389,7 @@ void PassiveExternalParamsComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMENUMEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamEnumExt
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -1415,7 +1415,7 @@ void PassiveExternalParamsComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMARRAYEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamArrayExt
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -1441,7 +1441,7 @@ void PassiveExternalParamsComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMSTRUCTEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamStructExt
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -1463,7 +1463,7 @@ void PassiveExternalParamsComponentBase ::
 PassiveExternalParamsComponentBase ::
   PassiveExternalParamsComponentBase(const char* compName) :
     Fw::PassiveComponentBase(compName),
-    paramDelegatePtr(NULL)
+    paramDelegatePtr(nullptr)
 {
 
 }
@@ -2479,7 +2479,7 @@ I32 PassiveExternalParamsComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMI32EXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -2502,7 +2502,7 @@ F64 PassiveExternalParamsComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMF64EXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -2525,7 +2525,7 @@ Fw::ParamString PassiveExternalParamsComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMSTRINGEXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -2548,7 +2548,7 @@ E PassiveExternalParamsComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMENUMEXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -2571,7 +2571,7 @@ A PassiveExternalParamsComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMARRAYEXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -2594,7 +2594,7 @@ S PassiveExternalParamsComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMSTRUCTEXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -2614,7 +2614,7 @@ S PassiveExternalParamsComponentBase ::
 void PassiveExternalParamsComponentBase ::
   registerExternalParameters(Fw::ParamExternalDelegate* paramExternalDelegatePtr)
 {
-  FW_ASSERT(paramExternalDelegatePtr != NULL);
+  FW_ASSERT(paramExternalDelegatePtr != nullptr);
   this->paramDelegatePtr = paramExternalDelegatePtr;
 }
 
@@ -3066,7 +3066,7 @@ Fw::CmdResponse PassiveExternalParamsComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMI32EXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamI32Ext
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -3089,7 +3089,7 @@ Fw::CmdResponse PassiveExternalParamsComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMF64EXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamF64Ext
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -3112,7 +3112,7 @@ Fw::CmdResponse PassiveExternalParamsComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMSTRINGEXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamStringExt
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -3135,7 +3135,7 @@ Fw::CmdResponse PassiveExternalParamsComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMENUMEXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamEnumExt
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -3158,7 +3158,7 @@ Fw::CmdResponse PassiveExternalParamsComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMARRAYEXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamArrayExt
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -3181,7 +3181,7 @@ Fw::CmdResponse PassiveExternalParamsComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMSTRUCTEXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamStructExt
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -3213,7 +3213,7 @@ Fw::CmdResponse PassiveExternalParamsComponentBase ::
     _id = PARAMID_PARAMI32EXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -3244,7 +3244,7 @@ Fw::CmdResponse PassiveExternalParamsComponentBase ::
     _id = PARAMID_PARAMF64EXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -3275,7 +3275,7 @@ Fw::CmdResponse PassiveExternalParamsComponentBase ::
     _id = PARAMID_PARAMSTRINGEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -3306,7 +3306,7 @@ Fw::CmdResponse PassiveExternalParamsComponentBase ::
     _id = PARAMID_PARAMENUMEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -3337,7 +3337,7 @@ Fw::CmdResponse PassiveExternalParamsComponentBase ::
     _id = PARAMID_PARAMARRAYEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -3368,7 +3368,7 @@ Fw::CmdResponse PassiveExternalParamsComponentBase ::
     _id = PARAMID_PARAMSTRUCTEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
@@ -1680,7 +1680,7 @@ void PassiveSerialComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMI32EXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamI32Ext
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -1706,7 +1706,7 @@ void PassiveSerialComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMF64EXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamF64Ext
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -1732,7 +1732,7 @@ void PassiveSerialComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMSTRINGEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamStringExt
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -1758,7 +1758,7 @@ void PassiveSerialComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMENUMEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamEnumExt
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -1784,7 +1784,7 @@ void PassiveSerialComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMARRAYEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamArrayExt
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -1810,7 +1810,7 @@ void PassiveSerialComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMSTRUCTEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamStructExt
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -1832,14 +1832,19 @@ void PassiveSerialComponentBase ::
 PassiveSerialComponentBase ::
   PassiveSerialComponentBase(const char* compName) :
     Fw::PassiveComponentBase(compName),
-    paramDelegatePtr(NULL)
+    paramDelegatePtr(nullptr)
 {
   // Write telemetry channel ChannelU32OnChange
   this->m_first_update_ChannelU32OnChange = true;
-  this->m_last_ChannelU32OnChange = 0;
+  this->m_last_ChannelU32OnChange = {};
 
   // Write telemetry channel ChannelEnumOnChange
   this->m_first_update_ChannelEnumOnChange = true;
+  this->m_last_ChannelEnumOnChange = {};
+
+  // Write telemetry channel ChannelBoolOnChange
+  this->m_first_update_ChannelBoolOnChange = true;
+  this->m_last_ChannelBoolOnChange = {};
 
   this->m_EventActivityLowThrottledThrottle = 0;
   this->m_EventFatalThrottledThrottle = 0;
@@ -4633,6 +4638,54 @@ void PassiveSerialComponentBase ::
   }
 }
 
+void PassiveSerialComponentBase ::
+  tlmWrite_ChannelBoolOnChange(
+      bool arg,
+      Fw::Time _tlmTime
+  )
+{
+  // Check to see if it is the first time
+  if (not this->m_first_update_ChannelBoolOnChange) {
+    // Check to see if value has changed. If not, don't write it.
+    if (arg == this->m_last_ChannelBoolOnChange) {
+      return;
+    }
+    else {
+      this->m_last_ChannelBoolOnChange = arg;
+    }
+  }
+  else {
+    this->m_first_update_ChannelBoolOnChange = false;
+    this->m_last_ChannelBoolOnChange = arg;
+  }
+
+  if (this->m_tlmOut_OutputPort[0].isConnected()) {
+    if (
+      this->m_timeGetOut_OutputPort[0].isConnected() &&
+      (_tlmTime ==  Fw::ZERO_TIME)
+    ) {
+      this->m_timeGetOut_OutputPort[0].invoke(_tlmTime);
+    }
+
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
+
+    FwChanIdType _id;
+
+    _id = this->getIdBase() + CHANNELID_CHANNELBOOLONCHANGE;
+
+    this->m_tlmOut_OutputPort[0].invoke(
+      _id,
+      _tlmTime,
+      _tlmBuff
+    );
+  }
+}
+
 // ----------------------------------------------------------------------
 // Parameter update hook
 // ----------------------------------------------------------------------
@@ -4729,7 +4782,7 @@ I32 PassiveSerialComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMI32EXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -4752,7 +4805,7 @@ F64 PassiveSerialComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMF64EXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -4775,7 +4828,7 @@ Fw::ParamString PassiveSerialComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMSTRINGEXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -4798,7 +4851,7 @@ E PassiveSerialComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMENUMEXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -4821,7 +4874,7 @@ A PassiveSerialComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMARRAYEXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -4844,7 +4897,7 @@ S PassiveSerialComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMSTRUCTEXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -4864,7 +4917,7 @@ S PassiveSerialComponentBase ::
 void PassiveSerialComponentBase ::
   registerExternalParameters(Fw::ParamExternalDelegate* paramExternalDelegatePtr)
 {
-  FW_ASSERT(paramExternalDelegatePtr != NULL);
+  FW_ASSERT(paramExternalDelegatePtr != nullptr);
   this->paramDelegatePtr = paramExternalDelegatePtr;
 }
 
@@ -5702,7 +5755,7 @@ Fw::CmdResponse PassiveSerialComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMI32EXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamI32Ext
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -5725,7 +5778,7 @@ Fw::CmdResponse PassiveSerialComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMF64EXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamF64Ext
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -5748,7 +5801,7 @@ Fw::CmdResponse PassiveSerialComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMSTRINGEXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamStringExt
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -5771,7 +5824,7 @@ Fw::CmdResponse PassiveSerialComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMENUMEXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamEnumExt
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -5794,7 +5847,7 @@ Fw::CmdResponse PassiveSerialComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMARRAYEXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamArrayExt
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -5817,7 +5870,7 @@ Fw::CmdResponse PassiveSerialComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMSTRUCTEXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamStructExt
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -6029,7 +6082,7 @@ Fw::CmdResponse PassiveSerialComponentBase ::
     _id = PARAMID_PARAMI32EXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -6060,7 +6113,7 @@ Fw::CmdResponse PassiveSerialComponentBase ::
     _id = PARAMID_PARAMF64EXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -6091,7 +6144,7 @@ Fw::CmdResponse PassiveSerialComponentBase ::
     _id = PARAMID_PARAMSTRINGEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -6122,7 +6175,7 @@ Fw::CmdResponse PassiveSerialComponentBase ::
     _id = PARAMID_PARAMENUMEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -6153,7 +6206,7 @@ Fw::CmdResponse PassiveSerialComponentBase ::
     _id = PARAMID_PARAMARRAYEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -6184,7 +6237,7 @@ Fw::CmdResponse PassiveSerialComponentBase ::
     _id = PARAMID_PARAMSTRUCTEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.hpp
@@ -199,6 +199,7 @@ class PassiveSerialComponentBase :
       CHANNELID_CHANNELF64 = 0x15, //!< Channel ID for ChannelF64
       CHANNELID_CHANNELU32ONCHANGE = 0x16, //!< Channel ID for ChannelU32OnChange
       CHANNELID_CHANNELENUMONCHANGE = 0x17, //!< Channel ID for ChannelEnumOnChange
+      CHANNELID_CHANNELBOOLONCHANGE = 0x18, //!< Channel ID for ChannelBoolOnChange
     };
 
     //! Parameter IDs
@@ -1737,6 +1738,14 @@ class PassiveSerialComponentBase :
         Fw::Time _tlmTime = Fw::Time() //!< Timestamp. Default: unspecified, request from getTime port
     );
 
+    //! Write telemetry channel ChannelBoolOnChange
+    //!
+    //! A telemetry channel with Boolean data and update on change frequency
+    void tlmWrite_ChannelBoolOnChange(
+        bool arg, //!< The telemetry value
+        Fw::Time _tlmTime = Fw::Time() //!< Timestamp. Default: unspecified, request from getTime port
+    );
+
   protected:
 
     // ----------------------------------------------------------------------
@@ -2406,6 +2415,9 @@ class PassiveSerialComponentBase :
     //! Initialized to true; cleared when channel ChannelEnumOnChange is first updated
     bool m_first_update_ChannelEnumOnChange;
 
+    //! Initialized to true; cleared when channel ChannelBoolOnChange is first updated
+    bool m_first_update_ChannelBoolOnChange;
+
   private:
 
     // ----------------------------------------------------------------------
@@ -2417,6 +2429,9 @@ class PassiveSerialComponentBase :
 
     //! Records the last emitted value for channel ChannelEnumOnChange
     E m_last_ChannelEnumOnChange;
+
+    //! Records the last emitted value for channel ChannelBoolOnChange
+    bool m_last_ChannelBoolOnChange;
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTelemetryComponentAc.ref.cpp
@@ -1232,10 +1232,15 @@ PassiveTelemetryComponentBase ::
 {
   // Write telemetry channel ChannelU32OnChange
   this->m_first_update_ChannelU32OnChange = true;
-  this->m_last_ChannelU32OnChange = 0;
+  this->m_last_ChannelU32OnChange = {};
 
   // Write telemetry channel ChannelEnumOnChange
   this->m_first_update_ChannelEnumOnChange = true;
+  this->m_last_ChannelEnumOnChange = {};
+
+  // Write telemetry channel ChannelBoolOnChange
+  this->m_first_update_ChannelBoolOnChange = true;
+  this->m_last_ChannelBoolOnChange = {};
 }
 
 PassiveTelemetryComponentBase ::
@@ -2592,6 +2597,54 @@ void PassiveTelemetryComponentBase ::
     FwChanIdType _id;
 
     _id = this->getIdBase() + CHANNELID_CHANNELENUMONCHANGE;
+
+    this->m_tlmOut_OutputPort[0].invoke(
+      _id,
+      _tlmTime,
+      _tlmBuff
+    );
+  }
+}
+
+void PassiveTelemetryComponentBase ::
+  tlmWrite_ChannelBoolOnChange(
+      bool arg,
+      Fw::Time _tlmTime
+  )
+{
+  // Check to see if it is the first time
+  if (not this->m_first_update_ChannelBoolOnChange) {
+    // Check to see if value has changed. If not, don't write it.
+    if (arg == this->m_last_ChannelBoolOnChange) {
+      return;
+    }
+    else {
+      this->m_last_ChannelBoolOnChange = arg;
+    }
+  }
+  else {
+    this->m_first_update_ChannelBoolOnChange = false;
+    this->m_last_ChannelBoolOnChange = arg;
+  }
+
+  if (this->m_tlmOut_OutputPort[0].isConnected()) {
+    if (
+      this->m_timeGetOut_OutputPort[0].isConnected() &&
+      (_tlmTime ==  Fw::ZERO_TIME)
+    ) {
+      this->m_timeGetOut_OutputPort[0].invoke(_tlmTime);
+    }
+
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
+
+    FwChanIdType _id;
+
+    _id = this->getIdBase() + CHANNELID_CHANNELBOOLONCHANGE;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTelemetryComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTelemetryComponentAc.ref.hpp
@@ -119,6 +119,7 @@ class PassiveTelemetryComponentBase :
       CHANNELID_CHANNELF64 = 0x15, //!< Channel ID for ChannelF64
       CHANNELID_CHANNELU32ONCHANGE = 0x16, //!< Channel ID for ChannelU32OnChange
       CHANNELID_CHANNELENUMONCHANGE = 0x17, //!< Channel ID for ChannelEnumOnChange
+      CHANNELID_CHANNELBOOLONCHANGE = 0x18, //!< Channel ID for ChannelBoolOnChange
     };
 
   public:
@@ -1175,6 +1176,14 @@ class PassiveTelemetryComponentBase :
         Fw::Time _tlmTime = Fw::Time() //!< Timestamp. Default: unspecified, request from getTime port
     );
 
+    //! Write telemetry channel ChannelBoolOnChange
+    //!
+    //! A telemetry channel with Boolean data and update on change frequency
+    void tlmWrite_ChannelBoolOnChange(
+        bool arg, //!< The telemetry value
+        Fw::Time _tlmTime = Fw::Time() //!< Timestamp. Default: unspecified, request from getTime port
+    );
+
   protected:
 
     // ----------------------------------------------------------------------
@@ -1479,6 +1488,9 @@ class PassiveTelemetryComponentBase :
     //! Initialized to true; cleared when channel ChannelEnumOnChange is first updated
     bool m_first_update_ChannelEnumOnChange;
 
+    //! Initialized to true; cleared when channel ChannelBoolOnChange is first updated
+    bool m_first_update_ChannelBoolOnChange;
+
   private:
 
     // ----------------------------------------------------------------------
@@ -1490,6 +1502,9 @@ class PassiveTelemetryComponentBase :
 
     //! Records the last emitted value for channel ChannelEnumOnChange
     E m_last_ChannelEnumOnChange;
+
+    //! Records the last emitted value for channel ChannelBoolOnChange
+    bool m_last_ChannelBoolOnChange;
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
@@ -1916,7 +1916,7 @@ void PassiveTestComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMI32EXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamI32Ext
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -1942,7 +1942,7 @@ void PassiveTestComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMF64EXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamF64Ext
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -1968,7 +1968,7 @@ void PassiveTestComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMSTRINGEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamStringExt
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -1994,7 +1994,7 @@ void PassiveTestComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMENUMEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamEnumExt
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -2020,7 +2020,7 @@ void PassiveTestComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMARRAYEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamArrayExt
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -2046,7 +2046,7 @@ void PassiveTestComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMSTRUCTEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamStructExt
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -2068,14 +2068,19 @@ void PassiveTestComponentBase ::
 PassiveTestComponentBase ::
   PassiveTestComponentBase(const char* compName) :
     Fw::PassiveComponentBase(compName),
-    paramDelegatePtr(NULL)
+    paramDelegatePtr(nullptr)
 {
   // Write telemetry channel ChannelU32OnChange
   this->m_first_update_ChannelU32OnChange = true;
-  this->m_last_ChannelU32OnChange = 0;
+  this->m_last_ChannelU32OnChange = {};
 
   // Write telemetry channel ChannelEnumOnChange
   this->m_first_update_ChannelEnumOnChange = true;
+  this->m_last_ChannelEnumOnChange = {};
+
+  // Write telemetry channel ChannelBoolOnChange
+  this->m_first_update_ChannelBoolOnChange = true;
+  this->m_last_ChannelBoolOnChange = {};
 
   this->m_EventActivityLowThrottledThrottle = 0;
   this->m_EventFatalThrottledThrottle = 0;
@@ -4871,6 +4876,54 @@ void PassiveTestComponentBase ::
   }
 }
 
+void PassiveTestComponentBase ::
+  tlmWrite_ChannelBoolOnChange(
+      bool arg,
+      Fw::Time _tlmTime
+  )
+{
+  // Check to see if it is the first time
+  if (not this->m_first_update_ChannelBoolOnChange) {
+    // Check to see if value has changed. If not, don't write it.
+    if (arg == this->m_last_ChannelBoolOnChange) {
+      return;
+    }
+    else {
+      this->m_last_ChannelBoolOnChange = arg;
+    }
+  }
+  else {
+    this->m_first_update_ChannelBoolOnChange = false;
+    this->m_last_ChannelBoolOnChange = arg;
+  }
+
+  if (this->m_tlmOut_OutputPort[0].isConnected()) {
+    if (
+      this->m_timeGetOut_OutputPort[0].isConnected() &&
+      (_tlmTime ==  Fw::ZERO_TIME)
+    ) {
+      this->m_timeGetOut_OutputPort[0].invoke(_tlmTime);
+    }
+
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
+
+    FwChanIdType _id;
+
+    _id = this->getIdBase() + CHANNELID_CHANNELBOOLONCHANGE;
+
+    this->m_tlmOut_OutputPort[0].invoke(
+      _id,
+      _tlmTime,
+      _tlmBuff
+    );
+  }
+}
+
 // ----------------------------------------------------------------------
 // Parameter update hook
 // ----------------------------------------------------------------------
@@ -4967,7 +5020,7 @@ I32 PassiveTestComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMI32EXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -4990,7 +5043,7 @@ F64 PassiveTestComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMF64EXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -5013,7 +5066,7 @@ Fw::ParamString PassiveTestComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMSTRINGEXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -5036,7 +5089,7 @@ E PassiveTestComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMENUMEXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -5059,7 +5112,7 @@ A PassiveTestComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMARRAYEXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -5082,7 +5135,7 @@ S PassiveTestComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMSTRUCTEXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -5102,7 +5155,7 @@ S PassiveTestComponentBase ::
 void PassiveTestComponentBase ::
   registerExternalParameters(Fw::ParamExternalDelegate* paramExternalDelegatePtr)
 {
-  FW_ASSERT(paramExternalDelegatePtr != NULL);
+  FW_ASSERT(paramExternalDelegatePtr != nullptr);
   this->paramDelegatePtr = paramExternalDelegatePtr;
 }
 
@@ -5953,7 +6006,7 @@ Fw::CmdResponse PassiveTestComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMI32EXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamI32Ext
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -5976,7 +6029,7 @@ Fw::CmdResponse PassiveTestComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMF64EXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamF64Ext
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -5999,7 +6052,7 @@ Fw::CmdResponse PassiveTestComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMSTRINGEXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamStringExt
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -6022,7 +6075,7 @@ Fw::CmdResponse PassiveTestComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMENUMEXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamEnumExt
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -6045,7 +6098,7 @@ Fw::CmdResponse PassiveTestComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMARRAYEXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamArrayExt
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -6068,7 +6121,7 @@ Fw::CmdResponse PassiveTestComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMSTRUCTEXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamStructExt
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -6280,7 +6333,7 @@ Fw::CmdResponse PassiveTestComponentBase ::
     _id = PARAMID_PARAMI32EXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -6311,7 +6364,7 @@ Fw::CmdResponse PassiveTestComponentBase ::
     _id = PARAMID_PARAMF64EXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -6342,7 +6395,7 @@ Fw::CmdResponse PassiveTestComponentBase ::
     _id = PARAMID_PARAMSTRINGEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -6373,7 +6426,7 @@ Fw::CmdResponse PassiveTestComponentBase ::
     _id = PARAMID_PARAMENUMEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -6404,7 +6457,7 @@ Fw::CmdResponse PassiveTestComponentBase ::
     _id = PARAMID_PARAMARRAYEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -6435,7 +6488,7 @@ Fw::CmdResponse PassiveTestComponentBase ::
     _id = PARAMID_PARAMSTRUCTEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.hpp
@@ -191,6 +191,7 @@ class PassiveTestComponentBase :
       CHANNELID_CHANNELF64 = 0x15, //!< Channel ID for ChannelF64
       CHANNELID_CHANNELU32ONCHANGE = 0x16, //!< Channel ID for ChannelU32OnChange
       CHANNELID_CHANNELENUMONCHANGE = 0x17, //!< Channel ID for ChannelEnumOnChange
+      CHANNELID_CHANNELBOOLONCHANGE = 0x18, //!< Channel ID for ChannelBoolOnChange
     };
 
     //! Parameter IDs
@@ -1836,6 +1837,14 @@ class PassiveTestComponentBase :
         Fw::Time _tlmTime = Fw::Time() //!< Timestamp. Default: unspecified, request from getTime port
     );
 
+    //! Write telemetry channel ChannelBoolOnChange
+    //!
+    //! A telemetry channel with Boolean data and update on change frequency
+    void tlmWrite_ChannelBoolOnChange(
+        bool arg, //!< The telemetry value
+        Fw::Time _tlmTime = Fw::Time() //!< Timestamp. Default: unspecified, request from getTime port
+    );
+
   protected:
 
     // ----------------------------------------------------------------------
@@ -2581,6 +2590,9 @@ class PassiveTestComponentBase :
     //! Initialized to true; cleared when channel ChannelEnumOnChange is first updated
     bool m_first_update_ChannelEnumOnChange;
 
+    //! Initialized to true; cleared when channel ChannelBoolOnChange is first updated
+    bool m_first_update_ChannelBoolOnChange;
+
   private:
 
     // ----------------------------------------------------------------------
@@ -2592,6 +2604,9 @@ class PassiveTestComponentBase :
 
     //! Records the last emitted value for channel ChannelEnumOnChange
     E m_last_ChannelEnumOnChange;
+
+    //! Records the last emitted value for channel ChannelBoolOnChange
+    bool m_last_ChannelBoolOnChange;
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedExternalParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedExternalParamsComponentAc.ref.cpp
@@ -1592,7 +1592,7 @@ void QueuedExternalParamsComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMI32EXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamI32Ext
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -1618,7 +1618,7 @@ void QueuedExternalParamsComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMF64EXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamF64Ext
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -1644,7 +1644,7 @@ void QueuedExternalParamsComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMSTRINGEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamStringExt
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -1670,7 +1670,7 @@ void QueuedExternalParamsComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMENUMEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamEnumExt
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -1696,7 +1696,7 @@ void QueuedExternalParamsComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMARRAYEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamArrayExt
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -1722,7 +1722,7 @@ void QueuedExternalParamsComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMSTRUCTEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamStructExt
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -1744,7 +1744,7 @@ void QueuedExternalParamsComponentBase ::
 QueuedExternalParamsComponentBase ::
   QueuedExternalParamsComponentBase(const char* compName) :
     Fw::QueuedComponentBase(compName),
-    paramDelegatePtr(NULL)
+    paramDelegatePtr(nullptr)
 {
 
 }
@@ -3465,7 +3465,7 @@ I32 QueuedExternalParamsComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMI32EXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -3488,7 +3488,7 @@ F64 QueuedExternalParamsComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMF64EXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -3511,7 +3511,7 @@ Fw::ParamString QueuedExternalParamsComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMSTRINGEXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -3534,7 +3534,7 @@ E QueuedExternalParamsComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMENUMEXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -3557,7 +3557,7 @@ A QueuedExternalParamsComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMARRAYEXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -3580,7 +3580,7 @@ S QueuedExternalParamsComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMSTRUCTEXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -3600,7 +3600,7 @@ S QueuedExternalParamsComponentBase ::
 void QueuedExternalParamsComponentBase ::
   registerExternalParameters(Fw::ParamExternalDelegate* paramExternalDelegatePtr)
 {
-  FW_ASSERT(paramExternalDelegatePtr != NULL);
+  FW_ASSERT(paramExternalDelegatePtr != nullptr);
   this->paramDelegatePtr = paramExternalDelegatePtr;
 }
 
@@ -4646,7 +4646,7 @@ Fw::CmdResponse QueuedExternalParamsComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMI32EXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamI32Ext
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -4669,7 +4669,7 @@ Fw::CmdResponse QueuedExternalParamsComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMF64EXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamF64Ext
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -4692,7 +4692,7 @@ Fw::CmdResponse QueuedExternalParamsComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMSTRINGEXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamStringExt
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -4715,7 +4715,7 @@ Fw::CmdResponse QueuedExternalParamsComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMENUMEXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamEnumExt
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -4738,7 +4738,7 @@ Fw::CmdResponse QueuedExternalParamsComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMARRAYEXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamArrayExt
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -4761,7 +4761,7 @@ Fw::CmdResponse QueuedExternalParamsComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMSTRUCTEXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamStructExt
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -4793,7 +4793,7 @@ Fw::CmdResponse QueuedExternalParamsComponentBase ::
     _id = PARAMID_PARAMI32EXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -4824,7 +4824,7 @@ Fw::CmdResponse QueuedExternalParamsComponentBase ::
     _id = PARAMID_PARAMF64EXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -4855,7 +4855,7 @@ Fw::CmdResponse QueuedExternalParamsComponentBase ::
     _id = PARAMID_PARAMSTRINGEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -4886,7 +4886,7 @@ Fw::CmdResponse QueuedExternalParamsComponentBase ::
     _id = PARAMID_PARAMENUMEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -4917,7 +4917,7 @@ Fw::CmdResponse QueuedExternalParamsComponentBase ::
     _id = PARAMID_PARAMARRAYEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -4948,7 +4948,7 @@ Fw::CmdResponse QueuedExternalParamsComponentBase ::
     _id = PARAMID_PARAMSTRUCTEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
@@ -2165,7 +2165,7 @@ void QueuedSerialComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMI32EXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamI32Ext
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -2191,7 +2191,7 @@ void QueuedSerialComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMF64EXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamF64Ext
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -2217,7 +2217,7 @@ void QueuedSerialComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMSTRINGEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamStringExt
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -2243,7 +2243,7 @@ void QueuedSerialComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMENUMEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamEnumExt
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -2269,7 +2269,7 @@ void QueuedSerialComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMARRAYEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamArrayExt
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -2295,7 +2295,7 @@ void QueuedSerialComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMSTRUCTEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamStructExt
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -2317,14 +2317,19 @@ void QueuedSerialComponentBase ::
 QueuedSerialComponentBase ::
   QueuedSerialComponentBase(const char* compName) :
     Fw::QueuedComponentBase(compName),
-    paramDelegatePtr(NULL)
+    paramDelegatePtr(nullptr)
 {
   // Write telemetry channel ChannelU32OnChange
   this->m_first_update_ChannelU32OnChange = true;
-  this->m_last_ChannelU32OnChange = 0;
+  this->m_last_ChannelU32OnChange = {};
 
   // Write telemetry channel ChannelEnumOnChange
   this->m_first_update_ChannelEnumOnChange = true;
+  this->m_last_ChannelEnumOnChange = {};
+
+  // Write telemetry channel ChannelBoolOnChange
+  this->m_first_update_ChannelBoolOnChange = true;
+  this->m_last_ChannelBoolOnChange = {};
 
   this->m_EventActivityLowThrottledThrottle = 0;
   this->m_EventFatalThrottledThrottle = 0;
@@ -6725,6 +6730,54 @@ void QueuedSerialComponentBase ::
   }
 }
 
+void QueuedSerialComponentBase ::
+  tlmWrite_ChannelBoolOnChange(
+      bool arg,
+      Fw::Time _tlmTime
+  )
+{
+  // Check to see if it is the first time
+  if (not this->m_first_update_ChannelBoolOnChange) {
+    // Check to see if value has changed. If not, don't write it.
+    if (arg == this->m_last_ChannelBoolOnChange) {
+      return;
+    }
+    else {
+      this->m_last_ChannelBoolOnChange = arg;
+    }
+  }
+  else {
+    this->m_first_update_ChannelBoolOnChange = false;
+    this->m_last_ChannelBoolOnChange = arg;
+  }
+
+  if (this->m_tlmOut_OutputPort[0].isConnected()) {
+    if (
+      this->m_timeGetOut_OutputPort[0].isConnected() &&
+      (_tlmTime ==  Fw::ZERO_TIME)
+    ) {
+      this->m_timeGetOut_OutputPort[0].invoke(_tlmTime);
+    }
+
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
+
+    FwChanIdType _id;
+
+    _id = this->getIdBase() + CHANNELID_CHANNELBOOLONCHANGE;
+
+    this->m_tlmOut_OutputPort[0].invoke(
+      _id,
+      _tlmTime,
+      _tlmBuff
+    );
+  }
+}
+
 // ----------------------------------------------------------------------
 // Parameter update hook
 // ----------------------------------------------------------------------
@@ -6821,7 +6874,7 @@ I32 QueuedSerialComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMI32EXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -6844,7 +6897,7 @@ F64 QueuedSerialComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMF64EXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -6867,7 +6920,7 @@ Fw::ParamString QueuedSerialComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMSTRINGEXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -6890,7 +6943,7 @@ E QueuedSerialComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMENUMEXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -6913,7 +6966,7 @@ A QueuedSerialComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMARRAYEXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -6936,7 +6989,7 @@ S QueuedSerialComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMSTRUCTEXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -6956,7 +7009,7 @@ S QueuedSerialComponentBase ::
 void QueuedSerialComponentBase ::
   registerExternalParameters(Fw::ParamExternalDelegate* paramExternalDelegatePtr)
 {
-  FW_ASSERT(paramExternalDelegatePtr != NULL);
+  FW_ASSERT(paramExternalDelegatePtr != nullptr);
   this->paramDelegatePtr = paramExternalDelegatePtr;
 }
 
@@ -9015,7 +9068,7 @@ Fw::CmdResponse QueuedSerialComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMI32EXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamI32Ext
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -9038,7 +9091,7 @@ Fw::CmdResponse QueuedSerialComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMF64EXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamF64Ext
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -9061,7 +9114,7 @@ Fw::CmdResponse QueuedSerialComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMSTRINGEXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamStringExt
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -9084,7 +9137,7 @@ Fw::CmdResponse QueuedSerialComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMENUMEXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamEnumExt
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -9107,7 +9160,7 @@ Fw::CmdResponse QueuedSerialComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMARRAYEXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamArrayExt
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -9130,7 +9183,7 @@ Fw::CmdResponse QueuedSerialComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMSTRUCTEXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamStructExt
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -9342,7 +9395,7 @@ Fw::CmdResponse QueuedSerialComponentBase ::
     _id = PARAMID_PARAMI32EXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -9373,7 +9426,7 @@ Fw::CmdResponse QueuedSerialComponentBase ::
     _id = PARAMID_PARAMF64EXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -9404,7 +9457,7 @@ Fw::CmdResponse QueuedSerialComponentBase ::
     _id = PARAMID_PARAMSTRINGEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -9435,7 +9488,7 @@ Fw::CmdResponse QueuedSerialComponentBase ::
     _id = PARAMID_PARAMENUMEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -9466,7 +9519,7 @@ Fw::CmdResponse QueuedSerialComponentBase ::
     _id = PARAMID_PARAMARRAYEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -9497,7 +9550,7 @@ Fw::CmdResponse QueuedSerialComponentBase ::
     _id = PARAMID_PARAMSTRUCTEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.hpp
@@ -215,6 +215,7 @@ class QueuedSerialComponentBase :
       CHANNELID_CHANNELF64 = 0x15, //!< Channel ID for ChannelF64
       CHANNELID_CHANNELU32ONCHANGE = 0x16, //!< Channel ID for ChannelU32OnChange
       CHANNELID_CHANNELENUMONCHANGE = 0x17, //!< Channel ID for ChannelEnumOnChange
+      CHANNELID_CHANNELBOOLONCHANGE = 0x18, //!< Channel ID for ChannelBoolOnChange
     };
 
     //! Parameter IDs
@@ -2363,6 +2364,14 @@ class QueuedSerialComponentBase :
         Fw::Time _tlmTime = Fw::Time() //!< Timestamp. Default: unspecified, request from getTime port
     );
 
+    //! Write telemetry channel ChannelBoolOnChange
+    //!
+    //! A telemetry channel with Boolean data and update on change frequency
+    void tlmWrite_ChannelBoolOnChange(
+        bool arg, //!< The telemetry value
+        Fw::Time _tlmTime = Fw::Time() //!< Timestamp. Default: unspecified, request from getTime port
+    );
+
   protected:
 
     // ----------------------------------------------------------------------
@@ -3179,6 +3188,9 @@ class QueuedSerialComponentBase :
     //! Initialized to true; cleared when channel ChannelEnumOnChange is first updated
     bool m_first_update_ChannelEnumOnChange;
 
+    //! Initialized to true; cleared when channel ChannelBoolOnChange is first updated
+    bool m_first_update_ChannelBoolOnChange;
+
   private:
 
     // ----------------------------------------------------------------------
@@ -3190,6 +3202,9 @@ class QueuedSerialComponentBase :
 
     //! Records the last emitted value for channel ChannelEnumOnChange
     E m_last_ChannelEnumOnChange;
+
+    //! Records the last emitted value for channel ChannelBoolOnChange
+    bool m_last_ChannelBoolOnChange;
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.cpp
@@ -1513,10 +1513,15 @@ QueuedTelemetryComponentBase ::
 {
   // Write telemetry channel ChannelU32OnChange
   this->m_first_update_ChannelU32OnChange = true;
-  this->m_last_ChannelU32OnChange = 0;
+  this->m_last_ChannelU32OnChange = {};
 
   // Write telemetry channel ChannelEnumOnChange
   this->m_first_update_ChannelEnumOnChange = true;
+  this->m_last_ChannelEnumOnChange = {};
+
+  // Write telemetry channel ChannelBoolOnChange
+  this->m_first_update_ChannelBoolOnChange = true;
+  this->m_last_ChannelBoolOnChange = {};
 }
 
 QueuedTelemetryComponentBase ::
@@ -3578,6 +3583,54 @@ void QueuedTelemetryComponentBase ::
     FwChanIdType _id;
 
     _id = this->getIdBase() + CHANNELID_CHANNELENUMONCHANGE;
+
+    this->m_tlmOut_OutputPort[0].invoke(
+      _id,
+      _tlmTime,
+      _tlmBuff
+    );
+  }
+}
+
+void QueuedTelemetryComponentBase ::
+  tlmWrite_ChannelBoolOnChange(
+      bool arg,
+      Fw::Time _tlmTime
+  )
+{
+  // Check to see if it is the first time
+  if (not this->m_first_update_ChannelBoolOnChange) {
+    // Check to see if value has changed. If not, don't write it.
+    if (arg == this->m_last_ChannelBoolOnChange) {
+      return;
+    }
+    else {
+      this->m_last_ChannelBoolOnChange = arg;
+    }
+  }
+  else {
+    this->m_first_update_ChannelBoolOnChange = false;
+    this->m_last_ChannelBoolOnChange = arg;
+  }
+
+  if (this->m_tlmOut_OutputPort[0].isConnected()) {
+    if (
+      this->m_timeGetOut_OutputPort[0].isConnected() &&
+      (_tlmTime ==  Fw::ZERO_TIME)
+    ) {
+      this->m_timeGetOut_OutputPort[0].invoke(_tlmTime);
+    }
+
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
+
+    FwChanIdType _id;
+
+    _id = this->getIdBase() + CHANNELID_CHANNELBOOLONCHANGE;
 
     this->m_tlmOut_OutputPort[0].invoke(
       _id,

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.hpp
@@ -125,6 +125,7 @@ class QueuedTelemetryComponentBase :
       CHANNELID_CHANNELF64 = 0x15, //!< Channel ID for ChannelF64
       CHANNELID_CHANNELU32ONCHANGE = 0x16, //!< Channel ID for ChannelU32OnChange
       CHANNELID_CHANNELENUMONCHANGE = 0x17, //!< Channel ID for ChannelEnumOnChange
+      CHANNELID_CHANNELBOOLONCHANGE = 0x18, //!< Channel ID for ChannelBoolOnChange
     };
 
   public:
@@ -1459,6 +1460,14 @@ class QueuedTelemetryComponentBase :
         Fw::Time _tlmTime = Fw::Time() //!< Timestamp. Default: unspecified, request from getTime port
     );
 
+    //! Write telemetry channel ChannelBoolOnChange
+    //!
+    //! A telemetry channel with Boolean data and update on change frequency
+    void tlmWrite_ChannelBoolOnChange(
+        bool arg, //!< The telemetry value
+        Fw::Time _tlmTime = Fw::Time() //!< Timestamp. Default: unspecified, request from getTime port
+    );
+
   protected:
 
     // ----------------------------------------------------------------------
@@ -1870,6 +1879,9 @@ class QueuedTelemetryComponentBase :
     //! Initialized to true; cleared when channel ChannelEnumOnChange is first updated
     bool m_first_update_ChannelEnumOnChange;
 
+    //! Initialized to true; cleared when channel ChannelBoolOnChange is first updated
+    bool m_first_update_ChannelBoolOnChange;
+
   private:
 
     // ----------------------------------------------------------------------
@@ -1881,6 +1893,9 @@ class QueuedTelemetryComponentBase :
 
     //! Records the last emitted value for channel ChannelEnumOnChange
     E m_last_ChannelEnumOnChange;
+
+    //! Records the last emitted value for channel ChannelBoolOnChange
+    bool m_last_ChannelBoolOnChange;
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
@@ -2253,7 +2253,7 @@ void QueuedTestComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMI32EXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamI32Ext
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -2279,7 +2279,7 @@ void QueuedTestComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMF64EXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamF64Ext
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -2305,7 +2305,7 @@ void QueuedTestComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMSTRINGEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamStringExt
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -2331,7 +2331,7 @@ void QueuedTestComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMENUMEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamEnumExt
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -2357,7 +2357,7 @@ void QueuedTestComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMARRAYEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamArrayExt
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -2383,7 +2383,7 @@ void QueuedTestComponentBase ::
     // Pass the local ID to the delegate
     _id = PARAMID_PARAMSTRUCTEXT;
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     // Call the delegate deserialize function for m_ParamStructExt
     _stat = this->paramDelegatePtr->deserializeParam(_baseId, _id, param_valid, _buff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
@@ -2405,14 +2405,19 @@ void QueuedTestComponentBase ::
 QueuedTestComponentBase ::
   QueuedTestComponentBase(const char* compName) :
     Fw::QueuedComponentBase(compName),
-    paramDelegatePtr(NULL)
+    paramDelegatePtr(nullptr)
 {
   // Write telemetry channel ChannelU32OnChange
   this->m_first_update_ChannelU32OnChange = true;
-  this->m_last_ChannelU32OnChange = 0;
+  this->m_last_ChannelU32OnChange = {};
 
   // Write telemetry channel ChannelEnumOnChange
   this->m_first_update_ChannelEnumOnChange = true;
+  this->m_last_ChannelEnumOnChange = {};
+
+  // Write telemetry channel ChannelBoolOnChange
+  this->m_first_update_ChannelBoolOnChange = true;
+  this->m_last_ChannelBoolOnChange = {};
 
   this->m_EventActivityLowThrottledThrottle = 0;
   this->m_EventFatalThrottledThrottle = 0;
@@ -6597,6 +6602,54 @@ void QueuedTestComponentBase ::
   }
 }
 
+void QueuedTestComponentBase ::
+  tlmWrite_ChannelBoolOnChange(
+      bool arg,
+      Fw::Time _tlmTime
+  )
+{
+  // Check to see if it is the first time
+  if (not this->m_first_update_ChannelBoolOnChange) {
+    // Check to see if value has changed. If not, don't write it.
+    if (arg == this->m_last_ChannelBoolOnChange) {
+      return;
+    }
+    else {
+      this->m_last_ChannelBoolOnChange = arg;
+    }
+  }
+  else {
+    this->m_first_update_ChannelBoolOnChange = false;
+    this->m_last_ChannelBoolOnChange = arg;
+  }
+
+  if (this->m_tlmOut_OutputPort[0].isConnected()) {
+    if (
+      this->m_timeGetOut_OutputPort[0].isConnected() &&
+      (_tlmTime ==  Fw::ZERO_TIME)
+    ) {
+      this->m_timeGetOut_OutputPort[0].invoke(_tlmTime);
+    }
+
+    Fw::TlmBuffer _tlmBuff;
+    Fw::SerializeStatus _stat = _tlmBuff.serializeFrom(arg);
+    FW_ASSERT(
+      _stat == Fw::FW_SERIALIZE_OK,
+      static_cast<FwAssertArgType>(_stat)
+    );
+
+    FwChanIdType _id;
+
+    _id = this->getIdBase() + CHANNELID_CHANNELBOOLONCHANGE;
+
+    this->m_tlmOut_OutputPort[0].invoke(
+      _id,
+      _tlmTime,
+      _tlmBuff
+    );
+  }
+}
+
 // ----------------------------------------------------------------------
 // Parameter update hook
 // ----------------------------------------------------------------------
@@ -6693,7 +6746,7 @@ I32 QueuedTestComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMI32EXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -6716,7 +6769,7 @@ F64 QueuedTestComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMF64EXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -6739,7 +6792,7 @@ Fw::ParamString QueuedTestComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMSTRINGEXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -6762,7 +6815,7 @@ E QueuedTestComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMENUMEXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -6785,7 +6838,7 @@ A QueuedTestComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMARRAYEXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -6808,7 +6861,7 @@ S QueuedTestComponentBase ::
   // Get the local ID to pass to the delegate
   const FwPrmIdType _localId = PARAMID_PARAMSTRUCTEXT;
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Get the external parameter from the delegate
   Fw::SerializeStatus _stat = this->paramDelegatePtr->serializeParam(_baseId, _localId, _getBuff);
   if(_stat == Fw::FW_SERIALIZE_OK) {
@@ -6828,7 +6881,7 @@ S QueuedTestComponentBase ::
 void QueuedTestComponentBase ::
   registerExternalParameters(Fw::ParamExternalDelegate* paramExternalDelegatePtr)
 {
-  FW_ASSERT(paramExternalDelegatePtr != NULL);
+  FW_ASSERT(paramExternalDelegatePtr != nullptr);
   this->paramDelegatePtr = paramExternalDelegatePtr;
 }
 
@@ -8800,7 +8853,7 @@ Fw::CmdResponse QueuedTestComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMI32EXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamI32Ext
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -8823,7 +8876,7 @@ Fw::CmdResponse QueuedTestComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMF64EXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamF64Ext
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -8846,7 +8899,7 @@ Fw::CmdResponse QueuedTestComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMSTRINGEXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamStringExt
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -8869,7 +8922,7 @@ Fw::CmdResponse QueuedTestComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMENUMEXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamEnumExt
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -8892,7 +8945,7 @@ Fw::CmdResponse QueuedTestComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMARRAYEXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamArrayExt
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -8915,7 +8968,7 @@ Fw::CmdResponse QueuedTestComponentBase ::
   const FwPrmIdType _localId = PARAMID_PARAMSTRUCTEXT;
   const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-  FW_ASSERT(this->paramDelegatePtr != NULL);
+  FW_ASSERT(this->paramDelegatePtr != nullptr);
   // Call the delegate serialize function for m_ParamStructExt
   const Fw::SerializeStatus _stat = this->paramDelegatePtr->deserializeParam(
     _baseId,
@@ -9127,7 +9180,7 @@ Fw::CmdResponse QueuedTestComponentBase ::
     _id = PARAMID_PARAMI32EXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -9158,7 +9211,7 @@ Fw::CmdResponse QueuedTestComponentBase ::
     _id = PARAMID_PARAMF64EXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -9189,7 +9242,7 @@ Fw::CmdResponse QueuedTestComponentBase ::
     _id = PARAMID_PARAMSTRINGEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -9220,7 +9273,7 @@ Fw::CmdResponse QueuedTestComponentBase ::
     _id = PARAMID_PARAMENUMEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -9251,7 +9304,7 @@ Fw::CmdResponse QueuedTestComponentBase ::
     _id = PARAMID_PARAMARRAYEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;
@@ -9282,7 +9335,7 @@ Fw::CmdResponse QueuedTestComponentBase ::
     _id = PARAMID_PARAMSTRUCTEXT;
     const FwPrmIdType _baseId = static_cast<FwPrmIdType>(this->getIdBase());
 
-    FW_ASSERT(this->paramDelegatePtr != NULL);
+    FW_ASSERT(this->paramDelegatePtr != nullptr);
     _stat = this->paramDelegatePtr->serializeParam(_baseId, _id, _saveBuff);
     if (_stat != Fw::FW_SERIALIZE_OK) {
       return Fw::CmdResponse::VALIDATION_ERROR;

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.hpp
@@ -203,6 +203,7 @@ class QueuedTestComponentBase :
       CHANNELID_CHANNELF64 = 0x15, //!< Channel ID for ChannelF64
       CHANNELID_CHANNELU32ONCHANGE = 0x16, //!< Channel ID for ChannelU32OnChange
       CHANNELID_CHANNELENUMONCHANGE = 0x17, //!< Channel ID for ChannelEnumOnChange
+      CHANNELID_CHANNELBOOLONCHANGE = 0x18, //!< Channel ID for ChannelBoolOnChange
     };
 
     //! Parameter IDs
@@ -2345,6 +2346,14 @@ class QueuedTestComponentBase :
         Fw::Time _tlmTime = Fw::Time() //!< Timestamp. Default: unspecified, request from getTime port
     );
 
+    //! Write telemetry channel ChannelBoolOnChange
+    //!
+    //! A telemetry channel with Boolean data and update on change frequency
+    void tlmWrite_ChannelBoolOnChange(
+        bool arg, //!< The telemetry value
+        Fw::Time _tlmTime = Fw::Time() //!< Timestamp. Default: unspecified, request from getTime port
+    );
+
   protected:
 
     // ----------------------------------------------------------------------
@@ -3197,6 +3206,9 @@ class QueuedTestComponentBase :
     //! Initialized to true; cleared when channel ChannelEnumOnChange is first updated
     bool m_first_update_ChannelEnumOnChange;
 
+    //! Initialized to true; cleared when channel ChannelBoolOnChange is first updated
+    bool m_first_update_ChannelBoolOnChange;
+
   private:
 
     // ----------------------------------------------------------------------
@@ -3208,6 +3220,9 @@ class QueuedTestComponentBase :
 
     //! Records the last emitted value for channel ChannelEnumOnChange
     E m_last_ChannelEnumOnChange;
+
+    //! Records the last emitted value for channel ChannelBoolOnChange
+    bool m_last_ChannelBoolOnChange;
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/include/telemetry.fppi
+++ b/compiler/tools/fpp-to-cpp/test/component/include/telemetry.fppi
@@ -48,3 +48,6 @@ telemetry ChannelU32OnChange: U32 \
 telemetry ChannelEnumOnChange: E \
   update on change
 
+@ A telemetry channel with Boolean data and update on change frequency
+telemetry ChannelBoolOnChange: bool \
+  update on change

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialGTestBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialGTestBase.ref.cpp
@@ -994,3 +994,45 @@ void ActiveSerialGTestBase ::
     << "  Expected: " << val << "\n"
     << "  Actual:   " << _e.arg << "\n";
 }
+
+void ActiveSerialGTestBase ::
+  assertTlm_ChannelBoolOnChange_size(
+      const char* const __callSiteFileName,
+      const U32 __callSiteLineNumber,
+      const U32 size
+  ) const
+{
+  ASSERT_EQ(this->tlmHistory_ChannelBoolOnChange->size(), size)
+    << "\n"
+    << __callSiteFileName << ":" << __callSiteLineNumber << "\n"
+    << "  Value:    Size of history for telemetry channel ChannelBoolOnChange\n"
+    << "  Expected: " << size << "\n"
+    << "  Actual:   " << this->tlmHistory_ChannelBoolOnChange->size() << "\n";
+}
+
+void ActiveSerialGTestBase ::
+  assertTlm_ChannelBoolOnChange(
+      const char* const __callSiteFileName,
+      const U32 __callSiteLineNumber,
+      const U32 __index,
+      const bool val
+  ) const
+{
+  ASSERT_LT(__index, this->tlmHistory_ChannelBoolOnChange->size())
+    << "\n"
+    << __callSiteFileName << ":" << __callSiteLineNumber << "\n"
+    << "  Value:    Index into history of telemetry channel ChannelBoolOnChange\n"
+    << "  Expected: Less than size of history ("
+    << this->tlmHistory_ChannelBoolOnChange->size() << ")\n"
+    << "  Actual:   " << __index << "\n";
+  const TlmEntry_ChannelBoolOnChange& _e =
+    this->tlmHistory_ChannelBoolOnChange->at(__index);
+  ASSERT_EQ(val, _e.arg)
+    << "\n"
+    << __callSiteFileName << ":" << __callSiteLineNumber << "\n"
+    << "  Value:    Value at index "
+    << __index
+    << " on telemetry channel ChannelBoolOnChange\n"
+    << "  Expected: " << val << "\n"
+    << "  Actual:   " << _e.arg << "\n";
+}

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialGTestBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialGTestBase.ref.hpp
@@ -551,6 +551,12 @@
 #define ASSERT_TLM_ChannelEnumOnChange(index, value) \
   this->assertTlm_ChannelEnumOnChange(__FILE__, __LINE__, index, value)
 
+#define ASSERT_TLM_ChannelBoolOnChange_SIZE(size) \
+  this->assertTlm_ChannelBoolOnChange_size(__FILE__, __LINE__, size)
+
+#define ASSERT_TLM_ChannelBoolOnChange(index, value) \
+  this->assertTlm_ChannelBoolOnChange(__FILE__, __LINE__, index, value)
+
 //! \class ActiveSerialGTestBase
 //! \brief Auto-generated base for ActiveSerial component Google Test harness
 class ActiveSerialGTestBase :
@@ -945,6 +951,21 @@ class ActiveSerialGTestBase :
         const U32 __callSiteLineNumber, //!< The line number of the call site
         const U32 __index, //!< The index
         const E& val //!< The channel value
+    ) const;
+
+    //! Channel: ChannelBoolOnChange
+    void assertTlm_ChannelBoolOnChange_size(
+        const char* const __callSiteFileName, //!< The name of the file containing the call site
+        const U32 __callSiteLineNumber, //!< The line number of the call site
+        const U32 size //!< The asserted size
+    ) const;
+
+    //! Channel: ChannelBoolOnChange
+    void assertTlm_ChannelBoolOnChange(
+        const char* const __callSiteFileName, //!< The name of the file containing the call site
+        const U32 __callSiteLineNumber, //!< The line number of the call site
+        const U32 __index, //!< The index
+        const bool val //!< The channel value
     ) const;
 
 };

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.cpp
@@ -1631,6 +1631,7 @@ ActiveSerialTesterBase ::
   this->tlmHistory_ChannelF64 = new History<TlmEntry_ChannelF64>(maxHistorySize);
   this->tlmHistory_ChannelU32OnChange = new History<TlmEntry_ChannelU32OnChange>(maxHistorySize);
   this->tlmHistory_ChannelEnumOnChange = new History<TlmEntry_ChannelEnumOnChange>(maxHistorySize);
+  this->tlmHistory_ChannelBoolOnChange = new History<TlmEntry_ChannelBoolOnChange>(maxHistorySize);
 
   // Clear history
   this->clearHistory();
@@ -1671,6 +1672,7 @@ ActiveSerialTesterBase ::
   delete this->tlmHistory_ChannelF64;
   delete this->tlmHistory_ChannelU32OnChange;
   delete this->tlmHistory_ChannelEnumOnChange;
+  delete this->tlmHistory_ChannelBoolOnChange;
 }
 
 // ----------------------------------------------------------------------
@@ -4299,6 +4301,19 @@ void ActiveSerialTesterBase ::
       break;
     }
 
+    case ActiveSerialComponentBase::CHANNELID_CHANNELBOOLONCHANGE: {
+      bool arg;
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
+
+      if (_status != Fw::FW_SERIALIZE_OK) {
+        printf("Error deserializing ChannelBoolOnChange: %d\n", _status);
+        return;
+      }
+
+      this->tlmInput_ChannelBoolOnChange(timeTag, arg);
+      break;
+    }
+
     default: {
       FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
@@ -4424,6 +4439,17 @@ void ActiveSerialTesterBase ::
 {
   TlmEntry_ChannelEnumOnChange e = { timeTag, val };
   this->tlmHistory_ChannelEnumOnChange->push_back(e);
+  this->tlmSize++;
+}
+
+void ActiveSerialTesterBase ::
+  tlmInput_ChannelBoolOnChange(
+      const Fw::Time& timeTag,
+      const bool val
+  )
+{
+  TlmEntry_ChannelBoolOnChange e = { timeTag, val };
+  this->tlmHistory_ChannelBoolOnChange->push_back(e);
   this->tlmSize++;
 }
 
@@ -5405,6 +5431,7 @@ void ActiveSerialTesterBase ::
   this->tlmHistory_ChannelF64->clear();
   this->tlmHistory_ChannelU32OnChange->clear();
   this->tlmHistory_ChannelEnumOnChange->clear();
+  this->tlmHistory_ChannelBoolOnChange->clear();
 }
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.hpp
@@ -326,6 +326,12 @@ class ActiveSerialTesterBase :
       E arg;
     };
 
+    //! A history entry for telemetry channel ChannelBoolOnChange
+    struct TlmEntry_ChannelBoolOnChange {
+      Fw::Time timeTag;
+      bool arg;
+    };
+
     //! External Parameter Delegate
     class ActiveSerialComponentBaseParamExternalDelegate :
       public Fw::ParamExternalDelegate
@@ -1827,6 +1833,12 @@ class ActiveSerialTesterBase :
         const E& val //!< The channel value
     );
 
+    //! Handle channel ChannelBoolOnChange
+    void tlmInput_ChannelBoolOnChange(
+        const Fw::Time& timeTag, //!< The time
+        const bool val //!< The channel value
+    );
+
   protected:
 
     // ----------------------------------------------------------------------
@@ -2441,6 +2453,9 @@ class ActiveSerialTesterBase :
 
     //! The history of ChannelEnumOnChange values
     History<TlmEntry_ChannelEnumOnChange>* tlmHistory_ChannelEnumOnChange;
+
+    //! The history of ChannelBoolOnChange values
+    History<TlmEntry_ChannelBoolOnChange>* tlmHistory_ChannelBoolOnChange;
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryGTestBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryGTestBase.ref.cpp
@@ -645,3 +645,45 @@ void ActiveTelemetryGTestBase ::
     << "  Expected: " << val << "\n"
     << "  Actual:   " << _e.arg << "\n";
 }
+
+void ActiveTelemetryGTestBase ::
+  assertTlm_ChannelBoolOnChange_size(
+      const char* const __callSiteFileName,
+      const U32 __callSiteLineNumber,
+      const U32 size
+  ) const
+{
+  ASSERT_EQ(this->tlmHistory_ChannelBoolOnChange->size(), size)
+    << "\n"
+    << __callSiteFileName << ":" << __callSiteLineNumber << "\n"
+    << "  Value:    Size of history for telemetry channel ChannelBoolOnChange\n"
+    << "  Expected: " << size << "\n"
+    << "  Actual:   " << this->tlmHistory_ChannelBoolOnChange->size() << "\n";
+}
+
+void ActiveTelemetryGTestBase ::
+  assertTlm_ChannelBoolOnChange(
+      const char* const __callSiteFileName,
+      const U32 __callSiteLineNumber,
+      const U32 __index,
+      const bool val
+  ) const
+{
+  ASSERT_LT(__index, this->tlmHistory_ChannelBoolOnChange->size())
+    << "\n"
+    << __callSiteFileName << ":" << __callSiteLineNumber << "\n"
+    << "  Value:    Index into history of telemetry channel ChannelBoolOnChange\n"
+    << "  Expected: Less than size of history ("
+    << this->tlmHistory_ChannelBoolOnChange->size() << ")\n"
+    << "  Actual:   " << __index << "\n";
+  const TlmEntry_ChannelBoolOnChange& _e =
+    this->tlmHistory_ChannelBoolOnChange->at(__index);
+  ASSERT_EQ(val, _e.arg)
+    << "\n"
+    << __callSiteFileName << ":" << __callSiteLineNumber << "\n"
+    << "  Value:    Value at index "
+    << __index
+    << " on telemetry channel ChannelBoolOnChange\n"
+    << "  Expected: " << val << "\n"
+    << "  Actual:   " << _e.arg << "\n";
+}

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryGTestBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryGTestBase.ref.hpp
@@ -498,6 +498,12 @@
 #define ASSERT_TLM_ChannelEnumOnChange(index, value) \
   this->assertTlm_ChannelEnumOnChange(__FILE__, __LINE__, index, value)
 
+#define ASSERT_TLM_ChannelBoolOnChange_SIZE(size) \
+  this->assertTlm_ChannelBoolOnChange_size(__FILE__, __LINE__, size)
+
+#define ASSERT_TLM_ChannelBoolOnChange(index, value) \
+  this->assertTlm_ChannelBoolOnChange(__FILE__, __LINE__, index, value)
+
 //! \class ActiveTelemetryGTestBase
 //! \brief Auto-generated base for ActiveTelemetry component Google Test harness
 class ActiveTelemetryGTestBase :
@@ -764,6 +770,21 @@ class ActiveTelemetryGTestBase :
         const U32 __callSiteLineNumber, //!< The line number of the call site
         const U32 __index, //!< The index
         const E& val //!< The channel value
+    ) const;
+
+    //! Channel: ChannelBoolOnChange
+    void assertTlm_ChannelBoolOnChange_size(
+        const char* const __callSiteFileName, //!< The name of the file containing the call site
+        const U32 __callSiteLineNumber, //!< The line number of the call site
+        const U32 size //!< The asserted size
+    ) const;
+
+    //! Channel: ChannelBoolOnChange
+    void assertTlm_ChannelBoolOnChange(
+        const char* const __callSiteFileName, //!< The name of the file containing the call site
+        const U32 __callSiteLineNumber, //!< The line number of the call site
+        const U32 __index, //!< The index
+        const bool val //!< The channel value
     ) const;
 
 };

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryTesterBase.ref.cpp
@@ -1119,6 +1119,7 @@ ActiveTelemetryTesterBase ::
   this->tlmHistory_ChannelF64 = new History<TlmEntry_ChannelF64>(maxHistorySize);
   this->tlmHistory_ChannelU32OnChange = new History<TlmEntry_ChannelU32OnChange>(maxHistorySize);
   this->tlmHistory_ChannelEnumOnChange = new History<TlmEntry_ChannelEnumOnChange>(maxHistorySize);
+  this->tlmHistory_ChannelBoolOnChange = new History<TlmEntry_ChannelBoolOnChange>(maxHistorySize);
 
   // Clear history
   this->clearHistory();
@@ -1146,6 +1147,7 @@ ActiveTelemetryTesterBase ::
   delete this->tlmHistory_ChannelF64;
   delete this->tlmHistory_ChannelU32OnChange;
   delete this->tlmHistory_ChannelEnumOnChange;
+  delete this->tlmHistory_ChannelBoolOnChange;
 }
 
 // ----------------------------------------------------------------------
@@ -2462,6 +2464,19 @@ void ActiveTelemetryTesterBase ::
       break;
     }
 
+    case ActiveTelemetryComponentBase::CHANNELID_CHANNELBOOLONCHANGE: {
+      bool arg;
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
+
+      if (_status != Fw::FW_SERIALIZE_OK) {
+        printf("Error deserializing ChannelBoolOnChange: %d\n", _status);
+        return;
+      }
+
+      this->tlmInput_ChannelBoolOnChange(timeTag, arg);
+      break;
+    }
+
     default: {
       FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
@@ -2587,6 +2602,17 @@ void ActiveTelemetryTesterBase ::
 {
   TlmEntry_ChannelEnumOnChange e = { timeTag, val };
   this->tlmHistory_ChannelEnumOnChange->push_back(e);
+  this->tlmSize++;
+}
+
+void ActiveTelemetryTesterBase ::
+  tlmInput_ChannelBoolOnChange(
+      const Fw::Time& timeTag,
+      const bool val
+  )
+{
+  TlmEntry_ChannelBoolOnChange e = { timeTag, val };
+  this->tlmHistory_ChannelBoolOnChange->push_back(e);
   this->tlmSize++;
 }
 
@@ -2776,6 +2802,7 @@ void ActiveTelemetryTesterBase ::
   this->tlmHistory_ChannelF64->clear();
   this->tlmHistory_ChannelU32OnChange->clear();
   this->tlmHistory_ChannelEnumOnChange->clear();
+  this->tlmHistory_ChannelBoolOnChange->clear();
 }
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryTesterBase.ref.hpp
@@ -278,6 +278,12 @@ class ActiveTelemetryTesterBase :
       E arg;
     };
 
+    //! A history entry for telemetry channel ChannelBoolOnChange
+    struct TlmEntry_ChannelBoolOnChange {
+      Fw::Time timeTag;
+      bool arg;
+    };
+
   public:
 
     // ----------------------------------------------------------------------
@@ -1315,6 +1321,12 @@ class ActiveTelemetryTesterBase :
         const E& val //!< The channel value
     );
 
+    //! Handle channel ChannelBoolOnChange
+    void tlmInput_ChannelBoolOnChange(
+        const Fw::Time& timeTag, //!< The time
+        const bool val //!< The channel value
+    );
+
   protected:
 
     // ----------------------------------------------------------------------
@@ -1594,6 +1606,9 @@ class ActiveTelemetryTesterBase :
 
     //! The history of ChannelEnumOnChange values
     History<TlmEntry_ChannelEnumOnChange>* tlmHistory_ChannelEnumOnChange;
+
+    //! The history of ChannelBoolOnChange values
+    History<TlmEntry_ChannelBoolOnChange>* tlmHistory_ChannelBoolOnChange;
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestGTestBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestGTestBase.ref.cpp
@@ -997,6 +997,48 @@ namespace M {
       << "  Actual:   " << _e.arg << "\n";
   }
 
+  void ActiveTestGTestBase ::
+    assertTlm_ChannelBoolOnChange_size(
+        const char* const __callSiteFileName,
+        const U32 __callSiteLineNumber,
+        const U32 size
+    ) const
+  {
+    ASSERT_EQ(this->tlmHistory_ChannelBoolOnChange->size(), size)
+      << "\n"
+      << __callSiteFileName << ":" << __callSiteLineNumber << "\n"
+      << "  Value:    Size of history for telemetry channel ChannelBoolOnChange\n"
+      << "  Expected: " << size << "\n"
+      << "  Actual:   " << this->tlmHistory_ChannelBoolOnChange->size() << "\n";
+  }
+
+  void ActiveTestGTestBase ::
+    assertTlm_ChannelBoolOnChange(
+        const char* const __callSiteFileName,
+        const U32 __callSiteLineNumber,
+        const U32 __index,
+        const bool val
+    ) const
+  {
+    ASSERT_LT(__index, this->tlmHistory_ChannelBoolOnChange->size())
+      << "\n"
+      << __callSiteFileName << ":" << __callSiteLineNumber << "\n"
+      << "  Value:    Index into history of telemetry channel ChannelBoolOnChange\n"
+      << "  Expected: Less than size of history ("
+      << this->tlmHistory_ChannelBoolOnChange->size() << ")\n"
+      << "  Actual:   " << __index << "\n";
+    const TlmEntry_ChannelBoolOnChange& _e =
+      this->tlmHistory_ChannelBoolOnChange->at(__index);
+    ASSERT_EQ(val, _e.arg)
+      << "\n"
+      << __callSiteFileName << ":" << __callSiteLineNumber << "\n"
+      << "  Value:    Value at index "
+      << __index
+      << " on telemetry channel ChannelBoolOnChange\n"
+      << "  Expected: " << val << "\n"
+      << "  Actual:   " << _e.arg << "\n";
+  }
+
   // ----------------------------------------------------------------------
   // Data Product Request
   // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestGTestBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestGTestBase.ref.hpp
@@ -551,6 +551,12 @@
 #define ASSERT_TLM_ChannelEnumOnChange(index, value) \
   this->assertTlm_ChannelEnumOnChange(__FILE__, __LINE__, index, value)
 
+#define ASSERT_TLM_ChannelBoolOnChange_SIZE(size) \
+  this->assertTlm_ChannelBoolOnChange_size(__FILE__, __LINE__, size)
+
+#define ASSERT_TLM_ChannelBoolOnChange(index, value) \
+  this->assertTlm_ChannelBoolOnChange(__FILE__, __LINE__, index, value)
+
 // ----------------------------------------------------------------------
 // Macros for product request assertions
 // ----------------------------------------------------------------------
@@ -967,6 +973,21 @@ namespace M {
           const U32 __callSiteLineNumber, //!< The line number of the call site
           const U32 __index, //!< The index
           const E& val //!< The channel value
+      ) const;
+
+      //! Channel: ChannelBoolOnChange
+      void assertTlm_ChannelBoolOnChange_size(
+          const char* const __callSiteFileName, //!< The name of the file containing the call site
+          const U32 __callSiteLineNumber, //!< The line number of the call site
+          const U32 size //!< The asserted size
+      ) const;
+
+      //! Channel: ChannelBoolOnChange
+      void assertTlm_ChannelBoolOnChange(
+          const char* const __callSiteFileName, //!< The name of the file containing the call site
+          const U32 __callSiteLineNumber, //!< The line number of the call site
+          const U32 __index, //!< The index
+          const bool val //!< The channel value
       ) const;
 
     protected:

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.cpp
@@ -1503,6 +1503,7 @@ namespace M {
     this->tlmHistory_ChannelF64 = new History<TlmEntry_ChannelF64>(maxHistorySize);
     this->tlmHistory_ChannelU32OnChange = new History<TlmEntry_ChannelU32OnChange>(maxHistorySize);
     this->tlmHistory_ChannelEnumOnChange = new History<TlmEntry_ChannelEnumOnChange>(maxHistorySize);
+    this->tlmHistory_ChannelBoolOnChange = new History<TlmEntry_ChannelBoolOnChange>(maxHistorySize);
 
     // Initialize data product histories
     this->productRequestHistory = new History<DpRequest>(maxHistorySize);
@@ -1547,6 +1548,7 @@ namespace M {
     delete this->tlmHistory_ChannelF64;
     delete this->tlmHistory_ChannelU32OnChange;
     delete this->tlmHistory_ChannelEnumOnChange;
+    delete this->tlmHistory_ChannelBoolOnChange;
 
     // Destroy data product histories
     delete this->productRequestHistory;
@@ -3973,6 +3975,19 @@ namespace M {
         break;
       }
 
+      case ActiveTestComponentBase::CHANNELID_CHANNELBOOLONCHANGE: {
+        bool arg;
+        const Fw::SerializeStatus _status = val.deserializeTo(arg);
+
+        if (_status != Fw::FW_SERIALIZE_OK) {
+          printf("Error deserializing ChannelBoolOnChange: %d\n", _status);
+          return;
+        }
+
+        this->tlmInput_ChannelBoolOnChange(timeTag, arg);
+        break;
+      }
+
       default: {
         FW_ASSERT(0, static_cast<FwAssertArgType>(id));
         break;
@@ -4098,6 +4113,17 @@ namespace M {
   {
     TlmEntry_ChannelEnumOnChange e = { timeTag, val };
     this->tlmHistory_ChannelEnumOnChange->push_back(e);
+    this->tlmSize++;
+  }
+
+  void ActiveTestTesterBase ::
+    tlmInput_ChannelBoolOnChange(
+        const Fw::Time& timeTag,
+        const bool val
+    )
+  {
+    TlmEntry_ChannelBoolOnChange e = { timeTag, val };
+    this->tlmHistory_ChannelBoolOnChange->push_back(e);
     this->tlmSize++;
   }
 
@@ -5135,6 +5161,7 @@ namespace M {
     this->tlmHistory_ChannelF64->clear();
     this->tlmHistory_ChannelU32OnChange->clear();
     this->tlmHistory_ChannelEnumOnChange->clear();
+    this->tlmHistory_ChannelBoolOnChange->clear();
   }
 
   // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.hpp
@@ -329,6 +329,12 @@ namespace M {
         E arg;
       };
 
+      //! A history entry for telemetry channel ChannelBoolOnChange
+      struct TlmEntry_ChannelBoolOnChange {
+        Fw::Time timeTag;
+        bool arg;
+      };
+
       //! A type representing a data product request
       struct DpRequest {
         FwDpIdType id;
@@ -1709,6 +1715,12 @@ namespace M {
           const E& val //!< The channel value
       );
 
+      //! Handle channel ChannelBoolOnChange
+      void tlmInput_ChannelBoolOnChange(
+          const Fw::Time& timeTag, //!< The time
+          const bool val //!< The channel value
+      );
+
     protected:
 
       // ----------------------------------------------------------------------
@@ -2375,6 +2387,9 @@ namespace M {
 
       //! The history of ChannelEnumOnChange values
       History<TlmEntry_ChannelEnumOnChange>* tlmHistory_ChannelEnumOnChange;
+
+      //! The history of ChannelBoolOnChange values
+      History<TlmEntry_ChannelBoolOnChange>* tlmHistory_ChannelBoolOnChange;
 
       //! The data product request history
       History<DpRequest>* productRequestHistory;

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialGTestBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialGTestBase.ref.cpp
@@ -994,3 +994,45 @@ void PassiveSerialGTestBase ::
     << "  Expected: " << val << "\n"
     << "  Actual:   " << _e.arg << "\n";
 }
+
+void PassiveSerialGTestBase ::
+  assertTlm_ChannelBoolOnChange_size(
+      const char* const __callSiteFileName,
+      const U32 __callSiteLineNumber,
+      const U32 size
+  ) const
+{
+  ASSERT_EQ(this->tlmHistory_ChannelBoolOnChange->size(), size)
+    << "\n"
+    << __callSiteFileName << ":" << __callSiteLineNumber << "\n"
+    << "  Value:    Size of history for telemetry channel ChannelBoolOnChange\n"
+    << "  Expected: " << size << "\n"
+    << "  Actual:   " << this->tlmHistory_ChannelBoolOnChange->size() << "\n";
+}
+
+void PassiveSerialGTestBase ::
+  assertTlm_ChannelBoolOnChange(
+      const char* const __callSiteFileName,
+      const U32 __callSiteLineNumber,
+      const U32 __index,
+      const bool val
+  ) const
+{
+  ASSERT_LT(__index, this->tlmHistory_ChannelBoolOnChange->size())
+    << "\n"
+    << __callSiteFileName << ":" << __callSiteLineNumber << "\n"
+    << "  Value:    Index into history of telemetry channel ChannelBoolOnChange\n"
+    << "  Expected: Less than size of history ("
+    << this->tlmHistory_ChannelBoolOnChange->size() << ")\n"
+    << "  Actual:   " << __index << "\n";
+  const TlmEntry_ChannelBoolOnChange& _e =
+    this->tlmHistory_ChannelBoolOnChange->at(__index);
+  ASSERT_EQ(val, _e.arg)
+    << "\n"
+    << __callSiteFileName << ":" << __callSiteLineNumber << "\n"
+    << "  Value:    Value at index "
+    << __index
+    << " on telemetry channel ChannelBoolOnChange\n"
+    << "  Expected: " << val << "\n"
+    << "  Actual:   " << _e.arg << "\n";
+}

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialGTestBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialGTestBase.ref.hpp
@@ -551,6 +551,12 @@
 #define ASSERT_TLM_ChannelEnumOnChange(index, value) \
   this->assertTlm_ChannelEnumOnChange(__FILE__, __LINE__, index, value)
 
+#define ASSERT_TLM_ChannelBoolOnChange_SIZE(size) \
+  this->assertTlm_ChannelBoolOnChange_size(__FILE__, __LINE__, size)
+
+#define ASSERT_TLM_ChannelBoolOnChange(index, value) \
+  this->assertTlm_ChannelBoolOnChange(__FILE__, __LINE__, index, value)
+
 //! \class PassiveSerialGTestBase
 //! \brief Auto-generated base for PassiveSerial component Google Test harness
 class PassiveSerialGTestBase :
@@ -945,6 +951,21 @@ class PassiveSerialGTestBase :
         const U32 __callSiteLineNumber, //!< The line number of the call site
         const U32 __index, //!< The index
         const E& val //!< The channel value
+    ) const;
+
+    //! Channel: ChannelBoolOnChange
+    void assertTlm_ChannelBoolOnChange_size(
+        const char* const __callSiteFileName, //!< The name of the file containing the call site
+        const U32 __callSiteLineNumber, //!< The line number of the call site
+        const U32 size //!< The asserted size
+    ) const;
+
+    //! Channel: ChannelBoolOnChange
+    void assertTlm_ChannelBoolOnChange(
+        const char* const __callSiteFileName, //!< The name of the file containing the call site
+        const U32 __callSiteLineNumber, //!< The line number of the call site
+        const U32 __index, //!< The index
+        const bool val //!< The channel value
     ) const;
 
 };

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.cpp
@@ -1301,6 +1301,7 @@ PassiveSerialTesterBase ::
   this->tlmHistory_ChannelF64 = new History<TlmEntry_ChannelF64>(maxHistorySize);
   this->tlmHistory_ChannelU32OnChange = new History<TlmEntry_ChannelU32OnChange>(maxHistorySize);
   this->tlmHistory_ChannelEnumOnChange = new History<TlmEntry_ChannelEnumOnChange>(maxHistorySize);
+  this->tlmHistory_ChannelBoolOnChange = new History<TlmEntry_ChannelBoolOnChange>(maxHistorySize);
 
   // Clear history
   this->clearHistory();
@@ -1341,6 +1342,7 @@ PassiveSerialTesterBase ::
   delete this->tlmHistory_ChannelF64;
   delete this->tlmHistory_ChannelU32OnChange;
   delete this->tlmHistory_ChannelEnumOnChange;
+  delete this->tlmHistory_ChannelBoolOnChange;
 }
 
 // ----------------------------------------------------------------------
@@ -3441,6 +3443,19 @@ void PassiveSerialTesterBase ::
       break;
     }
 
+    case PassiveSerialComponentBase::CHANNELID_CHANNELBOOLONCHANGE: {
+      bool arg;
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
+
+      if (_status != Fw::FW_SERIALIZE_OK) {
+        printf("Error deserializing ChannelBoolOnChange: %d\n", _status);
+        return;
+      }
+
+      this->tlmInput_ChannelBoolOnChange(timeTag, arg);
+      break;
+    }
+
     default: {
       FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
@@ -3566,6 +3581,17 @@ void PassiveSerialTesterBase ::
 {
   TlmEntry_ChannelEnumOnChange e = { timeTag, val };
   this->tlmHistory_ChannelEnumOnChange->push_back(e);
+  this->tlmSize++;
+}
+
+void PassiveSerialTesterBase ::
+  tlmInput_ChannelBoolOnChange(
+      const Fw::Time& timeTag,
+      const bool val
+  )
+{
+  TlmEntry_ChannelBoolOnChange e = { timeTag, val };
+  this->tlmHistory_ChannelBoolOnChange->push_back(e);
   this->tlmSize++;
 }
 
@@ -4547,6 +4573,7 @@ void PassiveSerialTesterBase ::
   this->tlmHistory_ChannelF64->clear();
   this->tlmHistory_ChannelU32OnChange->clear();
   this->tlmHistory_ChannelEnumOnChange->clear();
+  this->tlmHistory_ChannelBoolOnChange->clear();
 }
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.hpp
@@ -326,6 +326,12 @@ class PassiveSerialTesterBase :
       E arg;
     };
 
+    //! A history entry for telemetry channel ChannelBoolOnChange
+    struct TlmEntry_ChannelBoolOnChange {
+      Fw::Time timeTag;
+      bool arg;
+    };
+
     //! External Parameter Delegate
     class PassiveSerialComponentBaseParamExternalDelegate :
       public Fw::ParamExternalDelegate
@@ -1526,6 +1532,12 @@ class PassiveSerialTesterBase :
         const E& val //!< The channel value
     );
 
+    //! Handle channel ChannelBoolOnChange
+    void tlmInput_ChannelBoolOnChange(
+        const Fw::Time& timeTag, //!< The time
+        const bool val //!< The channel value
+    );
+
   protected:
 
     // ----------------------------------------------------------------------
@@ -2124,6 +2136,9 @@ class PassiveSerialTesterBase :
 
     //! The history of ChannelEnumOnChange values
     History<TlmEntry_ChannelEnumOnChange>* tlmHistory_ChannelEnumOnChange;
+
+    //! The history of ChannelBoolOnChange values
+    History<TlmEntry_ChannelBoolOnChange>* tlmHistory_ChannelBoolOnChange;
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryGTestBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryGTestBase.ref.cpp
@@ -645,3 +645,45 @@ void PassiveTelemetryGTestBase ::
     << "  Expected: " << val << "\n"
     << "  Actual:   " << _e.arg << "\n";
 }
+
+void PassiveTelemetryGTestBase ::
+  assertTlm_ChannelBoolOnChange_size(
+      const char* const __callSiteFileName,
+      const U32 __callSiteLineNumber,
+      const U32 size
+  ) const
+{
+  ASSERT_EQ(this->tlmHistory_ChannelBoolOnChange->size(), size)
+    << "\n"
+    << __callSiteFileName << ":" << __callSiteLineNumber << "\n"
+    << "  Value:    Size of history for telemetry channel ChannelBoolOnChange\n"
+    << "  Expected: " << size << "\n"
+    << "  Actual:   " << this->tlmHistory_ChannelBoolOnChange->size() << "\n";
+}
+
+void PassiveTelemetryGTestBase ::
+  assertTlm_ChannelBoolOnChange(
+      const char* const __callSiteFileName,
+      const U32 __callSiteLineNumber,
+      const U32 __index,
+      const bool val
+  ) const
+{
+  ASSERT_LT(__index, this->tlmHistory_ChannelBoolOnChange->size())
+    << "\n"
+    << __callSiteFileName << ":" << __callSiteLineNumber << "\n"
+    << "  Value:    Index into history of telemetry channel ChannelBoolOnChange\n"
+    << "  Expected: Less than size of history ("
+    << this->tlmHistory_ChannelBoolOnChange->size() << ")\n"
+    << "  Actual:   " << __index << "\n";
+  const TlmEntry_ChannelBoolOnChange& _e =
+    this->tlmHistory_ChannelBoolOnChange->at(__index);
+  ASSERT_EQ(val, _e.arg)
+    << "\n"
+    << __callSiteFileName << ":" << __callSiteLineNumber << "\n"
+    << "  Value:    Value at index "
+    << __index
+    << " on telemetry channel ChannelBoolOnChange\n"
+    << "  Expected: " << val << "\n"
+    << "  Actual:   " << _e.arg << "\n";
+}

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryGTestBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryGTestBase.ref.hpp
@@ -498,6 +498,12 @@
 #define ASSERT_TLM_ChannelEnumOnChange(index, value) \
   this->assertTlm_ChannelEnumOnChange(__FILE__, __LINE__, index, value)
 
+#define ASSERT_TLM_ChannelBoolOnChange_SIZE(size) \
+  this->assertTlm_ChannelBoolOnChange_size(__FILE__, __LINE__, size)
+
+#define ASSERT_TLM_ChannelBoolOnChange(index, value) \
+  this->assertTlm_ChannelBoolOnChange(__FILE__, __LINE__, index, value)
+
 //! \class PassiveTelemetryGTestBase
 //! \brief Auto-generated base for PassiveTelemetry component Google Test harness
 class PassiveTelemetryGTestBase :
@@ -764,6 +770,21 @@ class PassiveTelemetryGTestBase :
         const U32 __callSiteLineNumber, //!< The line number of the call site
         const U32 __index, //!< The index
         const E& val //!< The channel value
+    ) const;
+
+    //! Channel: ChannelBoolOnChange
+    void assertTlm_ChannelBoolOnChange_size(
+        const char* const __callSiteFileName, //!< The name of the file containing the call site
+        const U32 __callSiteLineNumber, //!< The line number of the call site
+        const U32 size //!< The asserted size
+    ) const;
+
+    //! Channel: ChannelBoolOnChange
+    void assertTlm_ChannelBoolOnChange(
+        const char* const __callSiteFileName, //!< The name of the file containing the call site
+        const U32 __callSiteLineNumber, //!< The line number of the call site
+        const U32 __index, //!< The index
+        const bool val //!< The channel value
     ) const;
 
 };

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryTesterBase.ref.cpp
@@ -921,6 +921,7 @@ PassiveTelemetryTesterBase ::
   this->tlmHistory_ChannelF64 = new History<TlmEntry_ChannelF64>(maxHistorySize);
   this->tlmHistory_ChannelU32OnChange = new History<TlmEntry_ChannelU32OnChange>(maxHistorySize);
   this->tlmHistory_ChannelEnumOnChange = new History<TlmEntry_ChannelEnumOnChange>(maxHistorySize);
+  this->tlmHistory_ChannelBoolOnChange = new History<TlmEntry_ChannelBoolOnChange>(maxHistorySize);
 
   // Clear history
   this->clearHistory();
@@ -948,6 +949,7 @@ PassiveTelemetryTesterBase ::
   delete this->tlmHistory_ChannelF64;
   delete this->tlmHistory_ChannelU32OnChange;
   delete this->tlmHistory_ChannelEnumOnChange;
+  delete this->tlmHistory_ChannelBoolOnChange;
 }
 
 // ----------------------------------------------------------------------
@@ -2011,6 +2013,19 @@ void PassiveTelemetryTesterBase ::
       break;
     }
 
+    case PassiveTelemetryComponentBase::CHANNELID_CHANNELBOOLONCHANGE: {
+      bool arg;
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
+
+      if (_status != Fw::FW_SERIALIZE_OK) {
+        printf("Error deserializing ChannelBoolOnChange: %d\n", _status);
+        return;
+      }
+
+      this->tlmInput_ChannelBoolOnChange(timeTag, arg);
+      break;
+    }
+
     default: {
       FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
@@ -2136,6 +2151,17 @@ void PassiveTelemetryTesterBase ::
 {
   TlmEntry_ChannelEnumOnChange e = { timeTag, val };
   this->tlmHistory_ChannelEnumOnChange->push_back(e);
+  this->tlmSize++;
+}
+
+void PassiveTelemetryTesterBase ::
+  tlmInput_ChannelBoolOnChange(
+      const Fw::Time& timeTag,
+      const bool val
+  )
+{
+  TlmEntry_ChannelBoolOnChange e = { timeTag, val };
+  this->tlmHistory_ChannelBoolOnChange->push_back(e);
   this->tlmSize++;
 }
 
@@ -2325,6 +2351,7 @@ void PassiveTelemetryTesterBase ::
   this->tlmHistory_ChannelF64->clear();
   this->tlmHistory_ChannelU32OnChange->clear();
   this->tlmHistory_ChannelEnumOnChange->clear();
+  this->tlmHistory_ChannelBoolOnChange->clear();
 }
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryTesterBase.ref.hpp
@@ -278,6 +278,12 @@ class PassiveTelemetryTesterBase :
       E arg;
     };
 
+    //! A history entry for telemetry channel ChannelBoolOnChange
+    struct TlmEntry_ChannelBoolOnChange {
+      Fw::Time timeTag;
+      bool arg;
+    };
+
   public:
 
     // ----------------------------------------------------------------------
@@ -1142,6 +1148,12 @@ class PassiveTelemetryTesterBase :
         const E& val //!< The channel value
     );
 
+    //! Handle channel ChannelBoolOnChange
+    void tlmInput_ChannelBoolOnChange(
+        const Fw::Time& timeTag, //!< The time
+        const bool val //!< The channel value
+    );
+
   protected:
 
     // ----------------------------------------------------------------------
@@ -1405,6 +1417,9 @@ class PassiveTelemetryTesterBase :
 
     //! The history of ChannelEnumOnChange values
     History<TlmEntry_ChannelEnumOnChange>* tlmHistory_ChannelEnumOnChange;
+
+    //! The history of ChannelBoolOnChange values
+    History<TlmEntry_ChannelBoolOnChange>* tlmHistory_ChannelBoolOnChange;
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestGTestBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestGTestBase.ref.cpp
@@ -995,6 +995,48 @@ void PassiveTestGTestBase ::
     << "  Actual:   " << _e.arg << "\n";
 }
 
+void PassiveTestGTestBase ::
+  assertTlm_ChannelBoolOnChange_size(
+      const char* const __callSiteFileName,
+      const U32 __callSiteLineNumber,
+      const U32 size
+  ) const
+{
+  ASSERT_EQ(this->tlmHistory_ChannelBoolOnChange->size(), size)
+    << "\n"
+    << __callSiteFileName << ":" << __callSiteLineNumber << "\n"
+    << "  Value:    Size of history for telemetry channel ChannelBoolOnChange\n"
+    << "  Expected: " << size << "\n"
+    << "  Actual:   " << this->tlmHistory_ChannelBoolOnChange->size() << "\n";
+}
+
+void PassiveTestGTestBase ::
+  assertTlm_ChannelBoolOnChange(
+      const char* const __callSiteFileName,
+      const U32 __callSiteLineNumber,
+      const U32 __index,
+      const bool val
+  ) const
+{
+  ASSERT_LT(__index, this->tlmHistory_ChannelBoolOnChange->size())
+    << "\n"
+    << __callSiteFileName << ":" << __callSiteLineNumber << "\n"
+    << "  Value:    Index into history of telemetry channel ChannelBoolOnChange\n"
+    << "  Expected: Less than size of history ("
+    << this->tlmHistory_ChannelBoolOnChange->size() << ")\n"
+    << "  Actual:   " << __index << "\n";
+  const TlmEntry_ChannelBoolOnChange& _e =
+    this->tlmHistory_ChannelBoolOnChange->at(__index);
+  ASSERT_EQ(val, _e.arg)
+    << "\n"
+    << __callSiteFileName << ":" << __callSiteLineNumber << "\n"
+    << "  Value:    Value at index "
+    << __index
+    << " on telemetry channel ChannelBoolOnChange\n"
+    << "  Expected: " << val << "\n"
+    << "  Actual:   " << _e.arg << "\n";
+}
+
 // ----------------------------------------------------------------------
 // Data Product Request
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestGTestBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestGTestBase.ref.hpp
@@ -551,6 +551,12 @@
 #define ASSERT_TLM_ChannelEnumOnChange(index, value) \
   this->assertTlm_ChannelEnumOnChange(__FILE__, __LINE__, index, value)
 
+#define ASSERT_TLM_ChannelBoolOnChange_SIZE(size) \
+  this->assertTlm_ChannelBoolOnChange_size(__FILE__, __LINE__, size)
+
+#define ASSERT_TLM_ChannelBoolOnChange(index, value) \
+  this->assertTlm_ChannelBoolOnChange(__FILE__, __LINE__, index, value)
+
 // ----------------------------------------------------------------------
 // Macros for product request assertions
 // ----------------------------------------------------------------------
@@ -965,6 +971,21 @@ class PassiveTestGTestBase :
         const U32 __callSiteLineNumber, //!< The line number of the call site
         const U32 __index, //!< The index
         const E& val //!< The channel value
+    ) const;
+
+    //! Channel: ChannelBoolOnChange
+    void assertTlm_ChannelBoolOnChange_size(
+        const char* const __callSiteFileName, //!< The name of the file containing the call site
+        const U32 __callSiteLineNumber, //!< The line number of the call site
+        const U32 size //!< The asserted size
+    ) const;
+
+    //! Channel: ChannelBoolOnChange
+    void assertTlm_ChannelBoolOnChange(
+        const char* const __callSiteFileName, //!< The name of the file containing the call site
+        const U32 __callSiteLineNumber, //!< The line number of the call site
+        const U32 __index, //!< The index
+        const bool val //!< The channel value
     ) const;
 
   protected:

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.cpp
@@ -1303,6 +1303,7 @@ PassiveTestTesterBase ::
   this->tlmHistory_ChannelF64 = new History<TlmEntry_ChannelF64>(maxHistorySize);
   this->tlmHistory_ChannelU32OnChange = new History<TlmEntry_ChannelU32OnChange>(maxHistorySize);
   this->tlmHistory_ChannelEnumOnChange = new History<TlmEntry_ChannelEnumOnChange>(maxHistorySize);
+  this->tlmHistory_ChannelBoolOnChange = new History<TlmEntry_ChannelBoolOnChange>(maxHistorySize);
 
   // Initialize data product histories
   this->productRequestHistory = new History<DpRequest>(maxHistorySize);
@@ -1347,6 +1348,7 @@ PassiveTestTesterBase ::
   delete this->tlmHistory_ChannelF64;
   delete this->tlmHistory_ChannelU32OnChange;
   delete this->tlmHistory_ChannelEnumOnChange;
+  delete this->tlmHistory_ChannelBoolOnChange;
 
   // Destroy data product histories
   delete this->productRequestHistory;
@@ -3377,6 +3379,19 @@ void PassiveTestTesterBase ::
       break;
     }
 
+    case PassiveTestComponentBase::CHANNELID_CHANNELBOOLONCHANGE: {
+      bool arg;
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
+
+      if (_status != Fw::FW_SERIALIZE_OK) {
+        printf("Error deserializing ChannelBoolOnChange: %d\n", _status);
+        return;
+      }
+
+      this->tlmInput_ChannelBoolOnChange(timeTag, arg);
+      break;
+    }
+
     default: {
       FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
@@ -3502,6 +3517,17 @@ void PassiveTestTesterBase ::
 {
   TlmEntry_ChannelEnumOnChange e = { timeTag, val };
   this->tlmHistory_ChannelEnumOnChange->push_back(e);
+  this->tlmSize++;
+}
+
+void PassiveTestTesterBase ::
+  tlmInput_ChannelBoolOnChange(
+      const Fw::Time& timeTag,
+      const bool val
+  )
+{
+  TlmEntry_ChannelBoolOnChange e = { timeTag, val };
+  this->tlmHistory_ChannelBoolOnChange->push_back(e);
   this->tlmSize++;
 }
 
@@ -4539,6 +4565,7 @@ void PassiveTestTesterBase ::
   this->tlmHistory_ChannelF64->clear();
   this->tlmHistory_ChannelU32OnChange->clear();
   this->tlmHistory_ChannelEnumOnChange->clear();
+  this->tlmHistory_ChannelBoolOnChange->clear();
 }
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.hpp
@@ -327,6 +327,12 @@ class PassiveTestTesterBase :
       E arg;
     };
 
+    //! A history entry for telemetry channel ChannelBoolOnChange
+    struct TlmEntry_ChannelBoolOnChange {
+      Fw::Time timeTag;
+      bool arg;
+    };
+
     //! A type representing a data product request
     struct DpRequest {
       FwDpIdType id;
@@ -1502,6 +1508,12 @@ class PassiveTestTesterBase :
         const E& val //!< The channel value
     );
 
+    //! Handle channel ChannelBoolOnChange
+    void tlmInput_ChannelBoolOnChange(
+        const Fw::Time& timeTag, //!< The time
+        const bool val //!< The channel value
+    );
+
   protected:
 
     // ----------------------------------------------------------------------
@@ -2152,6 +2164,9 @@ class PassiveTestTesterBase :
 
     //! The history of ChannelEnumOnChange values
     History<TlmEntry_ChannelEnumOnChange>* tlmHistory_ChannelEnumOnChange;
+
+    //! The history of ChannelBoolOnChange values
+    History<TlmEntry_ChannelBoolOnChange>* tlmHistory_ChannelBoolOnChange;
 
     //! The data product request history
     History<DpRequest>* productRequestHistory;

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialGTestBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialGTestBase.ref.cpp
@@ -994,3 +994,45 @@ void QueuedSerialGTestBase ::
     << "  Expected: " << val << "\n"
     << "  Actual:   " << _e.arg << "\n";
 }
+
+void QueuedSerialGTestBase ::
+  assertTlm_ChannelBoolOnChange_size(
+      const char* const __callSiteFileName,
+      const U32 __callSiteLineNumber,
+      const U32 size
+  ) const
+{
+  ASSERT_EQ(this->tlmHistory_ChannelBoolOnChange->size(), size)
+    << "\n"
+    << __callSiteFileName << ":" << __callSiteLineNumber << "\n"
+    << "  Value:    Size of history for telemetry channel ChannelBoolOnChange\n"
+    << "  Expected: " << size << "\n"
+    << "  Actual:   " << this->tlmHistory_ChannelBoolOnChange->size() << "\n";
+}
+
+void QueuedSerialGTestBase ::
+  assertTlm_ChannelBoolOnChange(
+      const char* const __callSiteFileName,
+      const U32 __callSiteLineNumber,
+      const U32 __index,
+      const bool val
+  ) const
+{
+  ASSERT_LT(__index, this->tlmHistory_ChannelBoolOnChange->size())
+    << "\n"
+    << __callSiteFileName << ":" << __callSiteLineNumber << "\n"
+    << "  Value:    Index into history of telemetry channel ChannelBoolOnChange\n"
+    << "  Expected: Less than size of history ("
+    << this->tlmHistory_ChannelBoolOnChange->size() << ")\n"
+    << "  Actual:   " << __index << "\n";
+  const TlmEntry_ChannelBoolOnChange& _e =
+    this->tlmHistory_ChannelBoolOnChange->at(__index);
+  ASSERT_EQ(val, _e.arg)
+    << "\n"
+    << __callSiteFileName << ":" << __callSiteLineNumber << "\n"
+    << "  Value:    Value at index "
+    << __index
+    << " on telemetry channel ChannelBoolOnChange\n"
+    << "  Expected: " << val << "\n"
+    << "  Actual:   " << _e.arg << "\n";
+}

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialGTestBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialGTestBase.ref.hpp
@@ -551,6 +551,12 @@
 #define ASSERT_TLM_ChannelEnumOnChange(index, value) \
   this->assertTlm_ChannelEnumOnChange(__FILE__, __LINE__, index, value)
 
+#define ASSERT_TLM_ChannelBoolOnChange_SIZE(size) \
+  this->assertTlm_ChannelBoolOnChange_size(__FILE__, __LINE__, size)
+
+#define ASSERT_TLM_ChannelBoolOnChange(index, value) \
+  this->assertTlm_ChannelBoolOnChange(__FILE__, __LINE__, index, value)
+
 //! \class QueuedSerialGTestBase
 //! \brief Auto-generated base for QueuedSerial component Google Test harness
 class QueuedSerialGTestBase :
@@ -945,6 +951,21 @@ class QueuedSerialGTestBase :
         const U32 __callSiteLineNumber, //!< The line number of the call site
         const U32 __index, //!< The index
         const E& val //!< The channel value
+    ) const;
+
+    //! Channel: ChannelBoolOnChange
+    void assertTlm_ChannelBoolOnChange_size(
+        const char* const __callSiteFileName, //!< The name of the file containing the call site
+        const U32 __callSiteLineNumber, //!< The line number of the call site
+        const U32 size //!< The asserted size
+    ) const;
+
+    //! Channel: ChannelBoolOnChange
+    void assertTlm_ChannelBoolOnChange(
+        const char* const __callSiteFileName, //!< The name of the file containing the call site
+        const U32 __callSiteLineNumber, //!< The line number of the call site
+        const U32 __index, //!< The index
+        const bool val //!< The channel value
     ) const;
 
 };

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.cpp
@@ -1631,6 +1631,7 @@ QueuedSerialTesterBase ::
   this->tlmHistory_ChannelF64 = new History<TlmEntry_ChannelF64>(maxHistorySize);
   this->tlmHistory_ChannelU32OnChange = new History<TlmEntry_ChannelU32OnChange>(maxHistorySize);
   this->tlmHistory_ChannelEnumOnChange = new History<TlmEntry_ChannelEnumOnChange>(maxHistorySize);
+  this->tlmHistory_ChannelBoolOnChange = new History<TlmEntry_ChannelBoolOnChange>(maxHistorySize);
 
   // Clear history
   this->clearHistory();
@@ -1671,6 +1672,7 @@ QueuedSerialTesterBase ::
   delete this->tlmHistory_ChannelF64;
   delete this->tlmHistory_ChannelU32OnChange;
   delete this->tlmHistory_ChannelEnumOnChange;
+  delete this->tlmHistory_ChannelBoolOnChange;
 }
 
 // ----------------------------------------------------------------------
@@ -4299,6 +4301,19 @@ void QueuedSerialTesterBase ::
       break;
     }
 
+    case QueuedSerialComponentBase::CHANNELID_CHANNELBOOLONCHANGE: {
+      bool arg;
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
+
+      if (_status != Fw::FW_SERIALIZE_OK) {
+        printf("Error deserializing ChannelBoolOnChange: %d\n", _status);
+        return;
+      }
+
+      this->tlmInput_ChannelBoolOnChange(timeTag, arg);
+      break;
+    }
+
     default: {
       FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
@@ -4424,6 +4439,17 @@ void QueuedSerialTesterBase ::
 {
   TlmEntry_ChannelEnumOnChange e = { timeTag, val };
   this->tlmHistory_ChannelEnumOnChange->push_back(e);
+  this->tlmSize++;
+}
+
+void QueuedSerialTesterBase ::
+  tlmInput_ChannelBoolOnChange(
+      const Fw::Time& timeTag,
+      const bool val
+  )
+{
+  TlmEntry_ChannelBoolOnChange e = { timeTag, val };
+  this->tlmHistory_ChannelBoolOnChange->push_back(e);
   this->tlmSize++;
 }
 
@@ -5405,6 +5431,7 @@ void QueuedSerialTesterBase ::
   this->tlmHistory_ChannelF64->clear();
   this->tlmHistory_ChannelU32OnChange->clear();
   this->tlmHistory_ChannelEnumOnChange->clear();
+  this->tlmHistory_ChannelBoolOnChange->clear();
 }
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.hpp
@@ -326,6 +326,12 @@ class QueuedSerialTesterBase :
       E arg;
     };
 
+    //! A history entry for telemetry channel ChannelBoolOnChange
+    struct TlmEntry_ChannelBoolOnChange {
+      Fw::Time timeTag;
+      bool arg;
+    };
+
     //! External Parameter Delegate
     class QueuedSerialComponentBaseParamExternalDelegate :
       public Fw::ParamExternalDelegate
@@ -1827,6 +1833,12 @@ class QueuedSerialTesterBase :
         const E& val //!< The channel value
     );
 
+    //! Handle channel ChannelBoolOnChange
+    void tlmInput_ChannelBoolOnChange(
+        const Fw::Time& timeTag, //!< The time
+        const bool val //!< The channel value
+    );
+
   protected:
 
     // ----------------------------------------------------------------------
@@ -2425,6 +2437,9 @@ class QueuedSerialTesterBase :
 
     //! The history of ChannelEnumOnChange values
     History<TlmEntry_ChannelEnumOnChange>* tlmHistory_ChannelEnumOnChange;
+
+    //! The history of ChannelBoolOnChange values
+    History<TlmEntry_ChannelBoolOnChange>* tlmHistory_ChannelBoolOnChange;
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryGTestBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryGTestBase.ref.cpp
@@ -645,3 +645,45 @@ void QueuedTelemetryGTestBase ::
     << "  Expected: " << val << "\n"
     << "  Actual:   " << _e.arg << "\n";
 }
+
+void QueuedTelemetryGTestBase ::
+  assertTlm_ChannelBoolOnChange_size(
+      const char* const __callSiteFileName,
+      const U32 __callSiteLineNumber,
+      const U32 size
+  ) const
+{
+  ASSERT_EQ(this->tlmHistory_ChannelBoolOnChange->size(), size)
+    << "\n"
+    << __callSiteFileName << ":" << __callSiteLineNumber << "\n"
+    << "  Value:    Size of history for telemetry channel ChannelBoolOnChange\n"
+    << "  Expected: " << size << "\n"
+    << "  Actual:   " << this->tlmHistory_ChannelBoolOnChange->size() << "\n";
+}
+
+void QueuedTelemetryGTestBase ::
+  assertTlm_ChannelBoolOnChange(
+      const char* const __callSiteFileName,
+      const U32 __callSiteLineNumber,
+      const U32 __index,
+      const bool val
+  ) const
+{
+  ASSERT_LT(__index, this->tlmHistory_ChannelBoolOnChange->size())
+    << "\n"
+    << __callSiteFileName << ":" << __callSiteLineNumber << "\n"
+    << "  Value:    Index into history of telemetry channel ChannelBoolOnChange\n"
+    << "  Expected: Less than size of history ("
+    << this->tlmHistory_ChannelBoolOnChange->size() << ")\n"
+    << "  Actual:   " << __index << "\n";
+  const TlmEntry_ChannelBoolOnChange& _e =
+    this->tlmHistory_ChannelBoolOnChange->at(__index);
+  ASSERT_EQ(val, _e.arg)
+    << "\n"
+    << __callSiteFileName << ":" << __callSiteLineNumber << "\n"
+    << "  Value:    Value at index "
+    << __index
+    << " on telemetry channel ChannelBoolOnChange\n"
+    << "  Expected: " << val << "\n"
+    << "  Actual:   " << _e.arg << "\n";
+}

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryGTestBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryGTestBase.ref.hpp
@@ -498,6 +498,12 @@
 #define ASSERT_TLM_ChannelEnumOnChange(index, value) \
   this->assertTlm_ChannelEnumOnChange(__FILE__, __LINE__, index, value)
 
+#define ASSERT_TLM_ChannelBoolOnChange_SIZE(size) \
+  this->assertTlm_ChannelBoolOnChange_size(__FILE__, __LINE__, size)
+
+#define ASSERT_TLM_ChannelBoolOnChange(index, value) \
+  this->assertTlm_ChannelBoolOnChange(__FILE__, __LINE__, index, value)
+
 //! \class QueuedTelemetryGTestBase
 //! \brief Auto-generated base for QueuedTelemetry component Google Test harness
 class QueuedTelemetryGTestBase :
@@ -764,6 +770,21 @@ class QueuedTelemetryGTestBase :
         const U32 __callSiteLineNumber, //!< The line number of the call site
         const U32 __index, //!< The index
         const E& val //!< The channel value
+    ) const;
+
+    //! Channel: ChannelBoolOnChange
+    void assertTlm_ChannelBoolOnChange_size(
+        const char* const __callSiteFileName, //!< The name of the file containing the call site
+        const U32 __callSiteLineNumber, //!< The line number of the call site
+        const U32 size //!< The asserted size
+    ) const;
+
+    //! Channel: ChannelBoolOnChange
+    void assertTlm_ChannelBoolOnChange(
+        const char* const __callSiteFileName, //!< The name of the file containing the call site
+        const U32 __callSiteLineNumber, //!< The line number of the call site
+        const U32 __index, //!< The index
+        const bool val //!< The channel value
     ) const;
 
 };

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryTesterBase.ref.cpp
@@ -1119,6 +1119,7 @@ QueuedTelemetryTesterBase ::
   this->tlmHistory_ChannelF64 = new History<TlmEntry_ChannelF64>(maxHistorySize);
   this->tlmHistory_ChannelU32OnChange = new History<TlmEntry_ChannelU32OnChange>(maxHistorySize);
   this->tlmHistory_ChannelEnumOnChange = new History<TlmEntry_ChannelEnumOnChange>(maxHistorySize);
+  this->tlmHistory_ChannelBoolOnChange = new History<TlmEntry_ChannelBoolOnChange>(maxHistorySize);
 
   // Clear history
   this->clearHistory();
@@ -1146,6 +1147,7 @@ QueuedTelemetryTesterBase ::
   delete this->tlmHistory_ChannelF64;
   delete this->tlmHistory_ChannelU32OnChange;
   delete this->tlmHistory_ChannelEnumOnChange;
+  delete this->tlmHistory_ChannelBoolOnChange;
 }
 
 // ----------------------------------------------------------------------
@@ -2462,6 +2464,19 @@ void QueuedTelemetryTesterBase ::
       break;
     }
 
+    case QueuedTelemetryComponentBase::CHANNELID_CHANNELBOOLONCHANGE: {
+      bool arg;
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
+
+      if (_status != Fw::FW_SERIALIZE_OK) {
+        printf("Error deserializing ChannelBoolOnChange: %d\n", _status);
+        return;
+      }
+
+      this->tlmInput_ChannelBoolOnChange(timeTag, arg);
+      break;
+    }
+
     default: {
       FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
@@ -2587,6 +2602,17 @@ void QueuedTelemetryTesterBase ::
 {
   TlmEntry_ChannelEnumOnChange e = { timeTag, val };
   this->tlmHistory_ChannelEnumOnChange->push_back(e);
+  this->tlmSize++;
+}
+
+void QueuedTelemetryTesterBase ::
+  tlmInput_ChannelBoolOnChange(
+      const Fw::Time& timeTag,
+      const bool val
+  )
+{
+  TlmEntry_ChannelBoolOnChange e = { timeTag, val };
+  this->tlmHistory_ChannelBoolOnChange->push_back(e);
   this->tlmSize++;
 }
 
@@ -2776,6 +2802,7 @@ void QueuedTelemetryTesterBase ::
   this->tlmHistory_ChannelF64->clear();
   this->tlmHistory_ChannelU32OnChange->clear();
   this->tlmHistory_ChannelEnumOnChange->clear();
+  this->tlmHistory_ChannelBoolOnChange->clear();
 }
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryTesterBase.ref.hpp
@@ -278,6 +278,12 @@ class QueuedTelemetryTesterBase :
       E arg;
     };
 
+    //! A history entry for telemetry channel ChannelBoolOnChange
+    struct TlmEntry_ChannelBoolOnChange {
+      Fw::Time timeTag;
+      bool arg;
+    };
+
   public:
 
     // ----------------------------------------------------------------------
@@ -1315,6 +1321,12 @@ class QueuedTelemetryTesterBase :
         const E& val //!< The channel value
     );
 
+    //! Handle channel ChannelBoolOnChange
+    void tlmInput_ChannelBoolOnChange(
+        const Fw::Time& timeTag, //!< The time
+        const bool val //!< The channel value
+    );
+
   protected:
 
     // ----------------------------------------------------------------------
@@ -1578,6 +1590,9 @@ class QueuedTelemetryTesterBase :
 
     //! The history of ChannelEnumOnChange values
     History<TlmEntry_ChannelEnumOnChange>* tlmHistory_ChannelEnumOnChange;
+
+    //! The history of ChannelBoolOnChange values
+    History<TlmEntry_ChannelBoolOnChange>* tlmHistory_ChannelBoolOnChange;
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestGTestBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestGTestBase.ref.cpp
@@ -995,6 +995,48 @@ void QueuedTestGTestBase ::
     << "  Actual:   " << _e.arg << "\n";
 }
 
+void QueuedTestGTestBase ::
+  assertTlm_ChannelBoolOnChange_size(
+      const char* const __callSiteFileName,
+      const U32 __callSiteLineNumber,
+      const U32 size
+  ) const
+{
+  ASSERT_EQ(this->tlmHistory_ChannelBoolOnChange->size(), size)
+    << "\n"
+    << __callSiteFileName << ":" << __callSiteLineNumber << "\n"
+    << "  Value:    Size of history for telemetry channel ChannelBoolOnChange\n"
+    << "  Expected: " << size << "\n"
+    << "  Actual:   " << this->tlmHistory_ChannelBoolOnChange->size() << "\n";
+}
+
+void QueuedTestGTestBase ::
+  assertTlm_ChannelBoolOnChange(
+      const char* const __callSiteFileName,
+      const U32 __callSiteLineNumber,
+      const U32 __index,
+      const bool val
+  ) const
+{
+  ASSERT_LT(__index, this->tlmHistory_ChannelBoolOnChange->size())
+    << "\n"
+    << __callSiteFileName << ":" << __callSiteLineNumber << "\n"
+    << "  Value:    Index into history of telemetry channel ChannelBoolOnChange\n"
+    << "  Expected: Less than size of history ("
+    << this->tlmHistory_ChannelBoolOnChange->size() << ")\n"
+    << "  Actual:   " << __index << "\n";
+  const TlmEntry_ChannelBoolOnChange& _e =
+    this->tlmHistory_ChannelBoolOnChange->at(__index);
+  ASSERT_EQ(val, _e.arg)
+    << "\n"
+    << __callSiteFileName << ":" << __callSiteLineNumber << "\n"
+    << "  Value:    Value at index "
+    << __index
+    << " on telemetry channel ChannelBoolOnChange\n"
+    << "  Expected: " << val << "\n"
+    << "  Actual:   " << _e.arg << "\n";
+}
+
 // ----------------------------------------------------------------------
 // Data Product Request
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestGTestBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestGTestBase.ref.hpp
@@ -551,6 +551,12 @@
 #define ASSERT_TLM_ChannelEnumOnChange(index, value) \
   this->assertTlm_ChannelEnumOnChange(__FILE__, __LINE__, index, value)
 
+#define ASSERT_TLM_ChannelBoolOnChange_SIZE(size) \
+  this->assertTlm_ChannelBoolOnChange_size(__FILE__, __LINE__, size)
+
+#define ASSERT_TLM_ChannelBoolOnChange(index, value) \
+  this->assertTlm_ChannelBoolOnChange(__FILE__, __LINE__, index, value)
+
 // ----------------------------------------------------------------------
 // Macros for product request assertions
 // ----------------------------------------------------------------------
@@ -965,6 +971,21 @@ class QueuedTestGTestBase :
         const U32 __callSiteLineNumber, //!< The line number of the call site
         const U32 __index, //!< The index
         const E& val //!< The channel value
+    ) const;
+
+    //! Channel: ChannelBoolOnChange
+    void assertTlm_ChannelBoolOnChange_size(
+        const char* const __callSiteFileName, //!< The name of the file containing the call site
+        const U32 __callSiteLineNumber, //!< The line number of the call site
+        const U32 size //!< The asserted size
+    ) const;
+
+    //! Channel: ChannelBoolOnChange
+    void assertTlm_ChannelBoolOnChange(
+        const char* const __callSiteFileName, //!< The name of the file containing the call site
+        const U32 __callSiteLineNumber, //!< The line number of the call site
+        const U32 __index, //!< The index
+        const bool val //!< The channel value
     ) const;
 
   protected:

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.cpp
@@ -1501,6 +1501,7 @@ QueuedTestTesterBase ::
   this->tlmHistory_ChannelF64 = new History<TlmEntry_ChannelF64>(maxHistorySize);
   this->tlmHistory_ChannelU32OnChange = new History<TlmEntry_ChannelU32OnChange>(maxHistorySize);
   this->tlmHistory_ChannelEnumOnChange = new History<TlmEntry_ChannelEnumOnChange>(maxHistorySize);
+  this->tlmHistory_ChannelBoolOnChange = new History<TlmEntry_ChannelBoolOnChange>(maxHistorySize);
 
   // Initialize data product histories
   this->productRequestHistory = new History<DpRequest>(maxHistorySize);
@@ -1545,6 +1546,7 @@ QueuedTestTesterBase ::
   delete this->tlmHistory_ChannelF64;
   delete this->tlmHistory_ChannelU32OnChange;
   delete this->tlmHistory_ChannelEnumOnChange;
+  delete this->tlmHistory_ChannelBoolOnChange;
 
   // Destroy data product histories
   delete this->productRequestHistory;
@@ -3971,6 +3973,19 @@ void QueuedTestTesterBase ::
       break;
     }
 
+    case QueuedTestComponentBase::CHANNELID_CHANNELBOOLONCHANGE: {
+      bool arg;
+      const Fw::SerializeStatus _status = val.deserializeTo(arg);
+
+      if (_status != Fw::FW_SERIALIZE_OK) {
+        printf("Error deserializing ChannelBoolOnChange: %d\n", _status);
+        return;
+      }
+
+      this->tlmInput_ChannelBoolOnChange(timeTag, arg);
+      break;
+    }
+
     default: {
       FW_ASSERT(0, static_cast<FwAssertArgType>(id));
       break;
@@ -4096,6 +4111,17 @@ void QueuedTestTesterBase ::
 {
   TlmEntry_ChannelEnumOnChange e = { timeTag, val };
   this->tlmHistory_ChannelEnumOnChange->push_back(e);
+  this->tlmSize++;
+}
+
+void QueuedTestTesterBase ::
+  tlmInput_ChannelBoolOnChange(
+      const Fw::Time& timeTag,
+      const bool val
+  )
+{
+  TlmEntry_ChannelBoolOnChange e = { timeTag, val };
+  this->tlmHistory_ChannelBoolOnChange->push_back(e);
   this->tlmSize++;
 }
 
@@ -5133,6 +5159,7 @@ void QueuedTestTesterBase ::
   this->tlmHistory_ChannelF64->clear();
   this->tlmHistory_ChannelU32OnChange->clear();
   this->tlmHistory_ChannelEnumOnChange->clear();
+  this->tlmHistory_ChannelBoolOnChange->clear();
 }
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.hpp
@@ -327,6 +327,12 @@ class QueuedTestTesterBase :
       E arg;
     };
 
+    //! A history entry for telemetry channel ChannelBoolOnChange
+    struct TlmEntry_ChannelBoolOnChange {
+      Fw::Time timeTag;
+      bool arg;
+    };
+
     //! A type representing a data product request
     struct DpRequest {
       FwDpIdType id;
@@ -1707,6 +1713,12 @@ class QueuedTestTesterBase :
         const E& val //!< The channel value
     );
 
+    //! Handle channel ChannelBoolOnChange
+    void tlmInput_ChannelBoolOnChange(
+        const Fw::Time& timeTag, //!< The time
+        const bool val //!< The channel value
+    );
+
   protected:
 
     // ----------------------------------------------------------------------
@@ -2357,6 +2369,9 @@ class QueuedTestTesterBase :
 
     //! The history of ChannelEnumOnChange values
     History<TlmEntry_ChannelEnumOnChange>* tlmHistory_ChannelEnumOnChange;
+
+    //! The history of ChannelBoolOnChange values
+    History<TlmEntry_ChannelBoolOnChange>* tlmHistory_ChannelBoolOnChange;
 
     //! The data product request history
     History<DpRequest>* productRequestHistory;

--- a/compiler/tools/fpp-to-cpp/test/fprime/config/AcConstants.fpp
+++ b/compiler/tools/fpp-to-cpp/test/fprime/config/AcConstants.fpp
@@ -1,0 +1,70 @@
+# ======================================================================
+# AcConstants.fpp
+# F Prime configuration constants
+# ======================================================================
+
+@ Number of rate group member output ports for ActiveRateGroup
+constant ActiveRateGroupOutputPorts = 10
+
+@ Number of rate group member output ports for PassiveRateGroup
+constant PassiveRateGroupOutputPorts = 10
+
+@ Used to drive rate groups
+constant RateGroupDriverRateGroupPorts = 3
+
+@ Used for command and registration ports
+constant CmdDispatcherComponentCommandPorts = 30
+
+@ Used for uplink/sequencer buffer/response ports
+constant CmdDispatcherSequencePorts = 5
+
+@ Used for dispatching sequences to command sequencers
+constant SeqDispatcherSequencerPorts = 2
+
+@ Used for sizing the command splitter input arrays
+constant CmdSplitterPorts = CmdDispatcherSequencePorts
+
+@ Number of static memory allocations
+constant StaticMemoryAllocations = 4
+
+@ Used to ping active components
+constant HealthPingPorts = 25
+
+@ Used for broadcasting completed file downlinks
+constant FileDownCompletePorts = 1
+
+@ Used for number of Fw::Com type ports supported by Svc::ComQueue
+constant ComQueueComPorts = 2
+
+@ Used for number of Fw::Buffer type ports supported by Svc::ComQueue
+constant ComQueueBufferPorts = 1
+
+@ Used for maximum number of connected buffer repeater consumers
+constant BufferRepeaterOutputPorts = 10
+
+@ Size of port array for DpManager
+constant DpManagerNumPorts = 5
+
+@ Size of processing port array for DpWriter
+constant DpWriterNumProcPorts = 5
+
+@ The size of a file name string
+constant FileNameStringSize = 200
+
+@ The size of an assert text string
+constant FwAssertTextSize = 256
+
+@ The size of a file name in an AssertFatalAdapter event
+@ Note: File names in assertion failures are also truncated by
+@ the constants FW_ASSERT_TEXT_SIZE and FW_LOG_STRING_MAX_SIZE, set
+@ in FpConfig.h.
+constant AssertFatalAdapterEventFileSize = FileNameStringSize
+
+# ----------------------------------------------------------------------
+# Hub connections. Connections on all deployments should mirror these settings.
+# ----------------------------------------------------------------------
+
+constant GenericHubInputPorts = 10
+constant GenericHubOutputPorts = 10
+constant GenericHubInputBuffers = 10
+constant GenericHubOutputBuffers = 10

--- a/compiler/tools/fpp-to-cpp/test/fprime/config/ComCfg.fpp
+++ b/compiler/tools/fpp-to-cpp/test/fprime/config/ComCfg.fpp
@@ -6,6 +6,9 @@
 # defined
 # ======================================================================
 
+@ The width of packet descriptors when they are serialized by the framework
+type FwPacketDescriptorType = U16
+
 module ComCfg {
 
     # Needed in dictionary:
@@ -16,7 +19,7 @@ module ComCfg {
     constant TmFrameFixedSize = 1024  # Needs to be at least COM_BUFFER_MAX_SIZE + (2 * SpacePacketHeaderSize) + 1
 
     @ APIDs are 11 bits in the Space Packet protocol, so we use U16. Max value 7FF
-    enum APID : U16 {
+    enum Apid : FwPacketDescriptorType {
         # APIDs prefixed with FW are reserved for F Prime and need to be present
         # in the enumeration. Their values can be changed
         FW_PACKET_COMMAND        = 0x0000  @< Command packet type - incoming
@@ -35,12 +38,12 @@ module ComCfg {
     @ Type used to pass context info between components during framing/deframing
     struct FrameContext {
         comQueueIndex: FwIndexType  @< Queue Index used by the ComQueue, other components shall not modify
-        apid: APID                  @< 11 bits APID in CCSDS
+        apid: Apid                  @< 11 bits APID in CCSDS
         sequenceCount: U16          @< 14 bit Sequence count - sequence count is incremented per APID
         vcId: U8                    @< 6 bit Virtual Channel ID - used for TC and TM
     } default {
         comQueueIndex = 0
-        apid = APID.FW_PACKET_UNKNOWN
+        apid = Apid.FW_PACKET_UNKNOWN
         sequenceCount = 0
         vcId = 1
     }

--- a/compiler/tools/fpp-to-cpp/test/fprime/config/FpConfig.fpp
+++ b/compiler/tools/fpp-to-cpp/test/fprime/config/FpConfig.fpp
@@ -64,9 +64,6 @@ type FwEventIdType = FwIdType
 @ The type of a command opcode
 type FwOpcodeType = FwIdType
 
-@ The type of a com packet descriptor
-type FwPacketDescriptorType = FwIdType
-
 @ The type of a parameter identifier
 type FwPrmIdType = FwIdType
 

--- a/compiler/tools/fpp-to-cpp/test/fprime/config/FpySequencerCfg.fpp
+++ b/compiler/tools/fpp-to-cpp/test/fprime/config/FpySequencerCfg.fpp
@@ -1,0 +1,12 @@
+module Svc {
+    module Fpy {
+        @ The maximum number of arguments a sequence can have
+        constant MAX_SEQUENCE_ARG_COUNT = 16
+        @ The maximum number of statements a sequence can have
+        constant MAX_SEQUENCE_STATEMENT_COUNT = 1024
+        @ the maximum number of bytes in a stack
+        constant MAX_STACK_SIZE = 65535
+        @ the maximum number of bytes in a directive
+        constant MAX_DIRECTIVE_SIZE = 2048
+    }
+}

--- a/compiler/tools/fpp-to-cpp/test/fprime/config/PolyDbCfg.fpp
+++ b/compiler/tools/fpp-to-cpp/test/fprime/config/PolyDbCfg.fpp
@@ -1,0 +1,34 @@
+# ======================================================================
+# FPP file for PolyDb configuration
+# ======================================================================
+
+module Svc {
+
+  module PolyDbCfg {
+
+    @ Define a set of PolyDb entries on a project-specific
+    @ basis. 
+    enum PolyDbEntry: U32 {
+      @ Entry 0
+      POLYDB_ENTRY_00
+      @ Entry 1
+      POLYDB_ENTRY_01
+      @ Entry 2
+      POLYDB_ENTRY_03
+      @ Entry 4
+      POLYDB_ENTRY_04
+      @ Entry 5
+      POLYDB_ENTRY_05
+      @ Entry 6
+      POLYDB_ENTRY_06
+      @ Entry 7
+      POLYDB_ENTRY_07
+      @ Entry 8
+      POLYDB_ENTRY_08
+      @ Entry 9
+      POLYDB_ENTRY_09
+    }
+
+  }
+
+}

--- a/compiler/tools/fpp-to-cpp/test/fprime/config/VersionCfg.fpp
+++ b/compiler/tools/fpp-to-cpp/test/fprime/config/VersionCfg.fpp
@@ -1,0 +1,36 @@
+# ======================================================================
+# FPP file for Version configuration
+# ======================================================================
+
+module Svc {
+
+  module VersionCfg {
+
+    @ Define a set of Version entries on a project-specific
+    @ basis. 
+    enum VersionEnum: U32 {
+      @ Entry 0
+      PROJECT_VERSION_00
+      @ Entry 1
+      PROJECT_VERSION_01
+      @ Entry 2
+      PROJECT_VERSION_02
+      @ Entry 3
+      PROJECT_VERSION_03
+      @ Entry 4
+      PROJECT_VERSION_04
+      @ Entry 5
+      PROJECT_VERSION_05
+      @ Entry 6
+      PROJECT_VERSION_06
+      @ Entry 7
+      PROJECT_VERSION_07
+      @ Entry 8
+      PROJECT_VERSION_08
+      @ Entry 9
+      PROJECT_VERSION_09
+    }
+
+  }
+
+}

--- a/compiler/tools/fpp-to-cpp/test/fprime/generate_cpp
+++ b/compiler/tools/fpp-to-cpp/test/fprime/generate_cpp
@@ -92,7 +92,7 @@ mv Param*.hpp Param*.cpp Fw/Prm
 mv Sched*.hpp Sched*.cpp Svc/Sched
 
 # Move config files into place
-mv APIDEnum* config
+mv ApidEnum* config
 
 # Remaining files go into types
 mv *.hpp *.cpp Fw/Types


### PR DESCRIPTION
* Revise code gen. Use C++11 `= {}` initialization to avoid the issue of whether to write `= 0` or `= false` or anything else.
* Add a unit test to cover Boolean on change telemetry
* Update F Prime framework harness for check-cpp
* Incidental fixes
    * Replace NULL with nullptr
    * Replace flatten with concat

Closes #833.