### PR TITLE
Revise Common Type Specification For Concrete Arrays

### DIFF
--- a/docs/fpp-spec.html
+++ b/docs/fpp-spec.html
@@ -13083,9 +13083,38 @@ the enum type or types with the representation type specified in the enum defini
 and reapply these rules.</p>
 </li>
 <li>
-<p>Otherwise if \$T_1\$ or \$T_2\$ or both are array types,
-then replace the array type or types with structurally equivalent
-anonymous array types and reapply these rules.</p>
+<p>Otherwise if T1 and T2 are array types, the attempted resolution is invalid, throw an error.</p>
+</li>
+<li>
+<p>Otherwise if one of \$T_1\$ or \$T_2\$ is an array type \$A\$ equivalent to
+<em>[</em> \$n_1\$ <em>]</em> \$T'\$ and the other is an anonymous array type
+<em>[</em> \$n_2\$ <em>]</em> \$T''\$, then do the following:</p>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p>If \$T''\$ is convertible to \$T'\$ and \$n_1\$ is equal to \$n_2\$,
+let \$T\$ be \$A\$</p>
+</li>
+<li>
+<p>Otherwise the attempted resolution is invalid. Throw an error.</p>
+</li>
+</ol>
+</div>
+</li>
+<li>
+<p>Otherwise if one of \$T_1\$ or \$T_2\$ is an array type \$A\$ equivalent to
+<em>[</em> \$n\$ <em>]</em> \$T'\$ and the other is a type convertible to an anonymous array
+type, \$T''\$, then do the following:</p>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p>If \$T''\$ is convertible to \$T'\$, let \$T\$ be \$A\$</p>
+</li>
+<li>
+<p>Otherwise the attempted resolution is invalid. Throw an error</p>
+</li>
+</ol>
+</div>
 </li>
 <li>
 <p>Otherwise if \$T_1\$ and \$T_2\$ are anonymous array types with the same size \$n\$
@@ -14225,7 +14254,7 @@ equivalent.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-07-08 20:48:50 -0700
+Last updated 2026-07-08 21:21:26 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/spec/Type-Checking.adoc
+++ b/docs/spec/Type-Checking.adoc
@@ -457,9 +457,24 @@ produce the same result.
 the enum type or types with the representation type specified in the enum definitions and
 and reapply these rules.
 
-. Otherwise if stem:[T_1] or stem:[T_2] or both are array types,
-then replace the array type or types with structurally equivalent
-anonymous array types and reapply these rules.
+. Otherwise if T1 and T2 are array types, the attempted resolution is invalid, throw an error.
+
+. Otherwise if one of stem:[T_1] or stem:[T_2] is an array type stem:[A] equivalent to
+_[_ stem:[n_1] _]_ stem:[T'] and the other is an anonymous array type
+_[_ stem:[n_2] _]_ stem:[T''], then do the following:
+
+.. If stem:[T''] is convertible to stem:[T'] and stem:[n_1] is equal to stem:[n_2],
+   let stem:[T] be stem:[A]
+
+.. Otherwise the attempted resolution is invalid. Throw an error.
+
+. Otherwise if one of stem:[T_1] or stem:[T_2] is an array type stem:[A] equivalent to
+_[_ stem:[n] _]_ stem:[T'] and the other is a type convertible to an anonymous array
+type, stem:[T''], then do the following:
+
+.. If stem:[T''] is convertible to stem:[T'], let stem:[T] be stem:[A]
+
+.. Otherwise the attempted resolution is invalid. Throw an error
 
 . Otherwise if stem:[T_1] and stem:[T_2] are anonymous array types with the same size stem:[n]
 and with member types stem:[T'_1] and stem:[T'_2], then apply these rules to resolve


### PR DESCRIPTION
See https://github.com/nasa/fpp/pull/1006#issuecomment-4921285292 for why this change is needed.

One outstanding item here is if we need to revise the common type step that says:

> Otherwise if T1 or T2 or both are struct types, then replace the struct type or types with structurally equivalent anonymous struct types and reapply these rules.
