### PR TITLE
Implement direct connections for serial ports

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriterUtils.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriterUtils.scala
@@ -530,11 +530,17 @@ abstract class ComponentCppWriterUtils(
     AnnotationCppWriter.asStringOpt(aNode)
   }
 
+  // The parameter name for a serial port
+  val serialPortParamName = "buffer"
+
+  // The parameter type for a serial port
+  val serialPortParamType = "Fw::LinearBufferBase"
+
   /** Get port params as a list of tuples containing the name and typename for each param */
   def getPortParams(p: PortInstance): List[(String, String, Option[Type])] =
     p.getType match {
       case Some(PortInstance.Type.Serial) => List(
-        ("buffer", "Fw::LinearBufferBase", None)
+        (serialPortParamName, serialPortParamType, None)
       )
       case _ => portParamTypeMap(p.getUnqualifiedName).map((n, tn, t) => (n, tn, Some(t)))
     }

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TopComponentCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TopComponentCppWriter.scala
@@ -133,26 +133,26 @@ case class TopComponentCppWriter (
 
   private def writeOutFnCase(fromPortNum: Int, connection: Connection) = {
     val fromPort = connection.from.port
-    val fromPortInstance = connection.from.port.portInstance
+    val fromPortInstance = fromPort.portInstance
     val toPort = connection.to.port
-    val toPortInstance = connection.to.port.portInstance
+    val toPortInstance = toPort.portInstance
     val toPortNum = topology.toPortNumberMap(connection)
-    // Connections must be flattened at this point
-    val _ @ InterfaceInstance.InterfaceComponentInstance(toComponentInstance) =
-      toPort.interfaceInstance
-    val componentInstanceName = CppWriter.writeQualifiedName(toComponentInstance.qualifiedName)
-    val portName = toPortInstance.getUnqualifiedName
-    val handlerBaseName = inputPortHandlerBaseName(portName)
-    val fnName = s"$componentInstanceName.$handlerBaseName"
-    val returnType = getHandlerReturnTypeAsString(toPortInstance)
-    val addResultPrefix = addConditionalPrefix (returnType != "void") ("_result =")
+    val fnName = {
+      // Connections must be flattened at this point
+      val _ @ InterfaceInstance.InterfaceComponentInstance(toComponentInstance) =
+        toPort.interfaceInstance
+      val componentInstanceName = CppWriter.writeQualifiedName(toComponentInstance.qualifiedName)
+      val toPortName = toPortInstance.getUnqualifiedName
+      val handlerBaseName = inputPortHandlerBaseName(toPortName)
+      s"$componentInstanceName.$handlerBaseName"
+    }
     (fromPortInstance.getType.get, toPortInstance.getType.get) match {
-      case (_: PortInstance.Type.DefPort, PortInstance.Type.Serial) =>
+      case (
+        PortInstance.Type.DefPort(portSymbol),
+        PortInstance.Type.Serial
+      ) =>
         // Typed to serial connection
-        lines(
-          """|// TODO: Typed to serial connection
-             |FW_ASSERT(0);"""
-        )
+        writeTypedToSerialConnection(portSymbol, fnName, toPortNum)
       case (PortInstance.Type.Serial, _: PortInstance.Type.DefPort) =>
         // Serial to typed connection
         lines(
@@ -161,10 +161,12 @@ case class TopComponentCppWriter (
         )
       case _ =>
         // Typed to typed connection or serial to serial connection
+        val returnType = getHandlerReturnTypeAsString(toPortInstance)
+        val addResultPrefix = addConditionalPrefix (returnType != "void") ("_result =")
         writeFunctionCall(
           addResultPrefix(fnName),
           List(toPortNum.toString),
-          getPortParams(fromPort.portInstance).map(_._1)
+          getPortParams(fromPortInstance).map(_._1)
         )
     }
   }
@@ -232,6 +234,34 @@ case class TopComponentCppWriter (
         lines("default:"),
         defaultLines.map(indentIn),
         lines("  break;")
+      )
+    )
+  }
+
+  private def writeTypedToSerialConnection(
+    fromPortSymbol: Symbol.Port,
+    fnName: String,
+    toPortNum: Int
+  ) = {
+    val params = fromPortSymbol.node._2.data.params
+    val portName = s.getName(fromPortSymbol)
+    val portBufferName = PortCppWriterUtils.getPortBufferName(portName)
+    val portSerializerName = PortCppWriterUtils.getPortSerializerName(portName)
+    val portParamNames = PortCppWriterUtils.writeParamNames(params)
+    wrapInBlock(
+      List.concat(
+        lines(s"$portBufferName _buffer;"),
+        guardedList (!params.isEmpty) (
+          lines(
+            s"""|Fw::SerializeStatus _status = $portSerializerName::serializePortArgs($portParamNames, _buffer);
+                |FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));"""
+          )
+        ),
+        writeFunctionCall(
+          fnName,
+          List(toPortNum.toString),
+          List("_buffer")
+        )
       )
     )
   }

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TopComponentCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TopComponentCppWriter.scala
@@ -148,17 +148,17 @@ case class TopComponentCppWriter (
     }
     (fromPortInstance.getType.get, toPortInstance.getType.get) match {
       case (
-        PortInstance.Type.DefPort(portSymbol),
+        PortInstance.Type.DefPort(fromPortSymbol),
         PortInstance.Type.Serial
       ) =>
         // Typed to serial connection
-        writeTypedToSerialConnection(portSymbol, fnName, toPortNum)
-      case (PortInstance.Type.Serial, _: PortInstance.Type.DefPort) =>
+        writeTypedToSerialConnection(fromPortSymbol, fnName, toPortNum)
+      case (
+        PortInstance.Type.Serial,
+        PortInstance.Type.DefPort(toPortSymbol)
+      ) =>
         // Serial to typed connection
-        lines(
-          """|// TODO: Serial to typed connection
-             |FW_ASSERT(0);"""
-        )
+        writeSerialToTypedConnection(toPortSymbol, fnName, toPortNum)
       case _ =>
         // Typed to typed connection or serial to serial connection
         val returnType = getHandlerReturnTypeAsString(toPortInstance)
@@ -235,6 +235,17 @@ case class TopComponentCppWriter (
         defaultLines.map(indentIn),
         lines("  break;")
       )
+    )
+  }
+
+  private def writeSerialToTypedConnection(
+    fromPortSymbol: Symbol.Port,
+    fnName: String,
+    toPortNum: Int
+  ) = {
+    lines(
+      """|// TODO: Serial to typed connection
+         |FW_ASSERT(0);"""
     )
   }
 

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TopComponentCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TopComponentCppWriter.scala
@@ -43,6 +43,21 @@ case class TopComponentCppWriter (
       ci1.qualifiedName.toString < ci2.qualifiedName.toString
   }
 
+  private def writeInstanceCase
+    (writeInnerCaseLines: (Int, Connection) => List[Line])
+    (innerDefaultLines: List[Line])
+    (pair: (ComponentInstance, TopComponents.PortNumberMap)) =
+  {
+    val (componentInstance, portNumberMap) = pair
+    val ident = CppWriterState.identFromQualifiedName(componentInstance.qualifiedName)
+    val instanceIds = s"${topologyQualifierPrefix}InstanceIds"
+    List.concat(
+      line(s"case $instanceIds::$ident:") ::
+      (writePortNumSwitch (writeInnerCaseLines, innerDefaultLines, portNumberMap)).map(indentIn),
+      lines("  break;")
+    )
+  }
+
   private def writeInstanceSwitch(
     componentInstanceMap: TopComponents.ComponentInstanceMap,
     writeInnerCaseLines: (Int, Connection) => List[Line],
@@ -61,15 +76,6 @@ case class TopComponentCppWriter (
       )
     )
   }
-
-  private def writePortNumAssertion(numPorts: String) =
-    lines(
-      s"""|FW_ASSERT(
-          |  (0 <= portNum) && (portNum < $numPorts),
-          |  static_cast<FwAssertArgType>(portNum),
-          |  static_cast<FwAssertArgType>($numPorts)
-          |);"""
-    )
 
   private def writeIsConnectedFnBody(
     portName: Name.Unqualified,
@@ -200,20 +206,14 @@ case class TopComponentCppWriter (
     )
   }
 
-  private def writeInstanceCase
-    (writeInnerCaseLines: (Int, Connection) => List[Line])
-    (innerDefaultLines: List[Line])
-    (pair: (ComponentInstance, TopComponents.PortNumberMap)) =
-  {
-    val (componentInstance, portNumberMap) = pair
-    val ident = CppWriterState.identFromQualifiedName(componentInstance.qualifiedName)
-    val instanceIds = s"${topologyQualifierPrefix}InstanceIds"
-    List.concat(
-      line(s"case $instanceIds::$ident:") ::
-      (writePortNumSwitch (writeInnerCaseLines, innerDefaultLines, portNumberMap)).map(indentIn),
-      lines("  break;")
+  private def writePortNumAssertion(numPorts: String) =
+    lines(
+      s"""|FW_ASSERT(
+          |  (0 <= portNum) && (portNum < $numPorts),
+          |  static_cast<FwAssertArgType>(portNum),
+          |  static_cast<FwAssertArgType>($numPorts)
+          |);"""
     )
-  }
 
   private def writePortNumSwitch(
     writeCaseLines: (Int, Connection) => List[Line],

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TopComponentCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TopComponentCppWriter.scala
@@ -239,13 +239,30 @@ case class TopComponentCppWriter (
   }
 
   private def writeSerialToTypedConnection(
-    fromPortSymbol: Symbol.Port,
+    toPortSymbol: Symbol.Port,
     fnName: String,
     toPortNum: Int
   ) = {
-    lines(
-      """|// TODO: Serial to typed connection
-         |FW_ASSERT(0);"""
+    val toPortParams = toPortSymbol.node._2.data.params
+    val bufferParamName = "buffer" // TODO
+    val toPortName = s.getName(toPortSymbol)
+    val portSerializerName = PortCppWriterUtils.getPortSerializerName(toPortName)
+    val serializerParamNames = PortCppWriterUtils.getSerializerParamNames(toPortParams)
+    wrapInBlock(
+      List.concat(
+        if (!toPortParams.isEmpty)
+        then lines(
+          s"""|$portSerializerName _serializer;
+              |Fw::SerializeStatus _status = _serializer.deserializePortArgs($bufferParamName);
+              |FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));"""
+        )
+        else lines(s"|(void) $bufferParamName;"),
+        writeFunctionCall(
+          fnName,
+          List(toPortNum.toString),
+          serializerParamNames
+        )
+      )
     )
   }
 

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TopComponentCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TopComponentCppWriter.scala
@@ -137,7 +137,7 @@ case class TopComponentCppWriter (
     val toPort = connection.to.port
     val toPortInstance = toPort.portInstance
     val toPortNum = topology.toPortNumberMap(connection)
-    val fnName = {
+    val functionName = {
       // Connections must be flattened at this point
       val _ @ InterfaceInstance.InterfaceComponentInstance(toComponentInstance) =
         toPort.interfaceInstance
@@ -152,19 +152,19 @@ case class TopComponentCppWriter (
         PortInstance.Type.Serial
       ) =>
         // Typed to serial connection
-        writeTypedToSerialConnection(fromPortSymbol, fnName, toPortNum)
+        writeTypedToSerialConnection(fromPortSymbol, functionName, toPortNum)
       case (
         PortInstance.Type.Serial,
         PortInstance.Type.DefPort(toPortSymbol)
       ) =>
         // Serial to typed connection
-        writeSerialToTypedConnection(toPortSymbol, fnName, toPortNum)
+        writeSerialToTypedConnection(toPortSymbol, functionName, toPortNum)
       case _ =>
         // Typed to typed connection or serial to serial connection
         val returnType = getHandlerReturnTypeAsString(toPortInstance)
         val addResultPrefix = addConditionalPrefix (returnType != "void") ("_result =")
         writeFunctionCall(
-          addResultPrefix(fnName),
+          addResultPrefix(functionName),
           List(toPortNum.toString),
           getPortParams(fromPortInstance).map(_._1)
         )
@@ -240,11 +240,10 @@ case class TopComponentCppWriter (
 
   private def writeSerialToTypedConnection(
     toPortSymbol: Symbol.Port,
-    fnName: String,
+    functionName: String,
     toPortNum: Int
   ) = {
     val toPortParams = toPortSymbol.node._2.data.params
-    val bufferParamName = "buffer" // TODO
     val toPortName = s.getName(toPortSymbol)
     val portSerializerName = PortCppWriterUtils.getPortSerializerName(toPortName)
     val serializerParamNames = PortCppWriterUtils.getSerializerParamNames(toPortParams)
@@ -253,12 +252,12 @@ case class TopComponentCppWriter (
         if (!toPortParams.isEmpty)
         then lines(
           s"""|$portSerializerName _serializer;
-              |Fw::SerializeStatus _status = _serializer.deserializePortArgs($bufferParamName);
+              |Fw::SerializeStatus _status = _serializer.deserializePortArgs($serialPortParamName);
               |FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));"""
         )
-        else lines(s"|(void) $bufferParamName;"),
+        else lines(s"|(void) $serialPortParamName;"),
         writeFunctionCall(
-          fnName,
+          functionName,
           List(toPortNum.toString),
           serializerParamNames
         )
@@ -268,7 +267,7 @@ case class TopComponentCppWriter (
 
   private def writeTypedToSerialConnection(
     fromPortSymbol: Symbol.Port,
-    fnName: String,
+    functionName: String,
     toPortNum: Int
   ) = {
     val params = fromPortSymbol.node._2.data.params
@@ -286,7 +285,7 @@ case class TopComponentCppWriter (
           )
         ),
         writeFunctionCall(
-          fnName,
+          functionName,
           List(toPortNum.toString),
           List("_buffer")
         )

--- a/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterUtils.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterUtils.scala
@@ -125,6 +125,9 @@ trait CppWriterUtils extends LineUtils {
   def wrapInAnonymousNamespace(ll: List[Line]): List[Line] =
     wrapInScope("namespace {", ll, "}")
 
+  def wrapInBlock(ll: List[Line]) =
+    wrapInScope("{", ll, "}")
+
   def wrapInNamespace(namespace: String, ll: List[Line]): List[Line] =
     wrapInScope(s"namespace $namespace {", ll, "}")
 

--- a/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter/InputPortClassWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter/InputPortClassWriter.scala
@@ -25,7 +25,7 @@ case class InputPortClassWriter(
 
   // Write serializer param names as a comma-separated list
   private def writeSerializerParamNames =
-    PortCppWriterUtils.writeParamNamesWithPrefix ("_serializer.m_") (portParams)
+    (PortCppWriterUtils.getSerializerParamNames (portParams)).mkString(", ")
 
   // Write serializer param names appended to a comma-separated list
   private def appendSerializerParamNames =

--- a/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter/InputPortClassWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter/InputPortClassWriter.scala
@@ -25,7 +25,7 @@ case class InputPortClassWriter(
 
   // Write serializer param names as a comma-separated list
   private def writeSerializerParamNames =
-    portParams.map(p => s"_serializer.m_${p._2.data.name}").mkString(", ")
+    PortCppWriterUtils.writeParamNamesWithPrefix ("_serializer.m_") (portParams)
 
   // Write serializer param names appended to a comma-separated list
   private def appendSerializerParamNames =

--- a/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter/PortCppWriterUtils.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter/PortCppWriterUtils.scala
@@ -130,11 +130,19 @@ object PortCppWriterUtils {
       case PortInstance.Direction.Output => getOutputPortClassName(name)
     }
 
+  /** Get a list of parameter names with the specified prefix */
+  def getParamNamesWithPrefix (prefix: String) (portParams: List[PortParamType]) =
+    portParams.map(p => s"${prefix}${p._2.data.name}")
+
   /** Write parameter names with prefix into a comma-separated list */
   def writeParamNamesWithPrefix (prefix: String) (portParams: List[PortParamType]) =
-    portParams.map(p => s"${prefix}${p._2.data.name}").mkString(", ")
+    (getParamNamesWithPrefix (prefix) (portParams)).mkString(", ")
 
   /** Write param names into a comma-separated list */
   val writeParamNames = writeParamNamesWithPrefix ("")
+
+  /** Get a list of serializer parameter names */
+  def getSerializerParamNames (portParams: List[PortParamType]) =
+    getParamNamesWithPrefix ("_serializer.m_") (portParams)
 
 }

--- a/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter/PortCppWriterUtils.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter/PortCppWriterUtils.scala
@@ -10,7 +10,7 @@ abstract class PortCppWriterUtils(
   aNode: Ast.Annotated[AstNode[Ast.DefPort]]
 ) extends CppWriterUtils {
 
-  type PortParamType = Ast.Annotated[AstNode[Ast.FormalParam]]
+  type PortParamType = PortCppWriterUtils.PortParamType
 
   val portNode = aNode._2
 
@@ -65,7 +65,7 @@ abstract class PortCppWriterUtils(
   val outputPortClassName = PortCppWriterUtils.getOutputPortClassName(portName)
 
   // Write param names as a comma-separated list
-  def writeParamNames = portParams.map(_._2.data.name).mkString(", ")
+  def writeParamNames = PortCppWriterUtils.writeParamNamesWithPrefix ("") (portParams)
 
   // Write param names appended to a comma-separated list
   def appendParamNames = commaPrefix(writeParamNames)
@@ -111,6 +111,8 @@ abstract class PortCppWriterUtils(
 
 object PortCppWriterUtils {
 
+  type PortParamType = Ast.Annotated[AstNode[Ast.FormalParam]]
+
   def getInputPortClassName(name: String) = s"Input${name}Port"
 
   def getOutputPortClassName(name: String) = s"Output${name}Port"
@@ -127,5 +129,9 @@ object PortCppWriterUtils {
       case PortInstance.Direction.Input => getInputPortClassName(name)
       case PortInstance.Direction.Output => getOutputPortClassName(name)
     }
+
+  /** Write parameter names with prefix into a list */
+  def writeParamNamesWithPrefix (prefix: String) (portParams: List[PortParamType]) =
+    portParams.map(p => s"${prefix}${p._2.data.name}").mkString(", ")
 
 }

--- a/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter/PortCppWriterUtils.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter/PortCppWriterUtils.scala
@@ -65,7 +65,7 @@ abstract class PortCppWriterUtils(
   val outputPortClassName = PortCppWriterUtils.getOutputPortClassName(portName)
 
   // Write param names as a comma-separated list
-  def writeParamNames = PortCppWriterUtils.writeParamNamesWithPrefix ("") (portParams)
+  def writeParamNames = PortCppWriterUtils.writeParamNames (portParams)
 
   // Write param names appended to a comma-separated list
   def appendParamNames = commaPrefix(writeParamNames)
@@ -130,8 +130,11 @@ object PortCppWriterUtils {
       case PortInstance.Direction.Output => getOutputPortClassName(name)
     }
 
-  /** Write parameter names with prefix into a list */
+  /** Write parameter names with prefix into a comma-separated list */
   def writeParamNamesWithPrefix (prefix: String) (portParams: List[PortParamType]) =
     portParams.map(p => s"${prefix}${p._2.data.name}").mkString(", ")
+
+  /** Write param names into a comma-separated list */
+  val writeParamNames = writeParamNamesWithPrefix ("")
 
 }

--- a/compiler/tools/fpp-to-cpp/test/top/serial_ports_active/SerialPortsActiveTopologyAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/top/serial_ports_active/SerialPortsActiveTopologyAc.ref.cpp
@@ -340,20 +340,48 @@ namespace SerialPortsActive {
       case ::SerialPortsActive::InstanceIds::SerialPortsActive_sender:
         switch (portNum) {
           case 0:
-            // TODO: Typed to serial connection
-            FW_ASSERT(0);
+            {
+              PTypedPortBuffer _buffer;
+              Fw::SerializeStatus _status = PTypedPortSerializer::serializePortArgs(x1, x2, x3, x4, x5, x6, x7, _buffer);
+              FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+              SerialPortsActive::receiver.pSerialSync_handlerBase(
+                0,
+                _buffer
+              );
+            }
             break;
           case 1:
-            // TODO: Typed to serial connection
-            FW_ASSERT(0);
+            {
+              PTypedPortBuffer _buffer;
+              Fw::SerializeStatus _status = PTypedPortSerializer::serializePortArgs(x1, x2, x3, x4, x5, x6, x7, _buffer);
+              FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+              SerialPortsActive::receiver.pSerialSync_handlerBase(
+                1,
+                _buffer
+              );
+            }
             break;
           case 2:
-            // TODO: Typed to serial connection
-            FW_ASSERT(0);
+            {
+              PTypedPortBuffer _buffer;
+              Fw::SerializeStatus _status = PTypedPortSerializer::serializePortArgs(x1, x2, x3, x4, x5, x6, x7, _buffer);
+              FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+              SerialPortsActive::receiver.pSerialAsync_handlerBase(
+                0,
+                _buffer
+              );
+            }
             break;
           case 3:
-            // TODO: Typed to serial connection
-            FW_ASSERT(0);
+            {
+              PTypedPortBuffer _buffer;
+              Fw::SerializeStatus _status = PTypedPortSerializer::serializePortArgs(x1, x2, x3, x4, x5, x6, x7, _buffer);
+              FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+              SerialPortsActive::receiver.pSerialAsync_handlerBase(
+                1,
+                _buffer
+              );
+            }
             break;
           default:
             FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));

--- a/compiler/tools/fpp-to-cpp/test/top/serial_ports_active/SerialPortsActiveTopologyAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/top/serial_ports_active/SerialPortsActiveTopologyAc.ref.cpp
@@ -269,20 +269,72 @@ namespace SerialPortsActive {
       case ::SerialPortsActive::InstanceIds::SerialPortsActive_sender:
         switch (portNum) {
           case 0:
-            // TODO: Serial to typed connection
-            FW_ASSERT(0);
+            {
+              PTypedPortSerializer _serializer;
+              Fw::SerializeStatus _status = _serializer.deserializePortArgs(buffer);
+              FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+              SerialPortsActive::receiver.pTypedSync_handlerBase(
+                0,
+                _serializer.m_x1,
+                _serializer.m_x2,
+                _serializer.m_x3,
+                _serializer.m_x4,
+                _serializer.m_x5,
+                _serializer.m_x6,
+                _serializer.m_x7
+              );
+            }
             break;
           case 1:
-            // TODO: Serial to typed connection
-            FW_ASSERT(0);
+            {
+              PTypedPortSerializer _serializer;
+              Fw::SerializeStatus _status = _serializer.deserializePortArgs(buffer);
+              FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+              SerialPortsActive::receiver.pTypedSync_handlerBase(
+                1,
+                _serializer.m_x1,
+                _serializer.m_x2,
+                _serializer.m_x3,
+                _serializer.m_x4,
+                _serializer.m_x5,
+                _serializer.m_x6,
+                _serializer.m_x7
+              );
+            }
             break;
           case 2:
-            // TODO: Serial to typed connection
-            FW_ASSERT(0);
+            {
+              PTypedPortSerializer _serializer;
+              Fw::SerializeStatus _status = _serializer.deserializePortArgs(buffer);
+              FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+              SerialPortsActive::receiver.pTypedAsync_handlerBase(
+                0,
+                _serializer.m_x1,
+                _serializer.m_x2,
+                _serializer.m_x3,
+                _serializer.m_x4,
+                _serializer.m_x5,
+                _serializer.m_x6,
+                _serializer.m_x7
+              );
+            }
             break;
           case 3:
-            // TODO: Serial to typed connection
-            FW_ASSERT(0);
+            {
+              PTypedPortSerializer _serializer;
+              Fw::SerializeStatus _status = _serializer.deserializePortArgs(buffer);
+              FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+              SerialPortsActive::receiver.pTypedAsync_handlerBase(
+                1,
+                _serializer.m_x1,
+                _serializer.m_x2,
+                _serializer.m_x3,
+                _serializer.m_x4,
+                _serializer.m_x5,
+                _serializer.m_x6,
+                _serializer.m_x7
+              );
+            }
             break;
           case 4:
             SerialPortsActive::receiver.pSerialSync_handlerBase(

--- a/compiler/tools/fpp-to-cpp/test/top/serial_ports_passive/SerialPortsPassiveTopologyAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/top/serial_ports_passive/SerialPortsPassiveTopologyAc.ref.cpp
@@ -335,20 +335,48 @@ namespace SerialPortsPassive {
       case ::SerialPortsPassive::InstanceIds::SerialPortsPassive_sender:
         switch (portNum) {
           case 0:
-            // TODO: Typed to serial connection
-            FW_ASSERT(0);
+            {
+              PTypedPortBuffer _buffer;
+              Fw::SerializeStatus _status = PTypedPortSerializer::serializePortArgs(x1, x2, x3, x4, x5, x6, x7, _buffer);
+              FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+              SerialPortsPassive::receiver.pSerialSync_handlerBase(
+                0,
+                _buffer
+              );
+            }
             break;
           case 1:
-            // TODO: Typed to serial connection
-            FW_ASSERT(0);
+            {
+              PTypedPortBuffer _buffer;
+              Fw::SerializeStatus _status = PTypedPortSerializer::serializePortArgs(x1, x2, x3, x4, x5, x6, x7, _buffer);
+              FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+              SerialPortsPassive::receiver.pSerialSync_handlerBase(
+                1,
+                _buffer
+              );
+            }
             break;
           case 2:
-            // TODO: Typed to serial connection
-            FW_ASSERT(0);
+            {
+              PTypedPortBuffer _buffer;
+              Fw::SerializeStatus _status = PTypedPortSerializer::serializePortArgs(x1, x2, x3, x4, x5, x6, x7, _buffer);
+              FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+              SerialPortsPassive::receiver.pSerialGuarded_handlerBase(
+                0,
+                _buffer
+              );
+            }
             break;
           case 3:
-            // TODO: Typed to serial connection
-            FW_ASSERT(0);
+            {
+              PTypedPortBuffer _buffer;
+              Fw::SerializeStatus _status = PTypedPortSerializer::serializePortArgs(x1, x2, x3, x4, x5, x6, x7, _buffer);
+              FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+              SerialPortsPassive::receiver.pSerialGuarded_handlerBase(
+                1,
+                _buffer
+              );
+            }
             break;
           default:
             FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));

--- a/compiler/tools/fpp-to-cpp/test/top/serial_ports_passive/SerialPortsPassiveTopologyAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/top/serial_ports_passive/SerialPortsPassiveTopologyAc.ref.cpp
@@ -264,20 +264,72 @@ namespace SerialPortsPassive {
       case ::SerialPortsPassive::InstanceIds::SerialPortsPassive_sender:
         switch (portNum) {
           case 0:
-            // TODO: Serial to typed connection
-            FW_ASSERT(0);
+            {
+              PTypedPortSerializer _serializer;
+              Fw::SerializeStatus _status = _serializer.deserializePortArgs(buffer);
+              FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+              SerialPortsPassive::receiver.pTypedSync_handlerBase(
+                0,
+                _serializer.m_x1,
+                _serializer.m_x2,
+                _serializer.m_x3,
+                _serializer.m_x4,
+                _serializer.m_x5,
+                _serializer.m_x6,
+                _serializer.m_x7
+              );
+            }
             break;
           case 1:
-            // TODO: Serial to typed connection
-            FW_ASSERT(0);
+            {
+              PTypedPortSerializer _serializer;
+              Fw::SerializeStatus _status = _serializer.deserializePortArgs(buffer);
+              FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+              SerialPortsPassive::receiver.pTypedSync_handlerBase(
+                1,
+                _serializer.m_x1,
+                _serializer.m_x2,
+                _serializer.m_x3,
+                _serializer.m_x4,
+                _serializer.m_x5,
+                _serializer.m_x6,
+                _serializer.m_x7
+              );
+            }
             break;
           case 2:
-            // TODO: Serial to typed connection
-            FW_ASSERT(0);
+            {
+              PTypedPortSerializer _serializer;
+              Fw::SerializeStatus _status = _serializer.deserializePortArgs(buffer);
+              FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+              SerialPortsPassive::receiver.pTypedGuarded_handlerBase(
+                0,
+                _serializer.m_x1,
+                _serializer.m_x2,
+                _serializer.m_x3,
+                _serializer.m_x4,
+                _serializer.m_x5,
+                _serializer.m_x6,
+                _serializer.m_x7
+              );
+            }
             break;
           case 3:
-            // TODO: Serial to typed connection
-            FW_ASSERT(0);
+            {
+              PTypedPortSerializer _serializer;
+              Fw::SerializeStatus _status = _serializer.deserializePortArgs(buffer);
+              FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+              SerialPortsPassive::receiver.pTypedGuarded_handlerBase(
+                1,
+                _serializer.m_x1,
+                _serializer.m_x2,
+                _serializer.m_x3,
+                _serializer.m_x4,
+                _serializer.m_x5,
+                _serializer.m_x6,
+                _serializer.m_x7
+              );
+            }
             break;
           case 4:
             SerialPortsPassive::receiver.pSerialSync_handlerBase(

--- a/compiler/tools/fpp-to-cpp/test/top/serial_ports_queued/SerialPortsQueuedTopologyAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/top/serial_ports_queued/SerialPortsQueuedTopologyAc.ref.cpp
@@ -264,20 +264,72 @@ namespace SerialPortsQueued {
       case ::SerialPortsQueued::InstanceIds::SerialPortsQueued_sender:
         switch (portNum) {
           case 0:
-            // TODO: Serial to typed connection
-            FW_ASSERT(0);
+            {
+              PTypedPortSerializer _serializer;
+              Fw::SerializeStatus _status = _serializer.deserializePortArgs(buffer);
+              FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+              SerialPortsQueued::receiver.pTypedSync_handlerBase(
+                0,
+                _serializer.m_x1,
+                _serializer.m_x2,
+                _serializer.m_x3,
+                _serializer.m_x4,
+                _serializer.m_x5,
+                _serializer.m_x6,
+                _serializer.m_x7
+              );
+            }
             break;
           case 1:
-            // TODO: Serial to typed connection
-            FW_ASSERT(0);
+            {
+              PTypedPortSerializer _serializer;
+              Fw::SerializeStatus _status = _serializer.deserializePortArgs(buffer);
+              FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+              SerialPortsQueued::receiver.pTypedSync_handlerBase(
+                1,
+                _serializer.m_x1,
+                _serializer.m_x2,
+                _serializer.m_x3,
+                _serializer.m_x4,
+                _serializer.m_x5,
+                _serializer.m_x6,
+                _serializer.m_x7
+              );
+            }
             break;
           case 2:
-            // TODO: Serial to typed connection
-            FW_ASSERT(0);
+            {
+              PTypedPortSerializer _serializer;
+              Fw::SerializeStatus _status = _serializer.deserializePortArgs(buffer);
+              FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+              SerialPortsQueued::receiver.pTypedAsync_handlerBase(
+                0,
+                _serializer.m_x1,
+                _serializer.m_x2,
+                _serializer.m_x3,
+                _serializer.m_x4,
+                _serializer.m_x5,
+                _serializer.m_x6,
+                _serializer.m_x7
+              );
+            }
             break;
           case 3:
-            // TODO: Serial to typed connection
-            FW_ASSERT(0);
+            {
+              PTypedPortSerializer _serializer;
+              Fw::SerializeStatus _status = _serializer.deserializePortArgs(buffer);
+              FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+              SerialPortsQueued::receiver.pTypedAsync_handlerBase(
+                1,
+                _serializer.m_x1,
+                _serializer.m_x2,
+                _serializer.m_x3,
+                _serializer.m_x4,
+                _serializer.m_x5,
+                _serializer.m_x6,
+                _serializer.m_x7
+              );
+            }
             break;
           case 4:
             SerialPortsQueued::receiver.pSerialSync_handlerBase(

--- a/compiler/tools/fpp-to-cpp/test/top/serial_ports_queued/SerialPortsQueuedTopologyAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/top/serial_ports_queued/SerialPortsQueuedTopologyAc.ref.cpp
@@ -335,20 +335,48 @@ namespace SerialPortsQueued {
       case ::SerialPortsQueued::InstanceIds::SerialPortsQueued_sender:
         switch (portNum) {
           case 0:
-            // TODO: Typed to serial connection
-            FW_ASSERT(0);
+            {
+              PTypedPortBuffer _buffer;
+              Fw::SerializeStatus _status = PTypedPortSerializer::serializePortArgs(x1, x2, x3, x4, x5, x6, x7, _buffer);
+              FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+              SerialPortsQueued::receiver.pSerialSync_handlerBase(
+                0,
+                _buffer
+              );
+            }
             break;
           case 1:
-            // TODO: Typed to serial connection
-            FW_ASSERT(0);
+            {
+              PTypedPortBuffer _buffer;
+              Fw::SerializeStatus _status = PTypedPortSerializer::serializePortArgs(x1, x2, x3, x4, x5, x6, x7, _buffer);
+              FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+              SerialPortsQueued::receiver.pSerialSync_handlerBase(
+                1,
+                _buffer
+              );
+            }
             break;
           case 2:
-            // TODO: Typed to serial connection
-            FW_ASSERT(0);
+            {
+              PTypedPortBuffer _buffer;
+              Fw::SerializeStatus _status = PTypedPortSerializer::serializePortArgs(x1, x2, x3, x4, x5, x6, x7, _buffer);
+              FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+              SerialPortsQueued::receiver.pSerialAsync_handlerBase(
+                0,
+                _buffer
+              );
+            }
             break;
           case 3:
-            // TODO: Typed to serial connection
-            FW_ASSERT(0);
+            {
+              PTypedPortBuffer _buffer;
+              Fw::SerializeStatus _status = PTypedPortSerializer::serializePortArgs(x1, x2, x3, x4, x5, x6, x7, _buffer);
+              FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+              SerialPortsQueued::receiver.pSerialAsync_handlerBase(
+                1,
+                _buffer
+              );
+            }
             break;
           default:
             FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));


### PR DESCRIPTION
* Implement serial-to-typed and typed-to-serial connections
* Regenerate unit test output

Further to #840.
Passes FppTest tests on this branch: https://github.com/bocchino/fprime/tree/direct-ports-serial.