### PR TITLE
Add serial value constructors for generated enums

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/EnumCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/EnumCppWriter.scala
@@ -199,11 +199,11 @@ case class EnumCppWriter(
                 |}
                 |
                 |//! Constructor (serial representation value)
-                |//! Call isValid() before using the constructed value.
                 |$name(
                 |    const SerialType e1 //!< The serial representation value
                 |)
                 |{
+                |  FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
                 |  this->e = static_cast<enum T>(e1);
                 |}
                 |

--- a/compiler/lib/src/main/scala/codegen/CppWriter/EnumCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/EnumCppWriter.scala
@@ -265,7 +265,8 @@ case class EnumCppWriter(
         ),
         CppDoc.Type(s"$name&"),
         lines(
-          """|this->e = static_cast<enum T>(e1);
+          """|FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
+             |this->e = static_cast<enum T>(e1);
              |#ifdef BUILD_UT
              |this->m_serializeValueIsSet = false;
              |this->m_serializeValue = 0;

--- a/compiler/lib/src/main/scala/codegen/CppWriter/EnumCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/EnumCppWriter.scala
@@ -198,6 +198,15 @@ case class EnumCppWriter(
                 |  this->e = e1;
                 |}
                 |
+                |//! Constructor (serial representation value)
+                |//! Call isValid() before using the constructed value.
+                |$name(
+                |    const SerialType e1 //!< The serial representation value
+                |)
+                |{
+                |  this->e = static_cast<enum T>(e1);
+                |}
+                |
                 |//! Copy constructor
                 |$name(
                 |    const $name& obj //!< The source object
@@ -240,6 +249,26 @@ case class EnumCppWriter(
              |#ifdef BUILD_UT
              |this->m_serializeValueIsSet = obj.m_serializeValueIsSet;
              |this->m_serializeValue = obj.m_serializeValue;
+             |#endif
+             |return *this;"""
+        )
+      ),
+      functionClassMember(
+        Some(s"Assignment operator (serial representation value)"),
+        "operator=",
+        List(
+          CppDoc.Function.Param(
+            CppDoc.Type("SerialType"),
+            "e1",
+            Some("The serial representation value"),
+          ),
+        ),
+        CppDoc.Type(s"$name&"),
+        lines(
+          """|this->e = static_cast<enum T>(e1);
+             |#ifdef BUILD_UT
+             |this->m_serializeValueIsSet = false;
+             |this->m_serializeValue = 0;
              |#endif
              |return *this;"""
         )

--- a/compiler/tools/fpp-to-cpp/test/array/E1EnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/E1EnumAc.ref.cpp
@@ -29,6 +29,7 @@ namespace M {
   E1& E1 ::
     operator=(SerialType e1)
   {
+    FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
     this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
     this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/array/E1EnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/E1EnumAc.ref.cpp
@@ -27,6 +27,17 @@ namespace M {
   }
 
   E1& E1 ::
+    operator=(SerialType e1)
+  {
+    this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+    this->m_serializeValueIsSet = false;
+    this->m_serializeValue = 0;
+#endif
+    return *this;
+  }
+
+  E1& E1 ::
     operator=(enum T e1)
   {
     FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/array/E1EnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/E1EnumAc.ref.hpp
@@ -73,11 +73,11 @@ namespace M {
       }
 
       //! Constructor (serial representation value)
-      //! Call isValid() before using the constructed value.
       E1(
           const SerialType e1 //!< The serial representation value
       )
       {
+        FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
         this->e = static_cast<enum T>(e1);
       }
 

--- a/compiler/tools/fpp-to-cpp/test/array/E1EnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/E1EnumAc.ref.hpp
@@ -72,6 +72,15 @@ namespace M {
         this->e = e1;
       }
 
+      //! Constructor (serial representation value)
+      //! Call isValid() before using the constructed value.
+      E1(
+          const SerialType e1 //!< The serial representation value
+      )
+      {
+        this->e = static_cast<enum T>(e1);
+      }
+
       //! Copy constructor
       E1(
           const E1& obj //!< The source object
@@ -93,6 +102,11 @@ namespace M {
       //! Copy assignment operator (object)
       E1& operator=(
           const E1& obj //!< The source object
+      );
+
+      //! Assignment operator (serial representation value)
+      E1& operator=(
+          SerialType e1 //!< The serial representation value
       );
 
       //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/array/E2EnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/E2EnumAc.ref.cpp
@@ -25,6 +25,17 @@ E2& E2 ::
 }
 
 E2& E2 ::
+  operator=(SerialType e1)
+{
+  this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+  this->m_serializeValueIsSet = false;
+  this->m_serializeValue = 0;
+#endif
+  return *this;
+}
+
+E2& E2 ::
   operator=(enum T e1)
 {
   FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/array/E2EnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/E2EnumAc.ref.cpp
@@ -27,6 +27,7 @@ E2& E2 ::
 E2& E2 ::
   operator=(SerialType e1)
 {
+  FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
   this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
   this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/array/E2EnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/E2EnumAc.ref.hpp
@@ -71,6 +71,15 @@ class E2 :
       this->e = e1;
     }
 
+    //! Constructor (serial representation value)
+    //! Call isValid() before using the constructed value.
+    E2(
+        const SerialType e1 //!< The serial representation value
+    )
+    {
+      this->e = static_cast<enum T>(e1);
+    }
+
     //! Copy constructor
     E2(
         const E2& obj //!< The source object
@@ -92,6 +101,11 @@ class E2 :
     //! Copy assignment operator (object)
     E2& operator=(
         const E2& obj //!< The source object
+    );
+
+    //! Assignment operator (serial representation value)
+    E2& operator=(
+        SerialType e1 //!< The serial representation value
     );
 
     //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/array/E2EnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/E2EnumAc.ref.hpp
@@ -72,11 +72,11 @@ class E2 :
     }
 
     //! Constructor (serial representation value)
-    //! Call isValid() before using the constructed value.
     E2(
         const SerialType e1 //!< The serial representation value
     )
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
     }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/EEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/EEnumAc.ref.cpp
@@ -27,6 +27,7 @@ E& E ::
 E& E ::
   operator=(SerialType e1)
 {
+  FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
   this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
   this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/component/base/EEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/EEnumAc.ref.cpp
@@ -25,6 +25,17 @@ E& E ::
 }
 
 E& E ::
+  operator=(SerialType e1)
+{
+  this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+  this->m_serializeValueIsSet = false;
+  this->m_serializeValue = 0;
+#endif
+  return *this;
+}
+
+E& E ::
   operator=(enum T e1)
 {
   FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/component/base/EEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/EEnumAc.ref.hpp
@@ -70,6 +70,15 @@ class E :
       this->e = e1;
     }
 
+    //! Constructor (serial representation value)
+    //! Call isValid() before using the constructed value.
+    E(
+        const SerialType e1 //!< The serial representation value
+    )
+    {
+      this->e = static_cast<enum T>(e1);
+    }
+
     //! Copy constructor
     E(
         const E& obj //!< The source object
@@ -91,6 +100,11 @@ class E :
     //! Copy assignment operator (object)
     E& operator=(
         const E& obj //!< The source object
+    );
+
+    //! Assignment operator (serial representation value)
+    E& operator=(
+        SerialType e1 //!< The serial representation value
     );
 
     //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/component/base/EEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/EEnumAc.ref.hpp
@@ -71,11 +71,11 @@ class E :
     }
 
     //! Constructor (serial representation value)
-    //! Call isValid() before using the constructed value.
     E(
         const SerialType e1 //!< The serial representation value
     )
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
     }
 

--- a/compiler/tools/fpp-to-cpp/test/enum/AliasSerialTypeEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/AliasSerialTypeEnumAc.ref.cpp
@@ -25,6 +25,17 @@ AliasSerialType& AliasSerialType ::
 }
 
 AliasSerialType& AliasSerialType ::
+  operator=(SerialType e1)
+{
+  this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+  this->m_serializeValueIsSet = false;
+  this->m_serializeValue = 0;
+#endif
+  return *this;
+}
+
+AliasSerialType& AliasSerialType ::
   operator=(enum T e1)
 {
   FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/enum/AliasSerialTypeEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/AliasSerialTypeEnumAc.ref.cpp
@@ -27,6 +27,7 @@ AliasSerialType& AliasSerialType ::
 AliasSerialType& AliasSerialType ::
   operator=(SerialType e1)
 {
+  FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
   this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
   this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/enum/AliasSerialTypeEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/AliasSerialTypeEnumAc.ref.hpp
@@ -70,11 +70,11 @@ class AliasSerialType :
     }
 
     //! Constructor (serial representation value)
-    //! Call isValid() before using the constructed value.
     AliasSerialType(
         const SerialType e1 //!< The serial representation value
     )
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
     }
 

--- a/compiler/tools/fpp-to-cpp/test/enum/AliasSerialTypeEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/AliasSerialTypeEnumAc.ref.hpp
@@ -69,6 +69,15 @@ class AliasSerialType :
       this->e = e1;
     }
 
+    //! Constructor (serial representation value)
+    //! Call isValid() before using the constructed value.
+    AliasSerialType(
+        const SerialType e1 //!< The serial representation value
+    )
+    {
+      this->e = static_cast<enum T>(e1);
+    }
+
     //! Copy constructor
     AliasSerialType(
         const AliasSerialType& obj //!< The source object
@@ -90,6 +99,11 @@ class AliasSerialType :
     //! Copy assignment operator (object)
     AliasSerialType& operator=(
         const AliasSerialType& obj //!< The source object
+    );
+
+    //! Assignment operator (serial representation value)
+    AliasSerialType& operator=(
+        SerialType e1 //!< The serial representation value
     );
 
     //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/enum/C_EEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/C_EEnumAc.ref.cpp
@@ -25,6 +25,17 @@ C_E& C_E ::
 }
 
 C_E& C_E ::
+  operator=(SerialType e1)
+{
+  this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+  this->m_serializeValueIsSet = false;
+  this->m_serializeValue = 0;
+#endif
+  return *this;
+}
+
+C_E& C_E ::
   operator=(enum T e1)
 {
   FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/enum/C_EEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/C_EEnumAc.ref.cpp
@@ -27,6 +27,7 @@ C_E& C_E ::
 C_E& C_E ::
   operator=(SerialType e1)
 {
+  FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
   this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
   this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/enum/C_EEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/C_EEnumAc.ref.hpp
@@ -69,11 +69,11 @@ class C_E :
     }
 
     //! Constructor (serial representation value)
-    //! Call isValid() before using the constructed value.
     C_E(
         const SerialType e1 //!< The serial representation value
     )
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
     }
 

--- a/compiler/tools/fpp-to-cpp/test/enum/C_EEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/C_EEnumAc.ref.hpp
@@ -68,6 +68,15 @@ class C_E :
       this->e = e1;
     }
 
+    //! Constructor (serial representation value)
+    //! Call isValid() before using the constructed value.
+    C_E(
+        const SerialType e1 //!< The serial representation value
+    )
+    {
+      this->e = static_cast<enum T>(e1);
+    }
+
     //! Copy constructor
     C_E(
         const C_E& obj //!< The source object
@@ -89,6 +98,11 @@ class C_E :
     //! Copy assignment operator (object)
     C_E& operator=(
         const C_E& obj //!< The source object
+    );
+
+    //! Assignment operator (serial representation value)
+    C_E& operator=(
+        SerialType e1 //!< The serial representation value
     );
 
     //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/enum/DefaultEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/DefaultEnumAc.ref.cpp
@@ -27,6 +27,17 @@ namespace M {
   }
 
   Default& Default ::
+    operator=(SerialType e1)
+  {
+    this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+    this->m_serializeValueIsSet = false;
+    this->m_serializeValue = 0;
+#endif
+    return *this;
+  }
+
+  Default& Default ::
     operator=(enum T e1)
   {
     FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/enum/DefaultEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/DefaultEnumAc.ref.cpp
@@ -29,6 +29,7 @@ namespace M {
   Default& Default ::
     operator=(SerialType e1)
   {
+    FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
     this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
     this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/enum/DefaultEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/DefaultEnumAc.ref.hpp
@@ -73,11 +73,11 @@ namespace M {
       }
 
       //! Constructor (serial representation value)
-      //! Call isValid() before using the constructed value.
       Default(
           const SerialType e1 //!< The serial representation value
       )
       {
+        FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
         this->e = static_cast<enum T>(e1);
       }
 

--- a/compiler/tools/fpp-to-cpp/test/enum/DefaultEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/DefaultEnumAc.ref.hpp
@@ -72,6 +72,15 @@ namespace M {
         this->e = e1;
       }
 
+      //! Constructor (serial representation value)
+      //! Call isValid() before using the constructed value.
+      Default(
+          const SerialType e1 //!< The serial representation value
+      )
+      {
+        this->e = static_cast<enum T>(e1);
+      }
+
       //! Copy constructor
       Default(
           const Default& obj //!< The source object
@@ -93,6 +102,11 @@ namespace M {
       //! Copy assignment operator (object)
       Default& operator=(
           const Default& obj //!< The source object
+      );
+
+      //! Assignment operator (serial representation value)
+      Default& operator=(
+          SerialType e1 //!< The serial representation value
       );
 
       //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/enum/EEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/EEnumAc.ref.cpp
@@ -27,6 +27,7 @@ E& E ::
 E& E ::
   operator=(SerialType e1)
 {
+  FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
   this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
   this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/enum/EEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/EEnumAc.ref.cpp
@@ -25,6 +25,17 @@ E& E ::
 }
 
 E& E ::
+  operator=(SerialType e1)
+{
+  this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+  this->m_serializeValueIsSet = false;
+  this->m_serializeValue = 0;
+#endif
+  return *this;
+}
+
+E& E ::
   operator=(enum T e1)
 {
   FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/enum/EEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/EEnumAc.ref.hpp
@@ -69,6 +69,15 @@ class E :
       this->e = e1;
     }
 
+    //! Constructor (serial representation value)
+    //! Call isValid() before using the constructed value.
+    E(
+        const SerialType e1 //!< The serial representation value
+    )
+    {
+      this->e = static_cast<enum T>(e1);
+    }
+
     //! Copy constructor
     E(
         const E& obj //!< The source object
@@ -90,6 +99,11 @@ class E :
     //! Copy assignment operator (object)
     E& operator=(
         const E& obj //!< The source object
+    );
+
+    //! Assignment operator (serial representation value)
+    E& operator=(
+        SerialType e1 //!< The serial representation value
     );
 
     //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/enum/EEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/EEnumAc.ref.hpp
@@ -70,11 +70,11 @@ class E :
     }
 
     //! Constructor (serial representation value)
-    //! Call isValid() before using the constructed value.
     E(
         const SerialType e1 //!< The serial representation value
     )
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
     }
 

--- a/compiler/tools/fpp-to-cpp/test/enum/ExplicitEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/ExplicitEnumAc.ref.cpp
@@ -27,6 +27,17 @@ namespace M {
   }
 
   Explicit& Explicit ::
+    operator=(SerialType e1)
+  {
+    this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+    this->m_serializeValueIsSet = false;
+    this->m_serializeValue = 0;
+#endif
+    return *this;
+  }
+
+  Explicit& Explicit ::
     operator=(enum T e1)
   {
     FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/enum/ExplicitEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/ExplicitEnumAc.ref.cpp
@@ -29,6 +29,7 @@ namespace M {
   Explicit& Explicit ::
     operator=(SerialType e1)
   {
+    FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
     this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
     this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/enum/ExplicitEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/ExplicitEnumAc.ref.hpp
@@ -73,11 +73,11 @@ namespace M {
       }
 
       //! Constructor (serial representation value)
-      //! Call isValid() before using the constructed value.
       Explicit(
           const SerialType e1 //!< The serial representation value
       )
       {
+        FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
         this->e = static_cast<enum T>(e1);
       }
 

--- a/compiler/tools/fpp-to-cpp/test/enum/ExplicitEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/ExplicitEnumAc.ref.hpp
@@ -72,6 +72,15 @@ namespace M {
         this->e = e1;
       }
 
+      //! Constructor (serial representation value)
+      //! Call isValid() before using the constructed value.
+      Explicit(
+          const SerialType e1 //!< The serial representation value
+      )
+      {
+        this->e = static_cast<enum T>(e1);
+      }
+
       //! Copy constructor
       Explicit(
           const Explicit& obj //!< The source object
@@ -93,6 +102,11 @@ namespace M {
       //! Copy assignment operator (object)
       Explicit& operator=(
           const Explicit& obj //!< The source object
+      );
+
+      //! Assignment operator (serial representation value)
+      Explicit& operator=(
+          SerialType e1 //!< The serial representation value
       );
 
       //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/enum/ImplicitEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/ImplicitEnumAc.ref.cpp
@@ -27,6 +27,17 @@ namespace M {
   }
 
   Implicit& Implicit ::
+    operator=(SerialType e1)
+  {
+    this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+    this->m_serializeValueIsSet = false;
+    this->m_serializeValue = 0;
+#endif
+    return *this;
+  }
+
+  Implicit& Implicit ::
     operator=(enum T e1)
   {
     FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/enum/ImplicitEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/ImplicitEnumAc.ref.cpp
@@ -29,6 +29,7 @@ namespace M {
   Implicit& Implicit ::
     operator=(SerialType e1)
   {
+    FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
     this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
     this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/enum/ImplicitEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/ImplicitEnumAc.ref.hpp
@@ -72,6 +72,15 @@ namespace M {
         this->e = e1;
       }
 
+      //! Constructor (serial representation value)
+      //! Call isValid() before using the constructed value.
+      Implicit(
+          const SerialType e1 //!< The serial representation value
+      )
+      {
+        this->e = static_cast<enum T>(e1);
+      }
+
       //! Copy constructor
       Implicit(
           const Implicit& obj //!< The source object
@@ -93,6 +102,11 @@ namespace M {
       //! Copy assignment operator (object)
       Implicit& operator=(
           const Implicit& obj //!< The source object
+      );
+
+      //! Assignment operator (serial representation value)
+      Implicit& operator=(
+          SerialType e1 //!< The serial representation value
       );
 
       //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/enum/ImplicitEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/ImplicitEnumAc.ref.hpp
@@ -73,11 +73,11 @@ namespace M {
       }
 
       //! Constructor (serial representation value)
-      //! Call isValid() before using the constructed value.
       Implicit(
           const SerialType e1 //!< The serial representation value
       )
       {
+        FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
         this->e = static_cast<enum T>(e1);
       }
 

--- a/compiler/tools/fpp-to-cpp/test/enum/SM_EEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/SM_EEnumAc.ref.cpp
@@ -25,6 +25,17 @@ SM_E& SM_E ::
 }
 
 SM_E& SM_E ::
+  operator=(SerialType e1)
+{
+  this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+  this->m_serializeValueIsSet = false;
+  this->m_serializeValue = 0;
+#endif
+  return *this;
+}
+
+SM_E& SM_E ::
   operator=(enum T e1)
 {
   FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/enum/SM_EEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/SM_EEnumAc.ref.cpp
@@ -27,6 +27,7 @@ SM_E& SM_E ::
 SM_E& SM_E ::
   operator=(SerialType e1)
 {
+  FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
   this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
   this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/enum/SM_EEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/SM_EEnumAc.ref.hpp
@@ -68,6 +68,15 @@ class SM_E :
       this->e = e1;
     }
 
+    //! Constructor (serial representation value)
+    //! Call isValid() before using the constructed value.
+    SM_E(
+        const SerialType e1 //!< The serial representation value
+    )
+    {
+      this->e = static_cast<enum T>(e1);
+    }
+
     //! Copy constructor
     SM_E(
         const SM_E& obj //!< The source object
@@ -89,6 +98,11 @@ class SM_E :
     //! Copy assignment operator (object)
     SM_E& operator=(
         const SM_E& obj //!< The source object
+    );
+
+    //! Assignment operator (serial representation value)
+    SM_E& operator=(
+        SerialType e1 //!< The serial representation value
     );
 
     //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/enum/SM_EEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/SM_EEnumAc.ref.hpp
@@ -69,11 +69,11 @@ class SM_E :
     }
 
     //! Constructor (serial representation value)
-    //! Call isValid() before using the constructed value.
     SM_E(
         const SerialType e1 //!< The serial representation value
     )
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
     }
 

--- a/compiler/tools/fpp-to-cpp/test/enum/SerializeTypeEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/SerializeTypeEnumAc.ref.cpp
@@ -27,6 +27,17 @@ namespace M {
   }
 
   SerializeType& SerializeType ::
+    operator=(SerialType e1)
+  {
+    this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+    this->m_serializeValueIsSet = false;
+    this->m_serializeValue = 0;
+#endif
+    return *this;
+  }
+
+  SerializeType& SerializeType ::
     operator=(enum T e1)
   {
     FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/enum/SerializeTypeEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/SerializeTypeEnumAc.ref.cpp
@@ -29,6 +29,7 @@ namespace M {
   SerializeType& SerializeType ::
     operator=(SerialType e1)
   {
+    FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
     this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
     this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/enum/SerializeTypeEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/SerializeTypeEnumAc.ref.hpp
@@ -72,6 +72,15 @@ namespace M {
         this->e = e1;
       }
 
+      //! Constructor (serial representation value)
+      //! Call isValid() before using the constructed value.
+      SerializeType(
+          const SerialType e1 //!< The serial representation value
+      )
+      {
+        this->e = static_cast<enum T>(e1);
+      }
+
       //! Copy constructor
       SerializeType(
           const SerializeType& obj //!< The source object
@@ -93,6 +102,11 @@ namespace M {
       //! Copy assignment operator (object)
       SerializeType& operator=(
           const SerializeType& obj //!< The source object
+      );
+
+      //! Assignment operator (serial representation value)
+      SerializeType& operator=(
+          SerialType e1 //!< The serial representation value
       );
 
       //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/enum/SerializeTypeEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/SerializeTypeEnumAc.ref.hpp
@@ -73,11 +73,11 @@ namespace M {
       }
 
       //! Constructor (serial representation value)
-      //! Call isValid() before using the constructed value.
       SerializeType(
           const SerialType e1 //!< The serial representation value
       )
       {
+        FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
         this->e = static_cast<enum T>(e1);
       }
 

--- a/compiler/tools/fpp-to-cpp/test/enum/SingletonRangeEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/SingletonRangeEnumAc.ref.cpp
@@ -25,6 +25,17 @@ SingletonRange& SingletonRange ::
 }
 
 SingletonRange& SingletonRange ::
+  operator=(SerialType e1)
+{
+  this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+  this->m_serializeValueIsSet = false;
+  this->m_serializeValue = 0;
+#endif
+  return *this;
+}
+
+SingletonRange& SingletonRange ::
   operator=(enum T e1)
 {
   FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/enum/SingletonRangeEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/SingletonRangeEnumAc.ref.cpp
@@ -27,6 +27,7 @@ SingletonRange& SingletonRange ::
 SingletonRange& SingletonRange ::
   operator=(SerialType e1)
 {
+  FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
   this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
   this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/enum/SingletonRangeEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/SingletonRangeEnumAc.ref.hpp
@@ -69,6 +69,15 @@ class SingletonRange :
       this->e = e1;
     }
 
+    //! Constructor (serial representation value)
+    //! Call isValid() before using the constructed value.
+    SingletonRange(
+        const SerialType e1 //!< The serial representation value
+    )
+    {
+      this->e = static_cast<enum T>(e1);
+    }
+
     //! Copy constructor
     SingletonRange(
         const SingletonRange& obj //!< The source object
@@ -90,6 +99,11 @@ class SingletonRange :
     //! Copy assignment operator (object)
     SingletonRange& operator=(
         const SingletonRange& obj //!< The source object
+    );
+
+    //! Assignment operator (serial representation value)
+    SingletonRange& operator=(
+        SerialType e1 //!< The serial representation value
     );
 
     //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/enum/SingletonRangeEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/SingletonRangeEnumAc.ref.hpp
@@ -70,11 +70,11 @@ class SingletonRange :
     }
 
     //! Constructor (serial representation value)
-    //! Call isValid() before using the constructed value.
     SingletonRange(
         const SerialType e1 //!< The serial representation value
     )
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
     }
 

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/BasicU32_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/BasicU32_StateEnumAc.ref.cpp
@@ -31,6 +31,7 @@ namespace FppTest {
     BasicU32_State& BasicU32_State ::
       operator=(SerialType e1)
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
       this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/BasicU32_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/BasicU32_StateEnumAc.ref.cpp
@@ -29,6 +29,17 @@ namespace FppTest {
     }
 
     BasicU32_State& BasicU32_State ::
+      operator=(SerialType e1)
+    {
+      this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+      this->m_serializeValueIsSet = false;
+      this->m_serializeValue = 0;
+#endif
+      return *this;
+    }
+
+    BasicU32_State& BasicU32_State ::
       operator=(enum T e1)
     {
       FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/BasicU32_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/BasicU32_StateEnumAc.ref.hpp
@@ -78,6 +78,15 @@ namespace FppTest {
           this->e = e1;
         }
 
+        //! Constructor (serial representation value)
+        //! Call isValid() before using the constructed value.
+        BasicU32_State(
+            const SerialType e1 //!< The serial representation value
+        )
+        {
+          this->e = static_cast<enum T>(e1);
+        }
+
         //! Copy constructor
         BasicU32_State(
             const BasicU32_State& obj //!< The source object
@@ -99,6 +108,11 @@ namespace FppTest {
         //! Copy assignment operator (object)
         BasicU32_State& operator=(
             const BasicU32_State& obj //!< The source object
+        );
+
+        //! Assignment operator (serial representation value)
+        BasicU32_State& operator=(
+            SerialType e1 //!< The serial representation value
         );
 
         //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/BasicU32_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/BasicU32_StateEnumAc.ref.hpp
@@ -79,11 +79,11 @@ namespace FppTest {
         }
 
         //! Constructor (serial representation value)
-        //! Call isValid() before using the constructed value.
         BasicU32_State(
             const SerialType e1 //!< The serial representation value
         )
         {
+          FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
           this->e = static_cast<enum T>(e1);
         }
 

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/Basic_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/Basic_StateEnumAc.ref.cpp
@@ -29,6 +29,17 @@ namespace FppTest {
     }
 
     Basic_State& Basic_State ::
+      operator=(SerialType e1)
+    {
+      this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+      this->m_serializeValueIsSet = false;
+      this->m_serializeValue = 0;
+#endif
+      return *this;
+    }
+
+    Basic_State& Basic_State ::
       operator=(enum T e1)
     {
       FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/Basic_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/Basic_StateEnumAc.ref.cpp
@@ -31,6 +31,7 @@ namespace FppTest {
     Basic_State& Basic_State ::
       operator=(SerialType e1)
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
       this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/Basic_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/Basic_StateEnumAc.ref.hpp
@@ -79,11 +79,11 @@ namespace FppTest {
         }
 
         //! Constructor (serial representation value)
-        //! Call isValid() before using the constructed value.
         Basic_State(
             const SerialType e1 //!< The serial representation value
         )
         {
+          FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
           this->e = static_cast<enum T>(e1);
         }
 

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/Basic_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/Basic_StateEnumAc.ref.hpp
@@ -78,6 +78,15 @@ namespace FppTest {
           this->e = e1;
         }
 
+        //! Constructor (serial representation value)
+        //! Call isValid() before using the constructed value.
+        Basic_State(
+            const SerialType e1 //!< The serial representation value
+        )
+        {
+          this->e = static_cast<enum T>(e1);
+        }
+
         //! Copy constructor
         Basic_State(
             const Basic_State& obj //!< The source object
@@ -99,6 +108,11 @@ namespace FppTest {
         //! Copy assignment operator (object)
         Basic_State& operator=(
             const Basic_State& obj //!< The source object
+        );
+
+        //! Assignment operator (serial representation value)
+        Basic_State& operator=(
+            SerialType e1 //!< The serial representation value
         );
 
         //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/ChoiceToChoice_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/ChoiceToChoice_StateEnumAc.ref.cpp
@@ -29,6 +29,17 @@ namespace FppTest {
     }
 
     ChoiceToChoice_State& ChoiceToChoice_State ::
+      operator=(SerialType e1)
+    {
+      this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+      this->m_serializeValueIsSet = false;
+      this->m_serializeValue = 0;
+#endif
+      return *this;
+    }
+
+    ChoiceToChoice_State& ChoiceToChoice_State ::
       operator=(enum T e1)
     {
       FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/ChoiceToChoice_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/ChoiceToChoice_StateEnumAc.ref.cpp
@@ -31,6 +31,7 @@ namespace FppTest {
     ChoiceToChoice_State& ChoiceToChoice_State ::
       operator=(SerialType e1)
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
       this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/ChoiceToChoice_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/ChoiceToChoice_StateEnumAc.ref.hpp
@@ -79,11 +79,11 @@ namespace FppTest {
         }
 
         //! Constructor (serial representation value)
-        //! Call isValid() before using the constructed value.
         ChoiceToChoice_State(
             const SerialType e1 //!< The serial representation value
         )
         {
+          FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
           this->e = static_cast<enum T>(e1);
         }
 

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/ChoiceToChoice_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/ChoiceToChoice_StateEnumAc.ref.hpp
@@ -78,6 +78,15 @@ namespace FppTest {
           this->e = e1;
         }
 
+        //! Constructor (serial representation value)
+        //! Call isValid() before using the constructed value.
+        ChoiceToChoice_State(
+            const SerialType e1 //!< The serial representation value
+        )
+        {
+          this->e = static_cast<enum T>(e1);
+        }
+
         //! Copy constructor
         ChoiceToChoice_State(
             const ChoiceToChoice_State& obj //!< The source object
@@ -99,6 +108,11 @@ namespace FppTest {
         //! Copy assignment operator (object)
         ChoiceToChoice_State& operator=(
             const ChoiceToChoice_State& obj //!< The source object
+        );
+
+        //! Assignment operator (serial representation value)
+        ChoiceToChoice_State& operator=(
+            SerialType e1 //!< The serial representation value
         );
 
         //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/ChoiceToState_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/ChoiceToState_StateEnumAc.ref.cpp
@@ -31,6 +31,7 @@ namespace FppTest {
     ChoiceToState_State& ChoiceToState_State ::
       operator=(SerialType e1)
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
       this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/ChoiceToState_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/ChoiceToState_StateEnumAc.ref.cpp
@@ -29,6 +29,17 @@ namespace FppTest {
     }
 
     ChoiceToState_State& ChoiceToState_State ::
+      operator=(SerialType e1)
+    {
+      this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+      this->m_serializeValueIsSet = false;
+      this->m_serializeValue = 0;
+#endif
+      return *this;
+    }
+
+    ChoiceToState_State& ChoiceToState_State ::
       operator=(enum T e1)
     {
       FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/ChoiceToState_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/ChoiceToState_StateEnumAc.ref.hpp
@@ -77,11 +77,11 @@ namespace FppTest {
         }
 
         //! Constructor (serial representation value)
-        //! Call isValid() before using the constructed value.
         ChoiceToState_State(
             const SerialType e1 //!< The serial representation value
         )
         {
+          FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
           this->e = static_cast<enum T>(e1);
         }
 

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/ChoiceToState_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/ChoiceToState_StateEnumAc.ref.hpp
@@ -76,6 +76,15 @@ namespace FppTest {
           this->e = e1;
         }
 
+        //! Constructor (serial representation value)
+        //! Call isValid() before using the constructed value.
+        ChoiceToState_State(
+            const SerialType e1 //!< The serial representation value
+        )
+        {
+          this->e = static_cast<enum T>(e1);
+        }
+
         //! Copy constructor
         ChoiceToState_State(
             const ChoiceToState_State& obj //!< The source object
@@ -97,6 +106,11 @@ namespace FppTest {
         //! Copy assignment operator (object)
         ChoiceToState_State& operator=(
             const ChoiceToState_State& obj //!< The source object
+        );
+
+        //! Assignment operator (serial representation value)
+        ChoiceToState_State& operator=(
+            SerialType e1 //!< The serial representation value
         );
 
         //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/InputPairU16U32_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/InputPairU16U32_StateEnumAc.ref.cpp
@@ -31,6 +31,7 @@ namespace FppTest {
     InputPairU16U32_State& InputPairU16U32_State ::
       operator=(SerialType e1)
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
       this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/InputPairU16U32_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/InputPairU16U32_StateEnumAc.ref.cpp
@@ -29,6 +29,17 @@ namespace FppTest {
     }
 
     InputPairU16U32_State& InputPairU16U32_State ::
+      operator=(SerialType e1)
+    {
+      this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+      this->m_serializeValueIsSet = false;
+      this->m_serializeValue = 0;
+#endif
+      return *this;
+    }
+
+    InputPairU16U32_State& InputPairU16U32_State ::
       operator=(enum T e1)
     {
       FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/InputPairU16U32_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/InputPairU16U32_StateEnumAc.ref.hpp
@@ -79,11 +79,11 @@ namespace FppTest {
         }
 
         //! Constructor (serial representation value)
-        //! Call isValid() before using the constructed value.
         InputPairU16U32_State(
             const SerialType e1 //!< The serial representation value
         )
         {
+          FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
           this->e = static_cast<enum T>(e1);
         }
 

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/InputPairU16U32_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/InputPairU16U32_StateEnumAc.ref.hpp
@@ -78,6 +78,15 @@ namespace FppTest {
           this->e = e1;
         }
 
+        //! Constructor (serial representation value)
+        //! Call isValid() before using the constructed value.
+        InputPairU16U32_State(
+            const SerialType e1 //!< The serial representation value
+        )
+        {
+          this->e = static_cast<enum T>(e1);
+        }
+
         //! Copy constructor
         InputPairU16U32_State(
             const InputPairU16U32_State& obj //!< The source object
@@ -99,6 +108,11 @@ namespace FppTest {
         //! Copy assignment operator (object)
         InputPairU16U32_State& operator=(
             const InputPairU16U32_State& obj //!< The source object
+        );
+
+        //! Assignment operator (serial representation value)
+        InputPairU16U32_State& operator=(
+            SerialType e1 //!< The serial representation value
         );
 
         //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/SequenceU32_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/SequenceU32_StateEnumAc.ref.cpp
@@ -31,6 +31,7 @@ namespace FppTest {
     SequenceU32_State& SequenceU32_State ::
       operator=(SerialType e1)
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
       this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/SequenceU32_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/SequenceU32_StateEnumAc.ref.cpp
@@ -29,6 +29,17 @@ namespace FppTest {
     }
 
     SequenceU32_State& SequenceU32_State ::
+      operator=(SerialType e1)
+    {
+      this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+      this->m_serializeValueIsSet = false;
+      this->m_serializeValue = 0;
+#endif
+      return *this;
+    }
+
+    SequenceU32_State& SequenceU32_State ::
       operator=(enum T e1)
     {
       FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/SequenceU32_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/SequenceU32_StateEnumAc.ref.hpp
@@ -80,6 +80,15 @@ namespace FppTest {
           this->e = e1;
         }
 
+        //! Constructor (serial representation value)
+        //! Call isValid() before using the constructed value.
+        SequenceU32_State(
+            const SerialType e1 //!< The serial representation value
+        )
+        {
+          this->e = static_cast<enum T>(e1);
+        }
+
         //! Copy constructor
         SequenceU32_State(
             const SequenceU32_State& obj //!< The source object
@@ -101,6 +110,11 @@ namespace FppTest {
         //! Copy assignment operator (object)
         SequenceU32_State& operator=(
             const SequenceU32_State& obj //!< The source object
+        );
+
+        //! Assignment operator (serial representation value)
+        SequenceU32_State& operator=(
+            SerialType e1 //!< The serial representation value
         );
 
         //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/SequenceU32_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/SequenceU32_StateEnumAc.ref.hpp
@@ -81,11 +81,11 @@ namespace FppTest {
         }
 
         //! Constructor (serial representation value)
-        //! Call isValid() before using the constructed value.
         SequenceU32_State(
             const SerialType e1 //!< The serial representation value
         )
         {
+          FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
           this->e = static_cast<enum T>(e1);
         }
 

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/Sequence_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/Sequence_StateEnumAc.ref.cpp
@@ -29,6 +29,17 @@ namespace FppTest {
     }
 
     Sequence_State& Sequence_State ::
+      operator=(SerialType e1)
+    {
+      this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+      this->m_serializeValueIsSet = false;
+      this->m_serializeValue = 0;
+#endif
+      return *this;
+    }
+
+    Sequence_State& Sequence_State ::
       operator=(enum T e1)
     {
       FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/Sequence_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/Sequence_StateEnumAc.ref.cpp
@@ -31,6 +31,7 @@ namespace FppTest {
     Sequence_State& Sequence_State ::
       operator=(SerialType e1)
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
       this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/Sequence_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/Sequence_StateEnumAc.ref.hpp
@@ -81,11 +81,11 @@ namespace FppTest {
         }
 
         //! Constructor (serial representation value)
-        //! Call isValid() before using the constructed value.
         Sequence_State(
             const SerialType e1 //!< The serial representation value
         )
         {
+          FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
           this->e = static_cast<enum T>(e1);
         }
 

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/Sequence_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/Sequence_StateEnumAc.ref.hpp
@@ -80,6 +80,15 @@ namespace FppTest {
           this->e = e1;
         }
 
+        //! Constructor (serial representation value)
+        //! Call isValid() before using the constructed value.
+        Sequence_State(
+            const SerialType e1 //!< The serial representation value
+        )
+        {
+          this->e = static_cast<enum T>(e1);
+        }
+
         //! Copy constructor
         Sequence_State(
             const Sequence_State& obj //!< The source object
@@ -101,6 +110,11 @@ namespace FppTest {
         //! Copy assignment operator (object)
         Sequence_State& operator=(
             const Sequence_State& obj //!< The source object
+        );
+
+        //! Assignment operator (serial representation value)
+        Sequence_State& operator=(
+            SerialType e1 //!< The serial representation value
         );
 
         //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/state-machine/initial/Basic_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/initial/Basic_StateEnumAc.ref.cpp
@@ -29,6 +29,17 @@ namespace FppTest {
     }
 
     Basic_State& Basic_State ::
+      operator=(SerialType e1)
+    {
+      this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+      this->m_serializeValueIsSet = false;
+      this->m_serializeValue = 0;
+#endif
+      return *this;
+    }
+
+    Basic_State& Basic_State ::
       operator=(enum T e1)
     {
       FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/state-machine/initial/Basic_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/initial/Basic_StateEnumAc.ref.cpp
@@ -31,6 +31,7 @@ namespace FppTest {
     Basic_State& Basic_State ::
       operator=(SerialType e1)
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
       this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/state-machine/initial/Basic_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/initial/Basic_StateEnumAc.ref.hpp
@@ -74,6 +74,15 @@ namespace FppTest {
           this->e = e1;
         }
 
+        //! Constructor (serial representation value)
+        //! Call isValid() before using the constructed value.
+        Basic_State(
+            const SerialType e1 //!< The serial representation value
+        )
+        {
+          this->e = static_cast<enum T>(e1);
+        }
+
         //! Copy constructor
         Basic_State(
             const Basic_State& obj //!< The source object
@@ -95,6 +104,11 @@ namespace FppTest {
         //! Copy assignment operator (object)
         Basic_State& operator=(
             const Basic_State& obj //!< The source object
+        );
+
+        //! Assignment operator (serial representation value)
+        Basic_State& operator=(
+            SerialType e1 //!< The serial representation value
         );
 
         //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/state-machine/initial/Basic_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/initial/Basic_StateEnumAc.ref.hpp
@@ -75,11 +75,11 @@ namespace FppTest {
         }
 
         //! Constructor (serial representation value)
-        //! Call isValid() before using the constructed value.
         Basic_State(
             const SerialType e1 //!< The serial representation value
         )
         {
+          FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
           this->e = static_cast<enum T>(e1);
         }
 

--- a/compiler/tools/fpp-to-cpp/test/state-machine/initial/Choice_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/initial/Choice_StateEnumAc.ref.cpp
@@ -31,6 +31,7 @@ namespace FppTest {
     Choice_State& Choice_State ::
       operator=(SerialType e1)
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
       this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/state-machine/initial/Choice_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/initial/Choice_StateEnumAc.ref.cpp
@@ -29,6 +29,17 @@ namespace FppTest {
     }
 
     Choice_State& Choice_State ::
+      operator=(SerialType e1)
+    {
+      this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+      this->m_serializeValueIsSet = false;
+      this->m_serializeValue = 0;
+#endif
+      return *this;
+    }
+
+    Choice_State& Choice_State ::
       operator=(enum T e1)
     {
       FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/state-machine/initial/Choice_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/initial/Choice_StateEnumAc.ref.hpp
@@ -77,11 +77,11 @@ namespace FppTest {
         }
 
         //! Constructor (serial representation value)
-        //! Call isValid() before using the constructed value.
         Choice_State(
             const SerialType e1 //!< The serial representation value
         )
         {
+          FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
           this->e = static_cast<enum T>(e1);
         }
 

--- a/compiler/tools/fpp-to-cpp/test/state-machine/initial/Choice_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/initial/Choice_StateEnumAc.ref.hpp
@@ -76,6 +76,15 @@ namespace FppTest {
           this->e = e1;
         }
 
+        //! Constructor (serial representation value)
+        //! Call isValid() before using the constructed value.
+        Choice_State(
+            const SerialType e1 //!< The serial representation value
+        )
+        {
+          this->e = static_cast<enum T>(e1);
+        }
+
         //! Copy constructor
         Choice_State(
             const Choice_State& obj //!< The source object
@@ -97,6 +106,11 @@ namespace FppTest {
         //! Copy assignment operator (object)
         Choice_State& operator=(
             const Choice_State& obj //!< The source object
+        );
+
+        //! Assignment operator (serial representation value)
+        Choice_State& operator=(
+            SerialType e1 //!< The serial representation value
         );
 
         //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/state-machine/initial/Nested_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/initial/Nested_StateEnumAc.ref.cpp
@@ -31,6 +31,7 @@ namespace FppTest {
     Nested_State& Nested_State ::
       operator=(SerialType e1)
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
       this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/state-machine/initial/Nested_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/initial/Nested_StateEnumAc.ref.cpp
@@ -29,6 +29,17 @@ namespace FppTest {
     }
 
     Nested_State& Nested_State ::
+      operator=(SerialType e1)
+    {
+      this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+      this->m_serializeValueIsSet = false;
+      this->m_serializeValue = 0;
+#endif
+      return *this;
+    }
+
+    Nested_State& Nested_State ::
       operator=(enum T e1)
     {
       FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/state-machine/initial/Nested_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/initial/Nested_StateEnumAc.ref.hpp
@@ -75,11 +75,11 @@ namespace FppTest {
         }
 
         //! Constructor (serial representation value)
-        //! Call isValid() before using the constructed value.
         Nested_State(
             const SerialType e1 //!< The serial representation value
         )
         {
+          FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
           this->e = static_cast<enum T>(e1);
         }
 

--- a/compiler/tools/fpp-to-cpp/test/state-machine/initial/Nested_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/initial/Nested_StateEnumAc.ref.hpp
@@ -74,6 +74,15 @@ namespace FppTest {
           this->e = e1;
         }
 
+        //! Constructor (serial representation value)
+        //! Call isValid() before using the constructed value.
+        Nested_State(
+            const SerialType e1 //!< The serial representation value
+        )
+        {
+          this->e = static_cast<enum T>(e1);
+        }
+
         //! Copy constructor
         Nested_State(
             const Nested_State& obj //!< The source object
@@ -95,6 +104,11 @@ namespace FppTest {
         //! Copy assignment operator (object)
         Nested_State& operator=(
             const Nested_State& obj //!< The source object
+        );
+
+        //! Assignment operator (serial representation value)
+        Nested_State& operator=(
+            SerialType e1 //!< The serial representation value
         );
 
         //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardString_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardString_StateEnumAc.ref.cpp
@@ -31,6 +31,7 @@ namespace FppTest {
     BasicGuardString_State& BasicGuardString_State ::
       operator=(SerialType e1)
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
       this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardString_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardString_StateEnumAc.ref.cpp
@@ -29,6 +29,17 @@ namespace FppTest {
     }
 
     BasicGuardString_State& BasicGuardString_State ::
+      operator=(SerialType e1)
+    {
+      this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+      this->m_serializeValueIsSet = false;
+      this->m_serializeValue = 0;
+#endif
+      return *this;
+    }
+
+    BasicGuardString_State& BasicGuardString_State ::
       operator=(enum T e1)
     {
       FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardString_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardString_StateEnumAc.ref.hpp
@@ -77,11 +77,11 @@ namespace FppTest {
         }
 
         //! Constructor (serial representation value)
-        //! Call isValid() before using the constructed value.
         BasicGuardString_State(
             const SerialType e1 //!< The serial representation value
         )
         {
+          FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
           this->e = static_cast<enum T>(e1);
         }
 

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardString_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardString_StateEnumAc.ref.hpp
@@ -76,6 +76,15 @@ namespace FppTest {
           this->e = e1;
         }
 
+        //! Constructor (serial representation value)
+        //! Call isValid() before using the constructed value.
+        BasicGuardString_State(
+            const SerialType e1 //!< The serial representation value
+        )
+        {
+          this->e = static_cast<enum T>(e1);
+        }
+
         //! Copy constructor
         BasicGuardString_State(
             const BasicGuardString_State& obj //!< The source object
@@ -97,6 +106,11 @@ namespace FppTest {
         //! Copy assignment operator (object)
         BasicGuardString_State& operator=(
             const BasicGuardString_State& obj //!< The source object
+        );
+
+        //! Assignment operator (serial representation value)
+        BasicGuardString_State& operator=(
+            SerialType e1 //!< The serial representation value
         );
 
         //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestAbsType_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestAbsType_StateEnumAc.ref.cpp
@@ -29,6 +29,17 @@ namespace FppTest {
     }
 
     BasicGuardTestAbsType_State& BasicGuardTestAbsType_State ::
+      operator=(SerialType e1)
+    {
+      this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+      this->m_serializeValueIsSet = false;
+      this->m_serializeValue = 0;
+#endif
+      return *this;
+    }
+
+    BasicGuardTestAbsType_State& BasicGuardTestAbsType_State ::
       operator=(enum T e1)
     {
       FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestAbsType_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestAbsType_StateEnumAc.ref.cpp
@@ -31,6 +31,7 @@ namespace FppTest {
     BasicGuardTestAbsType_State& BasicGuardTestAbsType_State ::
       operator=(SerialType e1)
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
       this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestAbsType_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestAbsType_StateEnumAc.ref.hpp
@@ -77,11 +77,11 @@ namespace FppTest {
         }
 
         //! Constructor (serial representation value)
-        //! Call isValid() before using the constructed value.
         BasicGuardTestAbsType_State(
             const SerialType e1 //!< The serial representation value
         )
         {
+          FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
           this->e = static_cast<enum T>(e1);
         }
 

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestAbsType_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestAbsType_StateEnumAc.ref.hpp
@@ -76,6 +76,15 @@ namespace FppTest {
           this->e = e1;
         }
 
+        //! Constructor (serial representation value)
+        //! Call isValid() before using the constructed value.
+        BasicGuardTestAbsType_State(
+            const SerialType e1 //!< The serial representation value
+        )
+        {
+          this->e = static_cast<enum T>(e1);
+        }
+
         //! Copy constructor
         BasicGuardTestAbsType_State(
             const BasicGuardTestAbsType_State& obj //!< The source object
@@ -97,6 +106,11 @@ namespace FppTest {
         //! Copy assignment operator (object)
         BasicGuardTestAbsType_State& operator=(
             const BasicGuardTestAbsType_State& obj //!< The source object
+        );
+
+        //! Assignment operator (serial representation value)
+        BasicGuardTestAbsType_State& operator=(
+            SerialType e1 //!< The serial representation value
         );
 
         //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestArray_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestArray_StateEnumAc.ref.cpp
@@ -29,6 +29,17 @@ namespace FppTest {
     }
 
     BasicGuardTestArray_State& BasicGuardTestArray_State ::
+      operator=(SerialType e1)
+    {
+      this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+      this->m_serializeValueIsSet = false;
+      this->m_serializeValue = 0;
+#endif
+      return *this;
+    }
+
+    BasicGuardTestArray_State& BasicGuardTestArray_State ::
       operator=(enum T e1)
     {
       FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestArray_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestArray_StateEnumAc.ref.cpp
@@ -31,6 +31,7 @@ namespace FppTest {
     BasicGuardTestArray_State& BasicGuardTestArray_State ::
       operator=(SerialType e1)
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
       this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestArray_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestArray_StateEnumAc.ref.hpp
@@ -77,11 +77,11 @@ namespace FppTest {
         }
 
         //! Constructor (serial representation value)
-        //! Call isValid() before using the constructed value.
         BasicGuardTestArray_State(
             const SerialType e1 //!< The serial representation value
         )
         {
+          FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
           this->e = static_cast<enum T>(e1);
         }
 

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestArray_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestArray_StateEnumAc.ref.hpp
@@ -76,6 +76,15 @@ namespace FppTest {
           this->e = e1;
         }
 
+        //! Constructor (serial representation value)
+        //! Call isValid() before using the constructed value.
+        BasicGuardTestArray_State(
+            const SerialType e1 //!< The serial representation value
+        )
+        {
+          this->e = static_cast<enum T>(e1);
+        }
+
         //! Copy constructor
         BasicGuardTestArray_State(
             const BasicGuardTestArray_State& obj //!< The source object
@@ -97,6 +106,11 @@ namespace FppTest {
         //! Copy assignment operator (object)
         BasicGuardTestArray_State& operator=(
             const BasicGuardTestArray_State& obj //!< The source object
+        );
+
+        //! Assignment operator (serial representation value)
+        BasicGuardTestArray_State& operator=(
+            SerialType e1 //!< The serial representation value
         );
 
         //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestEnum_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestEnum_StateEnumAc.ref.cpp
@@ -29,6 +29,17 @@ namespace FppTest {
     }
 
     BasicGuardTestEnum_State& BasicGuardTestEnum_State ::
+      operator=(SerialType e1)
+    {
+      this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+      this->m_serializeValueIsSet = false;
+      this->m_serializeValue = 0;
+#endif
+      return *this;
+    }
+
+    BasicGuardTestEnum_State& BasicGuardTestEnum_State ::
       operator=(enum T e1)
     {
       FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestEnum_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestEnum_StateEnumAc.ref.cpp
@@ -31,6 +31,7 @@ namespace FppTest {
     BasicGuardTestEnum_State& BasicGuardTestEnum_State ::
       operator=(SerialType e1)
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
       this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestEnum_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestEnum_StateEnumAc.ref.hpp
@@ -77,11 +77,11 @@ namespace FppTest {
         }
 
         //! Constructor (serial representation value)
-        //! Call isValid() before using the constructed value.
         BasicGuardTestEnum_State(
             const SerialType e1 //!< The serial representation value
         )
         {
+          FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
           this->e = static_cast<enum T>(e1);
         }
 

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestEnum_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestEnum_StateEnumAc.ref.hpp
@@ -76,6 +76,15 @@ namespace FppTest {
           this->e = e1;
         }
 
+        //! Constructor (serial representation value)
+        //! Call isValid() before using the constructed value.
+        BasicGuardTestEnum_State(
+            const SerialType e1 //!< The serial representation value
+        )
+        {
+          this->e = static_cast<enum T>(e1);
+        }
+
         //! Copy constructor
         BasicGuardTestEnum_State(
             const BasicGuardTestEnum_State& obj //!< The source object
@@ -97,6 +106,11 @@ namespace FppTest {
         //! Copy assignment operator (object)
         BasicGuardTestEnum_State& operator=(
             const BasicGuardTestEnum_State& obj //!< The source object
+        );
+
+        //! Assignment operator (serial representation value)
+        BasicGuardTestEnum_State& operator=(
+            SerialType e1 //!< The serial representation value
         );
 
         //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestStruct_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestStruct_StateEnumAc.ref.cpp
@@ -31,6 +31,7 @@ namespace FppTest {
     BasicGuardTestStruct_State& BasicGuardTestStruct_State ::
       operator=(SerialType e1)
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
       this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestStruct_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestStruct_StateEnumAc.ref.cpp
@@ -29,6 +29,17 @@ namespace FppTest {
     }
 
     BasicGuardTestStruct_State& BasicGuardTestStruct_State ::
+      operator=(SerialType e1)
+    {
+      this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+      this->m_serializeValueIsSet = false;
+      this->m_serializeValue = 0;
+#endif
+      return *this;
+    }
+
+    BasicGuardTestStruct_State& BasicGuardTestStruct_State ::
       operator=(enum T e1)
     {
       FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestStruct_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestStruct_StateEnumAc.ref.hpp
@@ -77,11 +77,11 @@ namespace FppTest {
         }
 
         //! Constructor (serial representation value)
-        //! Call isValid() before using the constructed value.
         BasicGuardTestStruct_State(
             const SerialType e1 //!< The serial representation value
         )
         {
+          FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
           this->e = static_cast<enum T>(e1);
         }
 

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestStruct_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestStruct_StateEnumAc.ref.hpp
@@ -76,6 +76,15 @@ namespace FppTest {
           this->e = e1;
         }
 
+        //! Constructor (serial representation value)
+        //! Call isValid() before using the constructed value.
+        BasicGuardTestStruct_State(
+            const SerialType e1 //!< The serial representation value
+        )
+        {
+          this->e = static_cast<enum T>(e1);
+        }
+
         //! Copy constructor
         BasicGuardTestStruct_State(
             const BasicGuardTestStruct_State& obj //!< The source object
@@ -97,6 +106,11 @@ namespace FppTest {
         //! Copy assignment operator (object)
         BasicGuardTestStruct_State& operator=(
             const BasicGuardTestStruct_State& obj //!< The source object
+        );
+
+        //! Assignment operator (serial representation value)
+        BasicGuardTestStruct_State& operator=(
+            SerialType e1 //!< The serial representation value
         );
 
         //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardU32_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardU32_StateEnumAc.ref.cpp
@@ -31,6 +31,7 @@ namespace FppTest {
     BasicGuardU32_State& BasicGuardU32_State ::
       operator=(SerialType e1)
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
       this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardU32_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardU32_StateEnumAc.ref.cpp
@@ -29,6 +29,17 @@ namespace FppTest {
     }
 
     BasicGuardU32_State& BasicGuardU32_State ::
+      operator=(SerialType e1)
+    {
+      this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+      this->m_serializeValueIsSet = false;
+      this->m_serializeValue = 0;
+#endif
+      return *this;
+    }
+
+    BasicGuardU32_State& BasicGuardU32_State ::
       operator=(enum T e1)
     {
       FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardU32_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardU32_StateEnumAc.ref.hpp
@@ -76,6 +76,15 @@ namespace FppTest {
           this->e = e1;
         }
 
+        //! Constructor (serial representation value)
+        //! Call isValid() before using the constructed value.
+        BasicGuardU32_State(
+            const SerialType e1 //!< The serial representation value
+        )
+        {
+          this->e = static_cast<enum T>(e1);
+        }
+
         //! Copy constructor
         BasicGuardU32_State(
             const BasicGuardU32_State& obj //!< The source object
@@ -97,6 +106,11 @@ namespace FppTest {
         //! Copy assignment operator (object)
         BasicGuardU32_State& operator=(
             const BasicGuardU32_State& obj //!< The source object
+        );
+
+        //! Assignment operator (serial representation value)
+        BasicGuardU32_State& operator=(
+            SerialType e1 //!< The serial representation value
         );
 
         //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardU32_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardU32_StateEnumAc.ref.hpp
@@ -77,11 +77,11 @@ namespace FppTest {
         }
 
         //! Constructor (serial representation value)
-        //! Call isValid() before using the constructed value.
         BasicGuardU32_State(
             const SerialType e1 //!< The serial representation value
         )
         {
+          FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
           this->e = static_cast<enum T>(e1);
         }
 

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuard_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuard_StateEnumAc.ref.cpp
@@ -31,6 +31,7 @@ namespace FppTest {
     BasicGuard_State& BasicGuard_State ::
       operator=(SerialType e1)
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
       this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuard_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuard_StateEnumAc.ref.cpp
@@ -29,6 +29,17 @@ namespace FppTest {
     }
 
     BasicGuard_State& BasicGuard_State ::
+      operator=(SerialType e1)
+    {
+      this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+      this->m_serializeValueIsSet = false;
+      this->m_serializeValue = 0;
+#endif
+      return *this;
+    }
+
+    BasicGuard_State& BasicGuard_State ::
       operator=(enum T e1)
     {
       FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuard_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuard_StateEnumAc.ref.hpp
@@ -77,11 +77,11 @@ namespace FppTest {
         }
 
         //! Constructor (serial representation value)
-        //! Call isValid() before using the constructed value.
         BasicGuard_State(
             const SerialType e1 //!< The serial representation value
         )
         {
+          FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
           this->e = static_cast<enum T>(e1);
         }
 

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuard_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuard_StateEnumAc.ref.hpp
@@ -76,6 +76,15 @@ namespace FppTest {
           this->e = e1;
         }
 
+        //! Constructor (serial representation value)
+        //! Call isValid() before using the constructed value.
+        BasicGuard_State(
+            const SerialType e1 //!< The serial representation value
+        )
+        {
+          this->e = static_cast<enum T>(e1);
+        }
+
         //! Copy constructor
         BasicGuard_State(
             const BasicGuard_State& obj //!< The source object
@@ -97,6 +106,11 @@ namespace FppTest {
         //! Copy assignment operator (object)
         BasicGuard_State& operator=(
             const BasicGuard_State& obj //!< The source object
+        );
+
+        //! Assignment operator (serial representation value)
+        BasicGuard_State& operator=(
+            SerialType e1 //!< The serial representation value
         );
 
         //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicInternal_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicInternal_StateEnumAc.ref.cpp
@@ -31,6 +31,7 @@ namespace FppTest {
     BasicInternal_State& BasicInternal_State ::
       operator=(SerialType e1)
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
       this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicInternal_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicInternal_StateEnumAc.ref.cpp
@@ -29,6 +29,17 @@ namespace FppTest {
     }
 
     BasicInternal_State& BasicInternal_State ::
+      operator=(SerialType e1)
+    {
+      this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+      this->m_serializeValueIsSet = false;
+      this->m_serializeValue = 0;
+#endif
+      return *this;
+    }
+
+    BasicInternal_State& BasicInternal_State ::
       operator=(enum T e1)
     {
       FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicInternal_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicInternal_StateEnumAc.ref.hpp
@@ -75,11 +75,11 @@ namespace FppTest {
         }
 
         //! Constructor (serial representation value)
-        //! Call isValid() before using the constructed value.
         BasicInternal_State(
             const SerialType e1 //!< The serial representation value
         )
         {
+          FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
           this->e = static_cast<enum T>(e1);
         }
 

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicInternal_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicInternal_StateEnumAc.ref.hpp
@@ -74,6 +74,15 @@ namespace FppTest {
           this->e = e1;
         }
 
+        //! Constructor (serial representation value)
+        //! Call isValid() before using the constructed value.
+        BasicInternal_State(
+            const SerialType e1 //!< The serial representation value
+        )
+        {
+          this->e = static_cast<enum T>(e1);
+        }
+
         //! Copy constructor
         BasicInternal_State(
             const BasicInternal_State& obj //!< The source object
@@ -95,6 +104,11 @@ namespace FppTest {
         //! Copy assignment operator (object)
         BasicInternal_State& operator=(
             const BasicInternal_State& obj //!< The source object
+        );
+
+        //! Assignment operator (serial representation value)
+        BasicInternal_State& operator=(
+            SerialType e1 //!< The serial representation value
         );
 
         //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicSelf_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicSelf_StateEnumAc.ref.cpp
@@ -31,6 +31,7 @@ namespace FppTest {
     BasicSelf_State& BasicSelf_State ::
       operator=(SerialType e1)
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
       this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicSelf_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicSelf_StateEnumAc.ref.cpp
@@ -29,6 +29,17 @@ namespace FppTest {
     }
 
     BasicSelf_State& BasicSelf_State ::
+      operator=(SerialType e1)
+    {
+      this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+      this->m_serializeValueIsSet = false;
+      this->m_serializeValue = 0;
+#endif
+      return *this;
+    }
+
+    BasicSelf_State& BasicSelf_State ::
       operator=(enum T e1)
     {
       FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicSelf_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicSelf_StateEnumAc.ref.hpp
@@ -74,6 +74,15 @@ namespace FppTest {
           this->e = e1;
         }
 
+        //! Constructor (serial representation value)
+        //! Call isValid() before using the constructed value.
+        BasicSelf_State(
+            const SerialType e1 //!< The serial representation value
+        )
+        {
+          this->e = static_cast<enum T>(e1);
+        }
+
         //! Copy constructor
         BasicSelf_State(
             const BasicSelf_State& obj //!< The source object
@@ -95,6 +104,11 @@ namespace FppTest {
         //! Copy assignment operator (object)
         BasicSelf_State& operator=(
             const BasicSelf_State& obj //!< The source object
+        );
+
+        //! Assignment operator (serial representation value)
+        BasicSelf_State& operator=(
+            SerialType e1 //!< The serial representation value
         );
 
         //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicSelf_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicSelf_StateEnumAc.ref.hpp
@@ -75,11 +75,11 @@ namespace FppTest {
         }
 
         //! Constructor (serial representation value)
-        //! Call isValid() before using the constructed value.
         BasicSelf_State(
             const SerialType e1 //!< The serial representation value
         )
         {
+          FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
           this->e = static_cast<enum T>(e1);
         }
 

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicString_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicString_StateEnumAc.ref.cpp
@@ -31,6 +31,7 @@ namespace FppTest {
     BasicString_State& BasicString_State ::
       operator=(SerialType e1)
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
       this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicString_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicString_StateEnumAc.ref.cpp
@@ -29,6 +29,17 @@ namespace FppTest {
     }
 
     BasicString_State& BasicString_State ::
+      operator=(SerialType e1)
+    {
+      this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+      this->m_serializeValueIsSet = false;
+      this->m_serializeValue = 0;
+#endif
+      return *this;
+    }
+
+    BasicString_State& BasicString_State ::
       operator=(enum T e1)
     {
       FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicString_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicString_StateEnumAc.ref.hpp
@@ -77,11 +77,11 @@ namespace FppTest {
         }
 
         //! Constructor (serial representation value)
-        //! Call isValid() before using the constructed value.
         BasicString_State(
             const SerialType e1 //!< The serial representation value
         )
         {
+          FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
           this->e = static_cast<enum T>(e1);
         }
 

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicString_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicString_StateEnumAc.ref.hpp
@@ -76,6 +76,15 @@ namespace FppTest {
           this->e = e1;
         }
 
+        //! Constructor (serial representation value)
+        //! Call isValid() before using the constructed value.
+        BasicString_State(
+            const SerialType e1 //!< The serial representation value
+        )
+        {
+          this->e = static_cast<enum T>(e1);
+        }
+
         //! Copy constructor
         BasicString_State(
             const BasicString_State& obj //!< The source object
@@ -97,6 +106,11 @@ namespace FppTest {
         //! Copy assignment operator (object)
         BasicString_State& operator=(
             const BasicString_State& obj //!< The source object
+        );
+
+        //! Assignment operator (serial representation value)
+        BasicString_State& operator=(
+            SerialType e1 //!< The serial representation value
         );
 
         //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestAbsType_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestAbsType_StateEnumAc.ref.cpp
@@ -29,6 +29,17 @@ namespace FppTest {
     }
 
     BasicTestAbsType_State& BasicTestAbsType_State ::
+      operator=(SerialType e1)
+    {
+      this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+      this->m_serializeValueIsSet = false;
+      this->m_serializeValue = 0;
+#endif
+      return *this;
+    }
+
+    BasicTestAbsType_State& BasicTestAbsType_State ::
       operator=(enum T e1)
     {
       FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestAbsType_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestAbsType_StateEnumAc.ref.cpp
@@ -31,6 +31,7 @@ namespace FppTest {
     BasicTestAbsType_State& BasicTestAbsType_State ::
       operator=(SerialType e1)
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
       this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestAbsType_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestAbsType_StateEnumAc.ref.hpp
@@ -77,11 +77,11 @@ namespace FppTest {
         }
 
         //! Constructor (serial representation value)
-        //! Call isValid() before using the constructed value.
         BasicTestAbsType_State(
             const SerialType e1 //!< The serial representation value
         )
         {
+          FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
           this->e = static_cast<enum T>(e1);
         }
 

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestAbsType_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestAbsType_StateEnumAc.ref.hpp
@@ -76,6 +76,15 @@ namespace FppTest {
           this->e = e1;
         }
 
+        //! Constructor (serial representation value)
+        //! Call isValid() before using the constructed value.
+        BasicTestAbsType_State(
+            const SerialType e1 //!< The serial representation value
+        )
+        {
+          this->e = static_cast<enum T>(e1);
+        }
+
         //! Copy constructor
         BasicTestAbsType_State(
             const BasicTestAbsType_State& obj //!< The source object
@@ -97,6 +106,11 @@ namespace FppTest {
         //! Copy assignment operator (object)
         BasicTestAbsType_State& operator=(
             const BasicTestAbsType_State& obj //!< The source object
+        );
+
+        //! Assignment operator (serial representation value)
+        BasicTestAbsType_State& operator=(
+            SerialType e1 //!< The serial representation value
         );
 
         //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestArray_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestArray_StateEnumAc.ref.cpp
@@ -29,6 +29,17 @@ namespace FppTest {
     }
 
     BasicTestArray_State& BasicTestArray_State ::
+      operator=(SerialType e1)
+    {
+      this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+      this->m_serializeValueIsSet = false;
+      this->m_serializeValue = 0;
+#endif
+      return *this;
+    }
+
+    BasicTestArray_State& BasicTestArray_State ::
       operator=(enum T e1)
     {
       FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestArray_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestArray_StateEnumAc.ref.cpp
@@ -31,6 +31,7 @@ namespace FppTest {
     BasicTestArray_State& BasicTestArray_State ::
       operator=(SerialType e1)
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
       this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestArray_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestArray_StateEnumAc.ref.hpp
@@ -77,11 +77,11 @@ namespace FppTest {
         }
 
         //! Constructor (serial representation value)
-        //! Call isValid() before using the constructed value.
         BasicTestArray_State(
             const SerialType e1 //!< The serial representation value
         )
         {
+          FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
           this->e = static_cast<enum T>(e1);
         }
 

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestArray_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestArray_StateEnumAc.ref.hpp
@@ -76,6 +76,15 @@ namespace FppTest {
           this->e = e1;
         }
 
+        //! Constructor (serial representation value)
+        //! Call isValid() before using the constructed value.
+        BasicTestArray_State(
+            const SerialType e1 //!< The serial representation value
+        )
+        {
+          this->e = static_cast<enum T>(e1);
+        }
+
         //! Copy constructor
         BasicTestArray_State(
             const BasicTestArray_State& obj //!< The source object
@@ -97,6 +106,11 @@ namespace FppTest {
         //! Copy assignment operator (object)
         BasicTestArray_State& operator=(
             const BasicTestArray_State& obj //!< The source object
+        );
+
+        //! Assignment operator (serial representation value)
+        BasicTestArray_State& operator=(
+            SerialType e1 //!< The serial representation value
         );
 
         //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestEnum_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestEnum_StateEnumAc.ref.cpp
@@ -31,6 +31,7 @@ namespace FppTest {
     BasicTestEnum_State& BasicTestEnum_State ::
       operator=(SerialType e1)
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
       this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestEnum_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestEnum_StateEnumAc.ref.cpp
@@ -29,6 +29,17 @@ namespace FppTest {
     }
 
     BasicTestEnum_State& BasicTestEnum_State ::
+      operator=(SerialType e1)
+    {
+      this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+      this->m_serializeValueIsSet = false;
+      this->m_serializeValue = 0;
+#endif
+      return *this;
+    }
+
+    BasicTestEnum_State& BasicTestEnum_State ::
       operator=(enum T e1)
     {
       FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestEnum_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestEnum_StateEnumAc.ref.hpp
@@ -77,11 +77,11 @@ namespace FppTest {
         }
 
         //! Constructor (serial representation value)
-        //! Call isValid() before using the constructed value.
         BasicTestEnum_State(
             const SerialType e1 //!< The serial representation value
         )
         {
+          FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
           this->e = static_cast<enum T>(e1);
         }
 

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestEnum_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestEnum_StateEnumAc.ref.hpp
@@ -76,6 +76,15 @@ namespace FppTest {
           this->e = e1;
         }
 
+        //! Constructor (serial representation value)
+        //! Call isValid() before using the constructed value.
+        BasicTestEnum_State(
+            const SerialType e1 //!< The serial representation value
+        )
+        {
+          this->e = static_cast<enum T>(e1);
+        }
+
         //! Copy constructor
         BasicTestEnum_State(
             const BasicTestEnum_State& obj //!< The source object
@@ -97,6 +106,11 @@ namespace FppTest {
         //! Copy assignment operator (object)
         BasicTestEnum_State& operator=(
             const BasicTestEnum_State& obj //!< The source object
+        );
+
+        //! Assignment operator (serial representation value)
+        BasicTestEnum_State& operator=(
+            SerialType e1 //!< The serial representation value
         );
 
         //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestStruct_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestStruct_StateEnumAc.ref.cpp
@@ -29,6 +29,17 @@ namespace FppTest {
     }
 
     BasicTestStruct_State& BasicTestStruct_State ::
+      operator=(SerialType e1)
+    {
+      this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+      this->m_serializeValueIsSet = false;
+      this->m_serializeValue = 0;
+#endif
+      return *this;
+    }
+
+    BasicTestStruct_State& BasicTestStruct_State ::
       operator=(enum T e1)
     {
       FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestStruct_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestStruct_StateEnumAc.ref.cpp
@@ -31,6 +31,7 @@ namespace FppTest {
     BasicTestStruct_State& BasicTestStruct_State ::
       operator=(SerialType e1)
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
       this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestStruct_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestStruct_StateEnumAc.ref.hpp
@@ -76,6 +76,15 @@ namespace FppTest {
           this->e = e1;
         }
 
+        //! Constructor (serial representation value)
+        //! Call isValid() before using the constructed value.
+        BasicTestStruct_State(
+            const SerialType e1 //!< The serial representation value
+        )
+        {
+          this->e = static_cast<enum T>(e1);
+        }
+
         //! Copy constructor
         BasicTestStruct_State(
             const BasicTestStruct_State& obj //!< The source object
@@ -97,6 +106,11 @@ namespace FppTest {
         //! Copy assignment operator (object)
         BasicTestStruct_State& operator=(
             const BasicTestStruct_State& obj //!< The source object
+        );
+
+        //! Assignment operator (serial representation value)
+        BasicTestStruct_State& operator=(
+            SerialType e1 //!< The serial representation value
         );
 
         //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestStruct_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestStruct_StateEnumAc.ref.hpp
@@ -77,11 +77,11 @@ namespace FppTest {
         }
 
         //! Constructor (serial representation value)
-        //! Call isValid() before using the constructed value.
         BasicTestStruct_State(
             const SerialType e1 //!< The serial representation value
         )
         {
+          FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
           this->e = static_cast<enum T>(e1);
         }
 

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicU32_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicU32_StateEnumAc.ref.cpp
@@ -31,6 +31,7 @@ namespace FppTest {
     BasicU32_State& BasicU32_State ::
       operator=(SerialType e1)
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
       this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicU32_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicU32_StateEnumAc.ref.cpp
@@ -29,6 +29,17 @@ namespace FppTest {
     }
 
     BasicU32_State& BasicU32_State ::
+      operator=(SerialType e1)
+    {
+      this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+      this->m_serializeValueIsSet = false;
+      this->m_serializeValue = 0;
+#endif
+      return *this;
+    }
+
+    BasicU32_State& BasicU32_State ::
       operator=(enum T e1)
     {
       FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicU32_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicU32_StateEnumAc.ref.hpp
@@ -76,6 +76,15 @@ namespace FppTest {
           this->e = e1;
         }
 
+        //! Constructor (serial representation value)
+        //! Call isValid() before using the constructed value.
+        BasicU32_State(
+            const SerialType e1 //!< The serial representation value
+        )
+        {
+          this->e = static_cast<enum T>(e1);
+        }
+
         //! Copy constructor
         BasicU32_State(
             const BasicU32_State& obj //!< The source object
@@ -97,6 +106,11 @@ namespace FppTest {
         //! Copy assignment operator (object)
         BasicU32_State& operator=(
             const BasicU32_State& obj //!< The source object
+        );
+
+        //! Assignment operator (serial representation value)
+        BasicU32_State& operator=(
+            SerialType e1 //!< The serial representation value
         );
 
         //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicU32_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicU32_StateEnumAc.ref.hpp
@@ -77,11 +77,11 @@ namespace FppTest {
         }
 
         //! Constructor (serial representation value)
-        //! Call isValid() before using the constructed value.
         BasicU32_State(
             const SerialType e1 //!< The serial representation value
         )
         {
+          FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
           this->e = static_cast<enum T>(e1);
         }
 

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/Basic_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/Basic_StateEnumAc.ref.cpp
@@ -29,6 +29,17 @@ namespace FppTest {
     }
 
     Basic_State& Basic_State ::
+      operator=(SerialType e1)
+    {
+      this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+      this->m_serializeValueIsSet = false;
+      this->m_serializeValue = 0;
+#endif
+      return *this;
+    }
+
+    Basic_State& Basic_State ::
       operator=(enum T e1)
     {
       FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/Basic_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/Basic_StateEnumAc.ref.cpp
@@ -31,6 +31,7 @@ namespace FppTest {
     Basic_State& Basic_State ::
       operator=(SerialType e1)
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
       this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/Basic_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/Basic_StateEnumAc.ref.hpp
@@ -76,6 +76,15 @@ namespace FppTest {
           this->e = e1;
         }
 
+        //! Constructor (serial representation value)
+        //! Call isValid() before using the constructed value.
+        Basic_State(
+            const SerialType e1 //!< The serial representation value
+        )
+        {
+          this->e = static_cast<enum T>(e1);
+        }
+
         //! Copy constructor
         Basic_State(
             const Basic_State& obj //!< The source object
@@ -97,6 +106,11 @@ namespace FppTest {
         //! Copy assignment operator (object)
         Basic_State& operator=(
             const Basic_State& obj //!< The source object
+        );
+
+        //! Assignment operator (serial representation value)
+        Basic_State& operator=(
+            SerialType e1 //!< The serial representation value
         );
 
         //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/Basic_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/Basic_StateEnumAc.ref.hpp
@@ -77,11 +77,11 @@ namespace FppTest {
         }
 
         //! Constructor (serial representation value)
-        //! Call isValid() before using the constructed value.
         Basic_State(
             const SerialType e1 //!< The serial representation value
         )
         {
+          FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
           this->e = static_cast<enum T>(e1);
         }
 

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/Internal_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/Internal_StateEnumAc.ref.cpp
@@ -31,6 +31,7 @@ namespace FppTest {
     Internal_State& Internal_State ::
       operator=(SerialType e1)
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
       this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/Internal_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/Internal_StateEnumAc.ref.cpp
@@ -29,6 +29,17 @@ namespace FppTest {
     }
 
     Internal_State& Internal_State ::
+      operator=(SerialType e1)
+    {
+      this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+      this->m_serializeValueIsSet = false;
+      this->m_serializeValue = 0;
+#endif
+      return *this;
+    }
+
+    Internal_State& Internal_State ::
       operator=(enum T e1)
     {
       FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/Internal_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/Internal_StateEnumAc.ref.hpp
@@ -76,6 +76,15 @@ namespace FppTest {
           this->e = e1;
         }
 
+        //! Constructor (serial representation value)
+        //! Call isValid() before using the constructed value.
+        Internal_State(
+            const SerialType e1 //!< The serial representation value
+        )
+        {
+          this->e = static_cast<enum T>(e1);
+        }
+
         //! Copy constructor
         Internal_State(
             const Internal_State& obj //!< The source object
@@ -97,6 +106,11 @@ namespace FppTest {
         //! Copy assignment operator (object)
         Internal_State& operator=(
             const Internal_State& obj //!< The source object
+        );
+
+        //! Assignment operator (serial representation value)
+        Internal_State& operator=(
+            SerialType e1 //!< The serial representation value
         );
 
         //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/Internal_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/Internal_StateEnumAc.ref.hpp
@@ -77,11 +77,11 @@ namespace FppTest {
         }
 
         //! Constructor (serial representation value)
-        //! Call isValid() before using the constructed value.
         Internal_State(
             const SerialType e1 //!< The serial representation value
         )
         {
+          FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
           this->e = static_cast<enum T>(e1);
         }
 

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/Polymorphism_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/Polymorphism_StateEnumAc.ref.cpp
@@ -31,6 +31,7 @@ namespace FppTest {
     Polymorphism_State& Polymorphism_State ::
       operator=(SerialType e1)
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
       this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/Polymorphism_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/Polymorphism_StateEnumAc.ref.cpp
@@ -29,6 +29,17 @@ namespace FppTest {
     }
 
     Polymorphism_State& Polymorphism_State ::
+      operator=(SerialType e1)
+    {
+      this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+      this->m_serializeValueIsSet = false;
+      this->m_serializeValue = 0;
+#endif
+      return *this;
+    }
+
+    Polymorphism_State& Polymorphism_State ::
       operator=(enum T e1)
     {
       FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/Polymorphism_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/Polymorphism_StateEnumAc.ref.hpp
@@ -81,11 +81,11 @@ namespace FppTest {
         }
 
         //! Constructor (serial representation value)
-        //! Call isValid() before using the constructed value.
         Polymorphism_State(
             const SerialType e1 //!< The serial representation value
         )
         {
+          FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
           this->e = static_cast<enum T>(e1);
         }
 

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/Polymorphism_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/Polymorphism_StateEnumAc.ref.hpp
@@ -80,6 +80,15 @@ namespace FppTest {
           this->e = e1;
         }
 
+        //! Constructor (serial representation value)
+        //! Call isValid() before using the constructed value.
+        Polymorphism_State(
+            const SerialType e1 //!< The serial representation value
+        )
+        {
+          this->e = static_cast<enum T>(e1);
+        }
+
         //! Copy constructor
         Polymorphism_State(
             const Polymorphism_State& obj //!< The source object
@@ -101,6 +110,11 @@ namespace FppTest {
         //! Copy assignment operator (object)
         Polymorphism_State& operator=(
             const Polymorphism_State& obj //!< The source object
+        );
+
+        //! Assignment operator (serial representation value)
+        Polymorphism_State& operator=(
+            SerialType e1 //!< The serial representation value
         );
 
         //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToChild_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToChild_StateEnumAc.ref.cpp
@@ -31,6 +31,7 @@ namespace FppTest {
     StateToChild_State& StateToChild_State ::
       operator=(SerialType e1)
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
       this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToChild_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToChild_StateEnumAc.ref.cpp
@@ -29,6 +29,17 @@ namespace FppTest {
     }
 
     StateToChild_State& StateToChild_State ::
+      operator=(SerialType e1)
+    {
+      this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+      this->m_serializeValueIsSet = false;
+      this->m_serializeValue = 0;
+#endif
+      return *this;
+    }
+
+    StateToChild_State& StateToChild_State ::
       operator=(enum T e1)
     {
       FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToChild_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToChild_StateEnumAc.ref.hpp
@@ -77,11 +77,11 @@ namespace FppTest {
         }
 
         //! Constructor (serial representation value)
-        //! Call isValid() before using the constructed value.
         StateToChild_State(
             const SerialType e1 //!< The serial representation value
         )
         {
+          FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
           this->e = static_cast<enum T>(e1);
         }
 

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToChild_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToChild_StateEnumAc.ref.hpp
@@ -76,6 +76,15 @@ namespace FppTest {
           this->e = e1;
         }
 
+        //! Constructor (serial representation value)
+        //! Call isValid() before using the constructed value.
+        StateToChild_State(
+            const SerialType e1 //!< The serial representation value
+        )
+        {
+          this->e = static_cast<enum T>(e1);
+        }
+
         //! Copy constructor
         StateToChild_State(
             const StateToChild_State& obj //!< The source object
@@ -97,6 +106,11 @@ namespace FppTest {
         //! Copy assignment operator (object)
         StateToChild_State& operator=(
             const StateToChild_State& obj //!< The source object
+        );
+
+        //! Assignment operator (serial representation value)
+        StateToChild_State& operator=(
+            SerialType e1 //!< The serial representation value
         );
 
         //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToChoice_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToChoice_StateEnumAc.ref.cpp
@@ -31,6 +31,7 @@ namespace FppTest {
     StateToChoice_State& StateToChoice_State ::
       operator=(SerialType e1)
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
       this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToChoice_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToChoice_StateEnumAc.ref.cpp
@@ -29,6 +29,17 @@ namespace FppTest {
     }
 
     StateToChoice_State& StateToChoice_State ::
+      operator=(SerialType e1)
+    {
+      this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+      this->m_serializeValueIsSet = false;
+      this->m_serializeValue = 0;
+#endif
+      return *this;
+    }
+
+    StateToChoice_State& StateToChoice_State ::
       operator=(enum T e1)
     {
       FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToChoice_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToChoice_StateEnumAc.ref.hpp
@@ -81,11 +81,11 @@ namespace FppTest {
         }
 
         //! Constructor (serial representation value)
-        //! Call isValid() before using the constructed value.
         StateToChoice_State(
             const SerialType e1 //!< The serial representation value
         )
         {
+          FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
           this->e = static_cast<enum T>(e1);
         }
 

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToChoice_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToChoice_StateEnumAc.ref.hpp
@@ -80,6 +80,15 @@ namespace FppTest {
           this->e = e1;
         }
 
+        //! Constructor (serial representation value)
+        //! Call isValid() before using the constructed value.
+        StateToChoice_State(
+            const SerialType e1 //!< The serial representation value
+        )
+        {
+          this->e = static_cast<enum T>(e1);
+        }
+
         //! Copy constructor
         StateToChoice_State(
             const StateToChoice_State& obj //!< The source object
@@ -101,6 +110,11 @@ namespace FppTest {
         //! Copy assignment operator (object)
         StateToChoice_State& operator=(
             const StateToChoice_State& obj //!< The source object
+        );
+
+        //! Assignment operator (serial representation value)
+        StateToChoice_State& operator=(
+            SerialType e1 //!< The serial representation value
         );
 
         //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToSelf_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToSelf_StateEnumAc.ref.cpp
@@ -29,6 +29,17 @@ namespace FppTest {
     }
 
     StateToSelf_State& StateToSelf_State ::
+      operator=(SerialType e1)
+    {
+      this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+      this->m_serializeValueIsSet = false;
+      this->m_serializeValue = 0;
+#endif
+      return *this;
+    }
+
+    StateToSelf_State& StateToSelf_State ::
       operator=(enum T e1)
     {
       FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToSelf_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToSelf_StateEnumAc.ref.cpp
@@ -31,6 +31,7 @@ namespace FppTest {
     StateToSelf_State& StateToSelf_State ::
       operator=(SerialType e1)
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
       this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToSelf_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToSelf_StateEnumAc.ref.hpp
@@ -76,6 +76,15 @@ namespace FppTest {
           this->e = e1;
         }
 
+        //! Constructor (serial representation value)
+        //! Call isValid() before using the constructed value.
+        StateToSelf_State(
+            const SerialType e1 //!< The serial representation value
+        )
+        {
+          this->e = static_cast<enum T>(e1);
+        }
+
         //! Copy constructor
         StateToSelf_State(
             const StateToSelf_State& obj //!< The source object
@@ -97,6 +106,11 @@ namespace FppTest {
         //! Copy assignment operator (object)
         StateToSelf_State& operator=(
             const StateToSelf_State& obj //!< The source object
+        );
+
+        //! Assignment operator (serial representation value)
+        StateToSelf_State& operator=(
+            SerialType e1 //!< The serial representation value
         );
 
         //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToSelf_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToSelf_StateEnumAc.ref.hpp
@@ -77,11 +77,11 @@ namespace FppTest {
         }
 
         //! Constructor (serial representation value)
-        //! Call isValid() before using the constructed value.
         StateToSelf_State(
             const SerialType e1 //!< The serial representation value
         )
         {
+          FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
           this->e = static_cast<enum T>(e1);
         }
 

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToState_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToState_StateEnumAc.ref.cpp
@@ -29,6 +29,17 @@ namespace FppTest {
     }
 
     StateToState_State& StateToState_State ::
+      operator=(SerialType e1)
+    {
+      this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+      this->m_serializeValueIsSet = false;
+      this->m_serializeValue = 0;
+#endif
+      return *this;
+    }
+
+    StateToState_State& StateToState_State ::
       operator=(enum T e1)
     {
       FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToState_StateEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToState_StateEnumAc.ref.cpp
@@ -31,6 +31,7 @@ namespace FppTest {
     StateToState_State& StateToState_State ::
       operator=(SerialType e1)
     {
+      FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
       this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
       this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToState_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToState_StateEnumAc.ref.hpp
@@ -79,11 +79,11 @@ namespace FppTest {
         }
 
         //! Constructor (serial representation value)
-        //! Call isValid() before using the constructed value.
         StateToState_State(
             const SerialType e1 //!< The serial representation value
         )
         {
+          FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
           this->e = static_cast<enum T>(e1);
         }
 

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToState_StateEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToState_StateEnumAc.ref.hpp
@@ -78,6 +78,15 @@ namespace FppTest {
           this->e = e1;
         }
 
+        //! Constructor (serial representation value)
+        //! Call isValid() before using the constructed value.
+        StateToState_State(
+            const SerialType e1 //!< The serial representation value
+        )
+        {
+          this->e = static_cast<enum T>(e1);
+        }
+
         //! Copy constructor
         StateToState_State(
             const StateToState_State& obj //!< The source object
@@ -99,6 +108,11 @@ namespace FppTest {
         //! Copy assignment operator (object)
         StateToState_State& operator=(
             const StateToState_State& obj //!< The source object
+        );
+
+        //! Assignment operator (serial representation value)
+        StateToState_State& operator=(
+            SerialType e1 //!< The serial representation value
         );
 
         //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/struct/EEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/EEnumAc.ref.cpp
@@ -27,6 +27,17 @@ namespace M {
   }
 
   E& E ::
+    operator=(SerialType e1)
+  {
+    this->e = static_cast<enum T>(e1);
+#ifdef BUILD_UT
+    this->m_serializeValueIsSet = false;
+    this->m_serializeValue = 0;
+#endif
+    return *this;
+  }
+
+  E& E ::
     operator=(enum T e1)
   {
     FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));

--- a/compiler/tools/fpp-to-cpp/test/struct/EEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/EEnumAc.ref.cpp
@@ -29,6 +29,7 @@ namespace M {
   E& E ::
     operator=(SerialType e1)
   {
+    FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
     this->e = static_cast<enum T>(e1);
 #ifdef BUILD_UT
     this->m_serializeValueIsSet = false;

--- a/compiler/tools/fpp-to-cpp/test/struct/EEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/EEnumAc.ref.hpp
@@ -70,6 +70,15 @@ namespace M {
         this->e = e1;
       }
 
+      //! Constructor (serial representation value)
+      //! Call isValid() before using the constructed value.
+      E(
+          const SerialType e1 //!< The serial representation value
+      )
+      {
+        this->e = static_cast<enum T>(e1);
+      }
+
       //! Copy constructor
       E(
           const E& obj //!< The source object
@@ -91,6 +100,11 @@ namespace M {
       //! Copy assignment operator (object)
       E& operator=(
           const E& obj //!< The source object
+      );
+
+      //! Assignment operator (serial representation value)
+      E& operator=(
+          SerialType e1 //!< The serial representation value
       );
 
       //! Copy assignment operator (raw enum)

--- a/compiler/tools/fpp-to-cpp/test/struct/EEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/EEnumAc.ref.hpp
@@ -71,11 +71,11 @@ namespace M {
       }
 
       //! Constructor (serial representation value)
-      //! Call isValid() before using the constructed value.
       E(
           const SerialType e1 //!< The serial representation value
       )
       {
+        FW_ASSERT(isValid(e1), static_cast<FwAssertArgType>(e1));
         this->e = static_cast<enum T>(e1);
       }
 


### PR DESCRIPTION
## Summary

Adds generated enum construction and assignment from `SerialType`. These APIs preserve the provided serial value so callers can validate it with `isValid()` before use.

Addresses nasa/fpp#1052.

## Validation

- `./fpp-sbt test` — 586 Scala tests passed
- `compiler/tools/fpp-to-cpp/test/test` — all CLI generator tests passed
- `compiler/tools/fpp-to-cpp/test/check-cpp` — generated C++ compile sweep passed

The golden outputs were regenerated with the repository-provided `update-ref` workflow.