### PR TITLE
Fix regression in on-change telemetry

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriter.scala
@@ -510,11 +510,18 @@ case class ComponentCppWriter (
   }
 
   private def getProtectedComponentFunctionMembers: List[CppDoc.Class.Member] = {
-    def writeChannelInit(channel: TlmChannel) = lines(
-      s"""|// Write telemetry channel ${channel.getName}
-          |this->${channelUpdateFlagName(channel.getName)} = true;
-          |this->${channelStorageName(channel.getName)} = {};
-          |"""
+    def writeChannelInit(channel: TlmChannel) = List.concat(
+      lines(
+        s"""|// Write telemetry channel ${channel.getName}
+            |this->${channelUpdateFlagName(channel.getName)} = true;
+            |"""
+      ),
+      channel.channelType match {
+        case t if s.isPrimitive(t, writeChannelType(t)) => lines(
+          s"this->${channelStorageName(channel.getName)} = {};"
+        )
+        case _ => Nil
+      }
     )
 
     addAccessTagAndComment(

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
@@ -2325,7 +2325,6 @@ ActiveSerialComponentBase ::
 
   // Write telemetry channel ChannelEnumOnChange
   this->m_first_update_ChannelEnumOnChange = true;
-  this->m_last_ChannelEnumOnChange = {};
 
   // Write telemetry channel ChannelBoolOnChange
   this->m_first_update_ChannelBoolOnChange = true;

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.cpp
@@ -1517,7 +1517,6 @@ ActiveTelemetryComponentBase ::
 
   // Write telemetry channel ChannelEnumOnChange
   this->m_first_update_ChannelEnumOnChange = true;
-  this->m_last_ChannelEnumOnChange = {};
 
   // Write telemetry channel ChannelBoolOnChange
   this->m_first_update_ChannelBoolOnChange = true;

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
@@ -2415,7 +2415,6 @@ namespace M {
 
     // Write telemetry channel ChannelEnumOnChange
     this->m_first_update_ChannelEnumOnChange = true;
-    this->m_last_ChannelEnumOnChange = {};
 
     // Write telemetry channel ChannelBoolOnChange
     this->m_first_update_ChannelBoolOnChange = true;

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
@@ -1840,7 +1840,6 @@ PassiveSerialComponentBase ::
 
   // Write telemetry channel ChannelEnumOnChange
   this->m_first_update_ChannelEnumOnChange = true;
-  this->m_last_ChannelEnumOnChange = {};
 
   // Write telemetry channel ChannelBoolOnChange
   this->m_first_update_ChannelBoolOnChange = true;

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTelemetryComponentAc.ref.cpp
@@ -1236,7 +1236,6 @@ PassiveTelemetryComponentBase ::
 
   // Write telemetry channel ChannelEnumOnChange
   this->m_first_update_ChannelEnumOnChange = true;
-  this->m_last_ChannelEnumOnChange = {};
 
   // Write telemetry channel ChannelBoolOnChange
   this->m_first_update_ChannelBoolOnChange = true;

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
@@ -2076,7 +2076,6 @@ PassiveTestComponentBase ::
 
   // Write telemetry channel ChannelEnumOnChange
   this->m_first_update_ChannelEnumOnChange = true;
-  this->m_last_ChannelEnumOnChange = {};
 
   // Write telemetry channel ChannelBoolOnChange
   this->m_first_update_ChannelBoolOnChange = true;

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
@@ -2325,7 +2325,6 @@ QueuedSerialComponentBase ::
 
   // Write telemetry channel ChannelEnumOnChange
   this->m_first_update_ChannelEnumOnChange = true;
-  this->m_last_ChannelEnumOnChange = {};
 
   // Write telemetry channel ChannelBoolOnChange
   this->m_first_update_ChannelBoolOnChange = true;

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.cpp
@@ -1517,7 +1517,6 @@ QueuedTelemetryComponentBase ::
 
   // Write telemetry channel ChannelEnumOnChange
   this->m_first_update_ChannelEnumOnChange = true;
-  this->m_last_ChannelEnumOnChange = {};
 
   // Write telemetry channel ChannelBoolOnChange
   this->m_first_update_ChannelBoolOnChange = true;

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
@@ -2413,7 +2413,6 @@ QueuedTestComponentBase ::
 
   // Write telemetry channel ChannelEnumOnChange
   this->m_first_update_ChannelEnumOnChange = true;
-  this->m_last_ChannelEnumOnChange = {};
 
   // Write telemetry channel ChannelBoolOnChange
   this->m_first_update_ChannelBoolOnChange = true;


### PR DESCRIPTION
Fix regression introduced by #834.

I still need to investigate why this code change caused a regression. For now, let's ensure that `fpp/main` is working.