### PR TITLE
Improve Topology Analysis Performance

### DIFF
--- a/compiler/lib/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/compiler/lib/src/main/resources/META-INF/native-image/reflect-config.json
@@ -23,6 +23,10 @@
   "fields":[{"name":"0bitmap$1"}]
 },
 {
+  "name":"fpp.compiler.analysis.Topology",
+  "fields":[{"name":"0bitmap$1"}]
+},
+{
   "name":"fpp.compiler.codegen.AnalysisJsonEncoder$$anon$1",
   "fields":[{"name":"0bitmap$2"}]
 },

--- a/compiler/lib/src/main/scala/analysis/Semantics/Topology.scala
+++ b/compiler/lib/src/main/scala/analysis/Semantics/Topology.scala
@@ -280,7 +280,7 @@ case class Topology(
   def getLoc: Location = Locations.get(aNode._2.id)
 
   /** Precompute the set of component instances in the topology */
-  val componentInstanceMap: Map[ComponentInstance, Location] = {
+  lazy val componentInstanceMap: Map[ComponentInstance, Location] = {
     instanceMap collect { case (InterfaceInstance.InterfaceComponentInstance(ci), loc: Location) => (ci, loc) }
   }
 


### PR DESCRIPTION
My investigation revealed `Topology.copy()` was slow which turns out is because I added a variable which computes a filtered list. Once I made the value `lazy`, performance returned to normal.

Closes #992 