### PR TITLE
Further fixes for on-change tlm init

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriter.scala
@@ -510,19 +510,6 @@ case class ComponentCppWriter (
   }
 
   private def getProtectedComponentFunctionMembers: List[CppDoc.Class.Member] = {
-    def writeChannelInit(channel: TlmChannel) = List.concat(
-      lines(
-        s"""|// Write telemetry channel ${channel.getName}
-            |this->${channelUpdateFlagName(channel.getName)} = true;
-            |"""
-      ),
-      channel.channelType match {
-        case t if s.isPrimitive(t, writeChannelType(t)) => lines(
-          s"this->${channelStorageName(channel.getName)} = {};"
-        )
-        case _ => Nil
-      }
-    )
 
     addAccessTagAndComment(
     "protected",
@@ -552,11 +539,6 @@ case class ComponentCppWriter (
             },
           intersperseBlankLines(
             List(
-              intersperseBlankLines(
-                updateOnChangeChannels.map((_, channel) =>
-                  writeChannelInit(channel)
-                )
-              ),
               throttledEvents.map((_, event) => line(
                 s"this->${eventThrottleCounterName(event.getName)} = 0;"
               )),

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentTelemetry.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentTelemetry.scala
@@ -45,7 +45,7 @@ case class ComponentTelemetry (
             lines(
               s"""|
                   |//! Initialized to true; cleared when channel ${channel.getName} is first updated
-                  |bool ${channelUpdateFlagName(channel.getName)};
+                  |bool ${channelUpdateFlagName(channel.getName)} = true;
                   |"""
             )
           )
@@ -63,7 +63,7 @@ case class ComponentTelemetry (
             lines(
               s"""|
                   |//! Records the last emitted value for channel $channelName
-                  |$channelType $channelStoreName;
+                  |$channelType $channelStoreName = {};
                   |"""
             )
           )

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
@@ -2319,17 +2319,6 @@ ActiveSerialComponentBase ::
     Fw::ActiveComponentBase(compName),
     paramDelegatePtr(nullptr)
 {
-  // Write telemetry channel ChannelU32OnChange
-  this->m_first_update_ChannelU32OnChange = true;
-  this->m_last_ChannelU32OnChange = {};
-
-  // Write telemetry channel ChannelEnumOnChange
-  this->m_first_update_ChannelEnumOnChange = true;
-
-  // Write telemetry channel ChannelBoolOnChange
-  this->m_first_update_ChannelBoolOnChange = true;
-  this->m_last_ChannelBoolOnChange = {};
-
   this->m_EventActivityLowThrottledThrottle = 0;
   this->m_EventFatalThrottledThrottle = 0;
   this->m_EventWarningLowThrottledThrottle = 0;

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.hpp
@@ -3174,13 +3174,13 @@ class ActiveSerialComponentBase :
     // ----------------------------------------------------------------------
 
     //! Initialized to true; cleared when channel ChannelU32OnChange is first updated
-    bool m_first_update_ChannelU32OnChange;
+    bool m_first_update_ChannelU32OnChange = true;
 
     //! Initialized to true; cleared when channel ChannelEnumOnChange is first updated
-    bool m_first_update_ChannelEnumOnChange;
+    bool m_first_update_ChannelEnumOnChange = true;
 
     //! Initialized to true; cleared when channel ChannelBoolOnChange is first updated
-    bool m_first_update_ChannelBoolOnChange;
+    bool m_first_update_ChannelBoolOnChange = true;
 
   private:
 
@@ -3189,13 +3189,13 @@ class ActiveSerialComponentBase :
     // ----------------------------------------------------------------------
 
     //! Records the last emitted value for channel ChannelU32OnChange
-    U32 m_last_ChannelU32OnChange;
+    U32 m_last_ChannelU32OnChange = {};
 
     //! Records the last emitted value for channel ChannelEnumOnChange
-    E m_last_ChannelEnumOnChange;
+    E m_last_ChannelEnumOnChange = {};
 
     //! Records the last emitted value for channel ChannelBoolOnChange
-    bool m_last_ChannelBoolOnChange;
+    bool m_last_ChannelBoolOnChange = {};
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.cpp
@@ -1511,16 +1511,7 @@ ActiveTelemetryComponentBase ::
   ActiveTelemetryComponentBase(const char* compName) :
     Fw::ActiveComponentBase(compName)
 {
-  // Write telemetry channel ChannelU32OnChange
-  this->m_first_update_ChannelU32OnChange = true;
-  this->m_last_ChannelU32OnChange = {};
 
-  // Write telemetry channel ChannelEnumOnChange
-  this->m_first_update_ChannelEnumOnChange = true;
-
-  // Write telemetry channel ChannelBoolOnChange
-  this->m_first_update_ChannelBoolOnChange = true;
-  this->m_last_ChannelBoolOnChange = {};
 }
 
 ActiveTelemetryComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.hpp
@@ -1865,13 +1865,13 @@ class ActiveTelemetryComponentBase :
     // ----------------------------------------------------------------------
 
     //! Initialized to true; cleared when channel ChannelU32OnChange is first updated
-    bool m_first_update_ChannelU32OnChange;
+    bool m_first_update_ChannelU32OnChange = true;
 
     //! Initialized to true; cleared when channel ChannelEnumOnChange is first updated
-    bool m_first_update_ChannelEnumOnChange;
+    bool m_first_update_ChannelEnumOnChange = true;
 
     //! Initialized to true; cleared when channel ChannelBoolOnChange is first updated
-    bool m_first_update_ChannelBoolOnChange;
+    bool m_first_update_ChannelBoolOnChange = true;
 
   private:
 
@@ -1880,13 +1880,13 @@ class ActiveTelemetryComponentBase :
     // ----------------------------------------------------------------------
 
     //! Records the last emitted value for channel ChannelU32OnChange
-    U32 m_last_ChannelU32OnChange;
+    U32 m_last_ChannelU32OnChange = {};
 
     //! Records the last emitted value for channel ChannelEnumOnChange
-    E m_last_ChannelEnumOnChange;
+    E m_last_ChannelEnumOnChange = {};
 
     //! Records the last emitted value for channel ChannelBoolOnChange
-    bool m_last_ChannelBoolOnChange;
+    bool m_last_ChannelBoolOnChange = {};
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
@@ -2409,17 +2409,6 @@ namespace M {
       Fw::ActiveComponentBase(compName),
       paramDelegatePtr(nullptr)
   {
-    // Write telemetry channel ChannelU32OnChange
-    this->m_first_update_ChannelU32OnChange = true;
-    this->m_last_ChannelU32OnChange = {};
-
-    // Write telemetry channel ChannelEnumOnChange
-    this->m_first_update_ChannelEnumOnChange = true;
-
-    // Write telemetry channel ChannelBoolOnChange
-    this->m_first_update_ChannelBoolOnChange = true;
-    this->m_last_ChannelBoolOnChange = {};
-
     this->m_EventActivityLowThrottledThrottle = 0;
     this->m_EventFatalThrottledThrottle = 0;
     this->m_EventWarningLowThrottledThrottle = 0;

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.hpp
@@ -3194,13 +3194,13 @@ namespace M {
       // ----------------------------------------------------------------------
 
       //! Initialized to true; cleared when channel ChannelU32OnChange is first updated
-      bool m_first_update_ChannelU32OnChange;
+      bool m_first_update_ChannelU32OnChange = true;
 
       //! Initialized to true; cleared when channel ChannelEnumOnChange is first updated
-      bool m_first_update_ChannelEnumOnChange;
+      bool m_first_update_ChannelEnumOnChange = true;
 
       //! Initialized to true; cleared when channel ChannelBoolOnChange is first updated
-      bool m_first_update_ChannelBoolOnChange;
+      bool m_first_update_ChannelBoolOnChange = true;
 
     private:
 
@@ -3209,13 +3209,13 @@ namespace M {
       // ----------------------------------------------------------------------
 
       //! Records the last emitted value for channel ChannelU32OnChange
-      U32 m_last_ChannelU32OnChange;
+      U32 m_last_ChannelU32OnChange = {};
 
       //! Records the last emitted value for channel ChannelEnumOnChange
-      E m_last_ChannelEnumOnChange;
+      E m_last_ChannelEnumOnChange = {};
 
       //! Records the last emitted value for channel ChannelBoolOnChange
-      bool m_last_ChannelBoolOnChange;
+      bool m_last_ChannelBoolOnChange = {};
 
     private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
@@ -1834,17 +1834,6 @@ PassiveSerialComponentBase ::
     Fw::PassiveComponentBase(compName),
     paramDelegatePtr(nullptr)
 {
-  // Write telemetry channel ChannelU32OnChange
-  this->m_first_update_ChannelU32OnChange = true;
-  this->m_last_ChannelU32OnChange = {};
-
-  // Write telemetry channel ChannelEnumOnChange
-  this->m_first_update_ChannelEnumOnChange = true;
-
-  // Write telemetry channel ChannelBoolOnChange
-  this->m_first_update_ChannelBoolOnChange = true;
-  this->m_last_ChannelBoolOnChange = {};
-
   this->m_EventActivityLowThrottledThrottle = 0;
   this->m_EventFatalThrottledThrottle = 0;
   this->m_EventWarningLowThrottledThrottle = 0;

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.hpp
@@ -2410,13 +2410,13 @@ class PassiveSerialComponentBase :
     // ----------------------------------------------------------------------
 
     //! Initialized to true; cleared when channel ChannelU32OnChange is first updated
-    bool m_first_update_ChannelU32OnChange;
+    bool m_first_update_ChannelU32OnChange = true;
 
     //! Initialized to true; cleared when channel ChannelEnumOnChange is first updated
-    bool m_first_update_ChannelEnumOnChange;
+    bool m_first_update_ChannelEnumOnChange = true;
 
     //! Initialized to true; cleared when channel ChannelBoolOnChange is first updated
-    bool m_first_update_ChannelBoolOnChange;
+    bool m_first_update_ChannelBoolOnChange = true;
 
   private:
 
@@ -2425,13 +2425,13 @@ class PassiveSerialComponentBase :
     // ----------------------------------------------------------------------
 
     //! Records the last emitted value for channel ChannelU32OnChange
-    U32 m_last_ChannelU32OnChange;
+    U32 m_last_ChannelU32OnChange = {};
 
     //! Records the last emitted value for channel ChannelEnumOnChange
-    E m_last_ChannelEnumOnChange;
+    E m_last_ChannelEnumOnChange = {};
 
     //! Records the last emitted value for channel ChannelBoolOnChange
-    bool m_last_ChannelBoolOnChange;
+    bool m_last_ChannelBoolOnChange = {};
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTelemetryComponentAc.ref.cpp
@@ -1230,16 +1230,7 @@ PassiveTelemetryComponentBase ::
   PassiveTelemetryComponentBase(const char* compName) :
     Fw::PassiveComponentBase(compName)
 {
-  // Write telemetry channel ChannelU32OnChange
-  this->m_first_update_ChannelU32OnChange = true;
-  this->m_last_ChannelU32OnChange = {};
 
-  // Write telemetry channel ChannelEnumOnChange
-  this->m_first_update_ChannelEnumOnChange = true;
-
-  // Write telemetry channel ChannelBoolOnChange
-  this->m_first_update_ChannelBoolOnChange = true;
-  this->m_last_ChannelBoolOnChange = {};
 }
 
 PassiveTelemetryComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTelemetryComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTelemetryComponentAc.ref.hpp
@@ -1483,13 +1483,13 @@ class PassiveTelemetryComponentBase :
     // ----------------------------------------------------------------------
 
     //! Initialized to true; cleared when channel ChannelU32OnChange is first updated
-    bool m_first_update_ChannelU32OnChange;
+    bool m_first_update_ChannelU32OnChange = true;
 
     //! Initialized to true; cleared when channel ChannelEnumOnChange is first updated
-    bool m_first_update_ChannelEnumOnChange;
+    bool m_first_update_ChannelEnumOnChange = true;
 
     //! Initialized to true; cleared when channel ChannelBoolOnChange is first updated
-    bool m_first_update_ChannelBoolOnChange;
+    bool m_first_update_ChannelBoolOnChange = true;
 
   private:
 
@@ -1498,13 +1498,13 @@ class PassiveTelemetryComponentBase :
     // ----------------------------------------------------------------------
 
     //! Records the last emitted value for channel ChannelU32OnChange
-    U32 m_last_ChannelU32OnChange;
+    U32 m_last_ChannelU32OnChange = {};
 
     //! Records the last emitted value for channel ChannelEnumOnChange
-    E m_last_ChannelEnumOnChange;
+    E m_last_ChannelEnumOnChange = {};
 
     //! Records the last emitted value for channel ChannelBoolOnChange
-    bool m_last_ChannelBoolOnChange;
+    bool m_last_ChannelBoolOnChange = {};
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
@@ -2070,17 +2070,6 @@ PassiveTestComponentBase ::
     Fw::PassiveComponentBase(compName),
     paramDelegatePtr(nullptr)
 {
-  // Write telemetry channel ChannelU32OnChange
-  this->m_first_update_ChannelU32OnChange = true;
-  this->m_last_ChannelU32OnChange = {};
-
-  // Write telemetry channel ChannelEnumOnChange
-  this->m_first_update_ChannelEnumOnChange = true;
-
-  // Write telemetry channel ChannelBoolOnChange
-  this->m_first_update_ChannelBoolOnChange = true;
-  this->m_last_ChannelBoolOnChange = {};
-
   this->m_EventActivityLowThrottledThrottle = 0;
   this->m_EventFatalThrottledThrottle = 0;
   this->m_EventWarningLowThrottledThrottle = 0;

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.hpp
@@ -2585,13 +2585,13 @@ class PassiveTestComponentBase :
     // ----------------------------------------------------------------------
 
     //! Initialized to true; cleared when channel ChannelU32OnChange is first updated
-    bool m_first_update_ChannelU32OnChange;
+    bool m_first_update_ChannelU32OnChange = true;
 
     //! Initialized to true; cleared when channel ChannelEnumOnChange is first updated
-    bool m_first_update_ChannelEnumOnChange;
+    bool m_first_update_ChannelEnumOnChange = true;
 
     //! Initialized to true; cleared when channel ChannelBoolOnChange is first updated
-    bool m_first_update_ChannelBoolOnChange;
+    bool m_first_update_ChannelBoolOnChange = true;
 
   private:
 
@@ -2600,13 +2600,13 @@ class PassiveTestComponentBase :
     // ----------------------------------------------------------------------
 
     //! Records the last emitted value for channel ChannelU32OnChange
-    U32 m_last_ChannelU32OnChange;
+    U32 m_last_ChannelU32OnChange = {};
 
     //! Records the last emitted value for channel ChannelEnumOnChange
-    E m_last_ChannelEnumOnChange;
+    E m_last_ChannelEnumOnChange = {};
 
     //! Records the last emitted value for channel ChannelBoolOnChange
-    bool m_last_ChannelBoolOnChange;
+    bool m_last_ChannelBoolOnChange = {};
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
@@ -2319,17 +2319,6 @@ QueuedSerialComponentBase ::
     Fw::QueuedComponentBase(compName),
     paramDelegatePtr(nullptr)
 {
-  // Write telemetry channel ChannelU32OnChange
-  this->m_first_update_ChannelU32OnChange = true;
-  this->m_last_ChannelU32OnChange = {};
-
-  // Write telemetry channel ChannelEnumOnChange
-  this->m_first_update_ChannelEnumOnChange = true;
-
-  // Write telemetry channel ChannelBoolOnChange
-  this->m_first_update_ChannelBoolOnChange = true;
-  this->m_last_ChannelBoolOnChange = {};
-
   this->m_EventActivityLowThrottledThrottle = 0;
   this->m_EventFatalThrottledThrottle = 0;
   this->m_EventWarningLowThrottledThrottle = 0;

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.hpp
@@ -3183,13 +3183,13 @@ class QueuedSerialComponentBase :
     // ----------------------------------------------------------------------
 
     //! Initialized to true; cleared when channel ChannelU32OnChange is first updated
-    bool m_first_update_ChannelU32OnChange;
+    bool m_first_update_ChannelU32OnChange = true;
 
     //! Initialized to true; cleared when channel ChannelEnumOnChange is first updated
-    bool m_first_update_ChannelEnumOnChange;
+    bool m_first_update_ChannelEnumOnChange = true;
 
     //! Initialized to true; cleared when channel ChannelBoolOnChange is first updated
-    bool m_first_update_ChannelBoolOnChange;
+    bool m_first_update_ChannelBoolOnChange = true;
 
   private:
 
@@ -3198,13 +3198,13 @@ class QueuedSerialComponentBase :
     // ----------------------------------------------------------------------
 
     //! Records the last emitted value for channel ChannelU32OnChange
-    U32 m_last_ChannelU32OnChange;
+    U32 m_last_ChannelU32OnChange = {};
 
     //! Records the last emitted value for channel ChannelEnumOnChange
-    E m_last_ChannelEnumOnChange;
+    E m_last_ChannelEnumOnChange = {};
 
     //! Records the last emitted value for channel ChannelBoolOnChange
-    bool m_last_ChannelBoolOnChange;
+    bool m_last_ChannelBoolOnChange = {};
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.cpp
@@ -1511,16 +1511,7 @@ QueuedTelemetryComponentBase ::
   QueuedTelemetryComponentBase(const char* compName) :
     Fw::QueuedComponentBase(compName)
 {
-  // Write telemetry channel ChannelU32OnChange
-  this->m_first_update_ChannelU32OnChange = true;
-  this->m_last_ChannelU32OnChange = {};
 
-  // Write telemetry channel ChannelEnumOnChange
-  this->m_first_update_ChannelEnumOnChange = true;
-
-  // Write telemetry channel ChannelBoolOnChange
-  this->m_first_update_ChannelBoolOnChange = true;
-  this->m_last_ChannelBoolOnChange = {};
 }
 
 QueuedTelemetryComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.hpp
@@ -1874,13 +1874,13 @@ class QueuedTelemetryComponentBase :
     // ----------------------------------------------------------------------
 
     //! Initialized to true; cleared when channel ChannelU32OnChange is first updated
-    bool m_first_update_ChannelU32OnChange;
+    bool m_first_update_ChannelU32OnChange = true;
 
     //! Initialized to true; cleared when channel ChannelEnumOnChange is first updated
-    bool m_first_update_ChannelEnumOnChange;
+    bool m_first_update_ChannelEnumOnChange = true;
 
     //! Initialized to true; cleared when channel ChannelBoolOnChange is first updated
-    bool m_first_update_ChannelBoolOnChange;
+    bool m_first_update_ChannelBoolOnChange = true;
 
   private:
 
@@ -1889,13 +1889,13 @@ class QueuedTelemetryComponentBase :
     // ----------------------------------------------------------------------
 
     //! Records the last emitted value for channel ChannelU32OnChange
-    U32 m_last_ChannelU32OnChange;
+    U32 m_last_ChannelU32OnChange = {};
 
     //! Records the last emitted value for channel ChannelEnumOnChange
-    E m_last_ChannelEnumOnChange;
+    E m_last_ChannelEnumOnChange = {};
 
     //! Records the last emitted value for channel ChannelBoolOnChange
-    bool m_last_ChannelBoolOnChange;
+    bool m_last_ChannelBoolOnChange = {};
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
@@ -2407,17 +2407,6 @@ QueuedTestComponentBase ::
     Fw::QueuedComponentBase(compName),
     paramDelegatePtr(nullptr)
 {
-  // Write telemetry channel ChannelU32OnChange
-  this->m_first_update_ChannelU32OnChange = true;
-  this->m_last_ChannelU32OnChange = {};
-
-  // Write telemetry channel ChannelEnumOnChange
-  this->m_first_update_ChannelEnumOnChange = true;
-
-  // Write telemetry channel ChannelBoolOnChange
-  this->m_first_update_ChannelBoolOnChange = true;
-  this->m_last_ChannelBoolOnChange = {};
-
   this->m_EventActivityLowThrottledThrottle = 0;
   this->m_EventFatalThrottledThrottle = 0;
   this->m_EventWarningLowThrottledThrottle = 0;

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.hpp
@@ -3201,13 +3201,13 @@ class QueuedTestComponentBase :
     // ----------------------------------------------------------------------
 
     //! Initialized to true; cleared when channel ChannelU32OnChange is first updated
-    bool m_first_update_ChannelU32OnChange;
+    bool m_first_update_ChannelU32OnChange = true;
 
     //! Initialized to true; cleared when channel ChannelEnumOnChange is first updated
-    bool m_first_update_ChannelEnumOnChange;
+    bool m_first_update_ChannelEnumOnChange = true;
 
     //! Initialized to true; cleared when channel ChannelBoolOnChange is first updated
-    bool m_first_update_ChannelBoolOnChange;
+    bool m_first_update_ChannelBoolOnChange = true;
 
   private:
 
@@ -3216,13 +3216,13 @@ class QueuedTestComponentBase :
     // ----------------------------------------------------------------------
 
     //! Records the last emitted value for channel ChannelU32OnChange
-    U32 m_last_ChannelU32OnChange;
+    U32 m_last_ChannelU32OnChange = {};
 
     //! Records the last emitted value for channel ChannelEnumOnChange
-    E m_last_ChannelEnumOnChange;
+    E m_last_ChannelEnumOnChange = {};
 
     //! Records the last emitted value for channel ChannelBoolOnChange
-    bool m_last_ChannelBoolOnChange;
+    bool m_last_ChannelBoolOnChange = {};
 
   private:
 


### PR DESCRIPTION
* Move initialization out of the constructor body and into the variable declaration using `= {}`. This is possible in C++11.
* Consistently initialize `m_last` variables of all types. The old code was initializing `m_last` variables of primitive type and not initializing other variables. The variables are never used until they are written, so there was never a read of an uninitialized variable. However, we should be consistent, and we should initialize all variables.

Related to #834, #837. 

Note: Writing an **assignment** `s = {}` where `s` is an `Fw::TlmString` turns out to be wrong, because it causes `operator=` to fail an assertion. In this PR we replace `s = {}` assignments with `s = {}` initializations.