### PR TITLE
Fix bug in code gen for GTestBase

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentGTestBaseWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentGTestBaseWriter.scala
@@ -217,8 +217,8 @@ case class ComponentGTestBaseWriter(
           ) ++ (eventParamTypeMap(id) match {
             case Nil => Nil
             case _ => Line.blank :: lines(
-              s"""#define ASSERT_EVENTS_$eventName(size$params) \\
-                 |  this->$eventAssertFn(__FILE__, __LINE__, size$params)
+              s"""#define ASSERT_EVENTS_$eventName(index$params) \\
+                 |  this->$eventAssertFn(__FILE__, __LINE__, index$params)
                  |"""
             )
           })

--- a/compiler/tools/fpp-to-cpp/test/component/compile_base_cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/compile_base_cpp
@@ -20,7 +20,7 @@
 all_flag=false
 for i in "$@"
 do
-  if [[ "$i" = "--all" ]]
+  if test "$i" = "--all"
   then
     all_flag=true
   fi

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsGTestBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsGTestBase.ref.hpp
@@ -438,32 +438,32 @@
 #define ASSERT_EVENTS_EventActivityLowThrottled_SIZE(size) \
   this->assertEvents_EventActivityLowThrottled_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventActivityLowThrottled(size, _u32, _f32, _b) \
-  this->assertEvents_EventActivityLowThrottled(__FILE__, __LINE__, size, _u32, _f32, _b)
+#define ASSERT_EVENTS_EventActivityLowThrottled(index, _u32, _f32, _b) \
+  this->assertEvents_EventActivityLowThrottled(__FILE__, __LINE__, index, _u32, _f32, _b)
 
 #define ASSERT_EVENTS_EventCommand_SIZE(size) \
   this->assertEvents_EventCommand_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventCommand(size, _str1, _str2) \
-  this->assertEvents_EventCommand(__FILE__, __LINE__, size, _str1, _str2)
+#define ASSERT_EVENTS_EventCommand(index, _str1, _str2) \
+  this->assertEvents_EventCommand(__FILE__, __LINE__, index, _str1, _str2)
 
 #define ASSERT_EVENTS_EventDiagnostic_SIZE(size) \
   this->assertEvents_EventDiagnostic_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventDiagnostic(size, _e) \
-  this->assertEvents_EventDiagnostic(__FILE__, __LINE__, size, _e)
+#define ASSERT_EVENTS_EventDiagnostic(index, _e) \
+  this->assertEvents_EventDiagnostic(__FILE__, __LINE__, index, _e)
 
 #define ASSERT_EVENTS_EventFatalThrottled_SIZE(size) \
   this->assertEvents_EventFatalThrottled_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventFatalThrottled(size, _a) \
-  this->assertEvents_EventFatalThrottled(__FILE__, __LINE__, size, _a)
+#define ASSERT_EVENTS_EventFatalThrottled(index, _a) \
+  this->assertEvents_EventFatalThrottled(__FILE__, __LINE__, index, _a)
 
 #define ASSERT_EVENTS_EventWarningHigh_SIZE(size) \
   this->assertEvents_EventWarningHigh_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventWarningHigh(size, _s) \
-  this->assertEvents_EventWarningHigh(__FILE__, __LINE__, size, _s)
+#define ASSERT_EVENTS_EventWarningHigh(index, _s) \
+  this->assertEvents_EventWarningHigh(__FILE__, __LINE__, index, _s)
 
 #define ASSERT_EVENTS_EventWarningLowThrottled_SIZE(size) \
   this->assertEvents_EventWarningLowThrottled_size(__FILE__, __LINE__, size)

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialGTestBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialGTestBase.ref.hpp
@@ -448,32 +448,32 @@
 #define ASSERT_EVENTS_EventActivityLowThrottled_SIZE(size) \
   this->assertEvents_EventActivityLowThrottled_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventActivityLowThrottled(size, _u32, _f32, _b) \
-  this->assertEvents_EventActivityLowThrottled(__FILE__, __LINE__, size, _u32, _f32, _b)
+#define ASSERT_EVENTS_EventActivityLowThrottled(index, _u32, _f32, _b) \
+  this->assertEvents_EventActivityLowThrottled(__FILE__, __LINE__, index, _u32, _f32, _b)
 
 #define ASSERT_EVENTS_EventCommand_SIZE(size) \
   this->assertEvents_EventCommand_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventCommand(size, _str1, _str2) \
-  this->assertEvents_EventCommand(__FILE__, __LINE__, size, _str1, _str2)
+#define ASSERT_EVENTS_EventCommand(index, _str1, _str2) \
+  this->assertEvents_EventCommand(__FILE__, __LINE__, index, _str1, _str2)
 
 #define ASSERT_EVENTS_EventDiagnostic_SIZE(size) \
   this->assertEvents_EventDiagnostic_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventDiagnostic(size, _e) \
-  this->assertEvents_EventDiagnostic(__FILE__, __LINE__, size, _e)
+#define ASSERT_EVENTS_EventDiagnostic(index, _e) \
+  this->assertEvents_EventDiagnostic(__FILE__, __LINE__, index, _e)
 
 #define ASSERT_EVENTS_EventFatalThrottled_SIZE(size) \
   this->assertEvents_EventFatalThrottled_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventFatalThrottled(size, _a) \
-  this->assertEvents_EventFatalThrottled(__FILE__, __LINE__, size, _a)
+#define ASSERT_EVENTS_EventFatalThrottled(index, _a) \
+  this->assertEvents_EventFatalThrottled(__FILE__, __LINE__, index, _a)
 
 #define ASSERT_EVENTS_EventWarningHigh_SIZE(size) \
   this->assertEvents_EventWarningHigh_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventWarningHigh(size, _s) \
-  this->assertEvents_EventWarningHigh(__FILE__, __LINE__, size, _s)
+#define ASSERT_EVENTS_EventWarningHigh(index, _s) \
+  this->assertEvents_EventWarningHigh(__FILE__, __LINE__, index, _s)
 
 #define ASSERT_EVENTS_EventWarningLowThrottled_SIZE(size) \
   this->assertEvents_EventWarningLowThrottled_size(__FILE__, __LINE__, size)

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestGTestBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestGTestBase.ref.hpp
@@ -448,32 +448,32 @@
 #define ASSERT_EVENTS_EventActivityLowThrottled_SIZE(size) \
   this->assertEvents_EventActivityLowThrottled_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventActivityLowThrottled(size, _u32, _f32, _b) \
-  this->assertEvents_EventActivityLowThrottled(__FILE__, __LINE__, size, _u32, _f32, _b)
+#define ASSERT_EVENTS_EventActivityLowThrottled(index, _u32, _f32, _b) \
+  this->assertEvents_EventActivityLowThrottled(__FILE__, __LINE__, index, _u32, _f32, _b)
 
 #define ASSERT_EVENTS_EventCommand_SIZE(size) \
   this->assertEvents_EventCommand_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventCommand(size, _str1, _str2) \
-  this->assertEvents_EventCommand(__FILE__, __LINE__, size, _str1, _str2)
+#define ASSERT_EVENTS_EventCommand(index, _str1, _str2) \
+  this->assertEvents_EventCommand(__FILE__, __LINE__, index, _str1, _str2)
 
 #define ASSERT_EVENTS_EventDiagnostic_SIZE(size) \
   this->assertEvents_EventDiagnostic_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventDiagnostic(size, _e) \
-  this->assertEvents_EventDiagnostic(__FILE__, __LINE__, size, _e)
+#define ASSERT_EVENTS_EventDiagnostic(index, _e) \
+  this->assertEvents_EventDiagnostic(__FILE__, __LINE__, index, _e)
 
 #define ASSERT_EVENTS_EventFatalThrottled_SIZE(size) \
   this->assertEvents_EventFatalThrottled_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventFatalThrottled(size, _a) \
-  this->assertEvents_EventFatalThrottled(__FILE__, __LINE__, size, _a)
+#define ASSERT_EVENTS_EventFatalThrottled(index, _a) \
+  this->assertEvents_EventFatalThrottled(__FILE__, __LINE__, index, _a)
 
 #define ASSERT_EVENTS_EventWarningHigh_SIZE(size) \
   this->assertEvents_EventWarningHigh_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventWarningHigh(size, _s) \
-  this->assertEvents_EventWarningHigh(__FILE__, __LINE__, size, _s)
+#define ASSERT_EVENTS_EventWarningHigh(index, _s) \
+  this->assertEvents_EventWarningHigh(__FILE__, __LINE__, index, _s)
 
 #define ASSERT_EVENTS_EventWarningLowThrottled_SIZE(size) \
   this->assertEvents_EventWarningLowThrottled_size(__FILE__, __LINE__, size)

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsGTestBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsGTestBase.ref.hpp
@@ -438,32 +438,32 @@
 #define ASSERT_EVENTS_EventActivityLowThrottled_SIZE(size) \
   this->assertEvents_EventActivityLowThrottled_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventActivityLowThrottled(size, _u32, _f32, _b) \
-  this->assertEvents_EventActivityLowThrottled(__FILE__, __LINE__, size, _u32, _f32, _b)
+#define ASSERT_EVENTS_EventActivityLowThrottled(index, _u32, _f32, _b) \
+  this->assertEvents_EventActivityLowThrottled(__FILE__, __LINE__, index, _u32, _f32, _b)
 
 #define ASSERT_EVENTS_EventCommand_SIZE(size) \
   this->assertEvents_EventCommand_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventCommand(size, _str1, _str2) \
-  this->assertEvents_EventCommand(__FILE__, __LINE__, size, _str1, _str2)
+#define ASSERT_EVENTS_EventCommand(index, _str1, _str2) \
+  this->assertEvents_EventCommand(__FILE__, __LINE__, index, _str1, _str2)
 
 #define ASSERT_EVENTS_EventDiagnostic_SIZE(size) \
   this->assertEvents_EventDiagnostic_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventDiagnostic(size, _e) \
-  this->assertEvents_EventDiagnostic(__FILE__, __LINE__, size, _e)
+#define ASSERT_EVENTS_EventDiagnostic(index, _e) \
+  this->assertEvents_EventDiagnostic(__FILE__, __LINE__, index, _e)
 
 #define ASSERT_EVENTS_EventFatalThrottled_SIZE(size) \
   this->assertEvents_EventFatalThrottled_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventFatalThrottled(size, _a) \
-  this->assertEvents_EventFatalThrottled(__FILE__, __LINE__, size, _a)
+#define ASSERT_EVENTS_EventFatalThrottled(index, _a) \
+  this->assertEvents_EventFatalThrottled(__FILE__, __LINE__, index, _a)
 
 #define ASSERT_EVENTS_EventWarningHigh_SIZE(size) \
   this->assertEvents_EventWarningHigh_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventWarningHigh(size, _s) \
-  this->assertEvents_EventWarningHigh(__FILE__, __LINE__, size, _s)
+#define ASSERT_EVENTS_EventWarningHigh(index, _s) \
+  this->assertEvents_EventWarningHigh(__FILE__, __LINE__, index, _s)
 
 #define ASSERT_EVENTS_EventWarningLowThrottled_SIZE(size) \
   this->assertEvents_EventWarningLowThrottled_size(__FILE__, __LINE__, size)

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialGTestBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialGTestBase.ref.hpp
@@ -448,32 +448,32 @@
 #define ASSERT_EVENTS_EventActivityLowThrottled_SIZE(size) \
   this->assertEvents_EventActivityLowThrottled_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventActivityLowThrottled(size, _u32, _f32, _b) \
-  this->assertEvents_EventActivityLowThrottled(__FILE__, __LINE__, size, _u32, _f32, _b)
+#define ASSERT_EVENTS_EventActivityLowThrottled(index, _u32, _f32, _b) \
+  this->assertEvents_EventActivityLowThrottled(__FILE__, __LINE__, index, _u32, _f32, _b)
 
 #define ASSERT_EVENTS_EventCommand_SIZE(size) \
   this->assertEvents_EventCommand_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventCommand(size, _str1, _str2) \
-  this->assertEvents_EventCommand(__FILE__, __LINE__, size, _str1, _str2)
+#define ASSERT_EVENTS_EventCommand(index, _str1, _str2) \
+  this->assertEvents_EventCommand(__FILE__, __LINE__, index, _str1, _str2)
 
 #define ASSERT_EVENTS_EventDiagnostic_SIZE(size) \
   this->assertEvents_EventDiagnostic_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventDiagnostic(size, _e) \
-  this->assertEvents_EventDiagnostic(__FILE__, __LINE__, size, _e)
+#define ASSERT_EVENTS_EventDiagnostic(index, _e) \
+  this->assertEvents_EventDiagnostic(__FILE__, __LINE__, index, _e)
 
 #define ASSERT_EVENTS_EventFatalThrottled_SIZE(size) \
   this->assertEvents_EventFatalThrottled_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventFatalThrottled(size, _a) \
-  this->assertEvents_EventFatalThrottled(__FILE__, __LINE__, size, _a)
+#define ASSERT_EVENTS_EventFatalThrottled(index, _a) \
+  this->assertEvents_EventFatalThrottled(__FILE__, __LINE__, index, _a)
 
 #define ASSERT_EVENTS_EventWarningHigh_SIZE(size) \
   this->assertEvents_EventWarningHigh_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventWarningHigh(size, _s) \
-  this->assertEvents_EventWarningHigh(__FILE__, __LINE__, size, _s)
+#define ASSERT_EVENTS_EventWarningHigh(index, _s) \
+  this->assertEvents_EventWarningHigh(__FILE__, __LINE__, index, _s)
 
 #define ASSERT_EVENTS_EventWarningLowThrottled_SIZE(size) \
   this->assertEvents_EventWarningLowThrottled_size(__FILE__, __LINE__, size)

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestGTestBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestGTestBase.ref.hpp
@@ -448,32 +448,32 @@
 #define ASSERT_EVENTS_EventActivityLowThrottled_SIZE(size) \
   this->assertEvents_EventActivityLowThrottled_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventActivityLowThrottled(size, _u32, _f32, _b) \
-  this->assertEvents_EventActivityLowThrottled(__FILE__, __LINE__, size, _u32, _f32, _b)
+#define ASSERT_EVENTS_EventActivityLowThrottled(index, _u32, _f32, _b) \
+  this->assertEvents_EventActivityLowThrottled(__FILE__, __LINE__, index, _u32, _f32, _b)
 
 #define ASSERT_EVENTS_EventCommand_SIZE(size) \
   this->assertEvents_EventCommand_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventCommand(size, _str1, _str2) \
-  this->assertEvents_EventCommand(__FILE__, __LINE__, size, _str1, _str2)
+#define ASSERT_EVENTS_EventCommand(index, _str1, _str2) \
+  this->assertEvents_EventCommand(__FILE__, __LINE__, index, _str1, _str2)
 
 #define ASSERT_EVENTS_EventDiagnostic_SIZE(size) \
   this->assertEvents_EventDiagnostic_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventDiagnostic(size, _e) \
-  this->assertEvents_EventDiagnostic(__FILE__, __LINE__, size, _e)
+#define ASSERT_EVENTS_EventDiagnostic(index, _e) \
+  this->assertEvents_EventDiagnostic(__FILE__, __LINE__, index, _e)
 
 #define ASSERT_EVENTS_EventFatalThrottled_SIZE(size) \
   this->assertEvents_EventFatalThrottled_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventFatalThrottled(size, _a) \
-  this->assertEvents_EventFatalThrottled(__FILE__, __LINE__, size, _a)
+#define ASSERT_EVENTS_EventFatalThrottled(index, _a) \
+  this->assertEvents_EventFatalThrottled(__FILE__, __LINE__, index, _a)
 
 #define ASSERT_EVENTS_EventWarningHigh_SIZE(size) \
   this->assertEvents_EventWarningHigh_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventWarningHigh(size, _s) \
-  this->assertEvents_EventWarningHigh(__FILE__, __LINE__, size, _s)
+#define ASSERT_EVENTS_EventWarningHigh(index, _s) \
+  this->assertEvents_EventWarningHigh(__FILE__, __LINE__, index, _s)
 
 #define ASSERT_EVENTS_EventWarningLowThrottled_SIZE(size) \
   this->assertEvents_EventWarningLowThrottled_size(__FILE__, __LINE__, size)

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsGTestBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsGTestBase.ref.hpp
@@ -438,32 +438,32 @@
 #define ASSERT_EVENTS_EventActivityLowThrottled_SIZE(size) \
   this->assertEvents_EventActivityLowThrottled_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventActivityLowThrottled(size, _u32, _f32, _b) \
-  this->assertEvents_EventActivityLowThrottled(__FILE__, __LINE__, size, _u32, _f32, _b)
+#define ASSERT_EVENTS_EventActivityLowThrottled(index, _u32, _f32, _b) \
+  this->assertEvents_EventActivityLowThrottled(__FILE__, __LINE__, index, _u32, _f32, _b)
 
 #define ASSERT_EVENTS_EventCommand_SIZE(size) \
   this->assertEvents_EventCommand_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventCommand(size, _str1, _str2) \
-  this->assertEvents_EventCommand(__FILE__, __LINE__, size, _str1, _str2)
+#define ASSERT_EVENTS_EventCommand(index, _str1, _str2) \
+  this->assertEvents_EventCommand(__FILE__, __LINE__, index, _str1, _str2)
 
 #define ASSERT_EVENTS_EventDiagnostic_SIZE(size) \
   this->assertEvents_EventDiagnostic_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventDiagnostic(size, _e) \
-  this->assertEvents_EventDiagnostic(__FILE__, __LINE__, size, _e)
+#define ASSERT_EVENTS_EventDiagnostic(index, _e) \
+  this->assertEvents_EventDiagnostic(__FILE__, __LINE__, index, _e)
 
 #define ASSERT_EVENTS_EventFatalThrottled_SIZE(size) \
   this->assertEvents_EventFatalThrottled_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventFatalThrottled(size, _a) \
-  this->assertEvents_EventFatalThrottled(__FILE__, __LINE__, size, _a)
+#define ASSERT_EVENTS_EventFatalThrottled(index, _a) \
+  this->assertEvents_EventFatalThrottled(__FILE__, __LINE__, index, _a)
 
 #define ASSERT_EVENTS_EventWarningHigh_SIZE(size) \
   this->assertEvents_EventWarningHigh_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventWarningHigh(size, _s) \
-  this->assertEvents_EventWarningHigh(__FILE__, __LINE__, size, _s)
+#define ASSERT_EVENTS_EventWarningHigh(index, _s) \
+  this->assertEvents_EventWarningHigh(__FILE__, __LINE__, index, _s)
 
 #define ASSERT_EVENTS_EventWarningLowThrottled_SIZE(size) \
   this->assertEvents_EventWarningLowThrottled_size(__FILE__, __LINE__, size)

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialGTestBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialGTestBase.ref.hpp
@@ -448,32 +448,32 @@
 #define ASSERT_EVENTS_EventActivityLowThrottled_SIZE(size) \
   this->assertEvents_EventActivityLowThrottled_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventActivityLowThrottled(size, _u32, _f32, _b) \
-  this->assertEvents_EventActivityLowThrottled(__FILE__, __LINE__, size, _u32, _f32, _b)
+#define ASSERT_EVENTS_EventActivityLowThrottled(index, _u32, _f32, _b) \
+  this->assertEvents_EventActivityLowThrottled(__FILE__, __LINE__, index, _u32, _f32, _b)
 
 #define ASSERT_EVENTS_EventCommand_SIZE(size) \
   this->assertEvents_EventCommand_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventCommand(size, _str1, _str2) \
-  this->assertEvents_EventCommand(__FILE__, __LINE__, size, _str1, _str2)
+#define ASSERT_EVENTS_EventCommand(index, _str1, _str2) \
+  this->assertEvents_EventCommand(__FILE__, __LINE__, index, _str1, _str2)
 
 #define ASSERT_EVENTS_EventDiagnostic_SIZE(size) \
   this->assertEvents_EventDiagnostic_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventDiagnostic(size, _e) \
-  this->assertEvents_EventDiagnostic(__FILE__, __LINE__, size, _e)
+#define ASSERT_EVENTS_EventDiagnostic(index, _e) \
+  this->assertEvents_EventDiagnostic(__FILE__, __LINE__, index, _e)
 
 #define ASSERT_EVENTS_EventFatalThrottled_SIZE(size) \
   this->assertEvents_EventFatalThrottled_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventFatalThrottled(size, _a) \
-  this->assertEvents_EventFatalThrottled(__FILE__, __LINE__, size, _a)
+#define ASSERT_EVENTS_EventFatalThrottled(index, _a) \
+  this->assertEvents_EventFatalThrottled(__FILE__, __LINE__, index, _a)
 
 #define ASSERT_EVENTS_EventWarningHigh_SIZE(size) \
   this->assertEvents_EventWarningHigh_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventWarningHigh(size, _s) \
-  this->assertEvents_EventWarningHigh(__FILE__, __LINE__, size, _s)
+#define ASSERT_EVENTS_EventWarningHigh(index, _s) \
+  this->assertEvents_EventWarningHigh(__FILE__, __LINE__, index, _s)
 
 #define ASSERT_EVENTS_EventWarningLowThrottled_SIZE(size) \
   this->assertEvents_EventWarningLowThrottled_size(__FILE__, __LINE__, size)

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestGTestBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestGTestBase.ref.hpp
@@ -448,32 +448,32 @@
 #define ASSERT_EVENTS_EventActivityLowThrottled_SIZE(size) \
   this->assertEvents_EventActivityLowThrottled_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventActivityLowThrottled(size, _u32, _f32, _b) \
-  this->assertEvents_EventActivityLowThrottled(__FILE__, __LINE__, size, _u32, _f32, _b)
+#define ASSERT_EVENTS_EventActivityLowThrottled(index, _u32, _f32, _b) \
+  this->assertEvents_EventActivityLowThrottled(__FILE__, __LINE__, index, _u32, _f32, _b)
 
 #define ASSERT_EVENTS_EventCommand_SIZE(size) \
   this->assertEvents_EventCommand_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventCommand(size, _str1, _str2) \
-  this->assertEvents_EventCommand(__FILE__, __LINE__, size, _str1, _str2)
+#define ASSERT_EVENTS_EventCommand(index, _str1, _str2) \
+  this->assertEvents_EventCommand(__FILE__, __LINE__, index, _str1, _str2)
 
 #define ASSERT_EVENTS_EventDiagnostic_SIZE(size) \
   this->assertEvents_EventDiagnostic_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventDiagnostic(size, _e) \
-  this->assertEvents_EventDiagnostic(__FILE__, __LINE__, size, _e)
+#define ASSERT_EVENTS_EventDiagnostic(index, _e) \
+  this->assertEvents_EventDiagnostic(__FILE__, __LINE__, index, _e)
 
 #define ASSERT_EVENTS_EventFatalThrottled_SIZE(size) \
   this->assertEvents_EventFatalThrottled_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventFatalThrottled(size, _a) \
-  this->assertEvents_EventFatalThrottled(__FILE__, __LINE__, size, _a)
+#define ASSERT_EVENTS_EventFatalThrottled(index, _a) \
+  this->assertEvents_EventFatalThrottled(__FILE__, __LINE__, index, _a)
 
 #define ASSERT_EVENTS_EventWarningHigh_SIZE(size) \
   this->assertEvents_EventWarningHigh_size(__FILE__, __LINE__, size)
 
-#define ASSERT_EVENTS_EventWarningHigh(size, _s) \
-  this->assertEvents_EventWarningHigh(__FILE__, __LINE__, size, _s)
+#define ASSERT_EVENTS_EventWarningHigh(index, _s) \
+  this->assertEvents_EventWarningHigh(__FILE__, __LINE__, index, _s)
 
 #define ASSERT_EVENTS_EventWarningLowThrottled_SIZE(size) \
   this->assertEvents_EventWarningLowThrottled_size(__FILE__, __LINE__, size)


### PR DESCRIPTION
This PR fixes a naming issue in a macro parameter: `size` instead of `index`.

Closes #1010.