### PR TITLE
Make fpp-to-json JAR based

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -185,16 +185,20 @@ jobs:
         with:
           name: build-${{ matrix.tag }}
           path: ${{ inputs.output-directory }}
+      - name: "Download JARs"
+        uses: actions/download-artifact@v4
+        with:
+          name: build-jar
+          path:  ${{ inputs.output-directory }}
       - name: "Run Builder"
         run: |
           pip install build
+          cp -vr ${{ inputs.output-directory }}/*.jar python/fprime_fpp/
           # Place the native files in the python package and determine platform options
           PLATFORM_OPTIONS=""
           if [[ "${{ matrix.tag }}" != "jar" ]]; then
             PLATFORM_OPTIONS="--config-setting=--build-option=--plat-name=${{ matrix.tag }}"
             cp -vr ${{ inputs.output-directory }}/fpp python/fprime_fpp/
-          else
-            cp -vr ${{ inputs.output-directory }}/*.jar python/fprime_fpp/
           fi
           # Github archiving clears executable flag, so put it back
           chmod +x python/fprime_fpp/fpp*

--- a/python/fprime_fpp/__main__.py
+++ b/python/fprime_fpp/__main__.py
@@ -23,7 +23,7 @@ def main():
     jar_file = Path(__file__).parent / "fpp.jar"
 
     # Prefer the binary file if it exists
-    if binary_file.exists():
+    if binary_file.exists() and name != "fpp-to-json":
         process = subprocess.run([str(binary_file)] + base_arguments)
     # Then check for the JAR file
     elif jar_file.exists():


### PR DESCRIPTION
This PR will make the `fpp-to-json` tool always run as the java/JAR version, not the broken native build version.

This is the staging PR for the alpha testing.