### PR TITLE
Emit boolean assertion expressions in generated C++

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentDataProducts.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentDataProducts.scala
@@ -273,7 +273,7 @@ case class ComponentDataProducts (
                 }),
                 lines (
                   """|default:
-                     |  FW_ASSERT(0);
+                     |  FW_ASSERT(false);
                      |  break;"""
                 )
               )
@@ -614,4 +614,3 @@ case class ComponentDataProducts (
   }
 
 }
-

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentInputPorts.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentInputPorts.scala
@@ -395,7 +395,7 @@ case class ComponentInputPorts(
     val handlerBaseName = inputPortHandlerBaseName(p.getUnqualifiedName)
     List.concat(
       lines(
-        s"""|FW_ASSERT(callComp);
+        s"""|FW_ASSERT(callComp != nullptr);
             |$componentClassName* compPtr = static_cast<$componentClassName*>(callComp);
             |
             |"""

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentInternalStateMachines.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentInternalStateMachines.scala
@@ -232,7 +232,7 @@ case class ComponentInternalStateMachines(
         ) ++
         lines(
           """|default:
-             |  FW_ASSERT(0, static_cast<FwAssertArgType>(smId));
+             |  FW_ASSERT(false, static_cast<FwAssertArgType>(smId));
              |  break;"""
         )
       )
@@ -500,7 +500,7 @@ case class ComponentInternalStateMachines(
         ) ++
         lines(
           """|default:
-             |  FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+             |  FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
              |  break;"""
         )
       )

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentTesterBaseWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TestWriter/ComponentTesterBaseWriter.scala
@@ -963,7 +963,7 @@ case class ComponentTesterBaseWriter(
         sortedEvents.map((id, event) => writeSwitchCase(id, event)) ++ List(
           lines(
             """|default: {
-               |  FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+               |  FW_ASSERT(false, static_cast<FwAssertArgType>(id));
                |  break;
                |}
                |"""
@@ -1114,7 +1114,7 @@ case class ComponentTesterBaseWriter(
           wrapInScope(
             "default: {",
             lines(
-              """|FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+              """|FW_ASSERT(false, static_cast<FwAssertArgType>(id));
                  |break;
                  |"""
             ),
@@ -1377,7 +1377,7 @@ case class ComponentTesterBaseWriter(
             ) ++ List(
               lines(
                 """|default:
-                   |  FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+                   |  FW_ASSERT(false, static_cast<FwAssertArgType>(id));
                    |  break;
                    |"""
               )
@@ -1433,7 +1433,7 @@ case class ComponentTesterBaseWriter(
           }) ++ List(
             lines(
               s"""|default:
-                  |  FW_ASSERT(0, static_cast<FwAssertArgType>($id));
+                  |  FW_ASSERT(false, static_cast<FwAssertArgType>($id));
                   |  break;
                   |"""
             )
@@ -1739,7 +1739,7 @@ case class ExternalParameterDelegate(
             lines(
               """|  default:
                  |    // Unknown ID; should not have gotten here
-                 |    FW_ASSERT(0, static_cast<FwAssertArgType>(localId));
+                 |    FW_ASSERT(false, static_cast<FwAssertArgType>(localId));
                  |}
                  |
                  |return stat;
@@ -1795,7 +1795,7 @@ case class ExternalParameterDelegate(
             lines(
               """|  default:
                  |    // Unknown ID; should not have gotten here
-                 |    FW_ASSERT(0, static_cast<FwAssertArgType>(localId));
+                 |    FW_ASSERT(false, static_cast<FwAssertArgType>(localId));
                  |}
                  |
                  |return stat;

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TopComponentCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/TopComponentCppWriter.scala
@@ -77,7 +77,7 @@ case class TopComponentCppWriter (
             lines(
               """|default:
                  |#ifdef FW_STRICT_ASSERTIONS
-                 |  FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+                 |  FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
                  |  break;
                  |#else
                  |  // Fall through
@@ -140,7 +140,7 @@ case class TopComponentCppWriter (
       writeInstanceSwitch(
         componentInstanceMap,
         writeOutFnCase,
-        lines("FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));")
+        lines("FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));")
       ),
       guardedList (nonVoidReturn) (lines(s"return _result;"))
     )

--- a/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter/InputPortClassWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter/InputPortClassWriter.scala
@@ -193,7 +193,7 @@ case class InputPortClassWriter(
       """|// For ports with a return type, invokeSerial is not used
          |(void) _buffer;
          |
-         |FW_ASSERT(0);
+         |FW_ASSERT(false);
          |return Fw::FW_SERIALIZE_OK;
          |"""
     )

--- a/compiler/lib/src/main/scala/codegen/CppWriter/StateMachineCppWriter/StateMachineCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/StateMachineCppWriter/StateMachineCppWriter.scala
@@ -241,7 +241,7 @@ case class StateMachineCppWriter(
       leafStateSymbols.flatMap(getSendSignalMemberCaseLines (signal)),
       lines(
         """|default:
-           |  FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+           |  FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
            |  break;"""
       )
     )

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductPortsOnlyComponentAc.ref.cpp
@@ -485,7 +485,7 @@ void ActiveAsyncProductPortsOnlyComponentBase ::
       const Fw::Success& status
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveAsyncProductPortsOnlyComponentBase* compPtr = static_cast<ActiveAsyncProductPortsOnlyComponentBase*>(callComp);
   compPtr->productRecvIn_handlerBase(
     portNum,

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductsComponentAc.ref.cpp
@@ -4083,7 +4083,7 @@ void ActiveAsyncProductsComponentBase ::
       Fw::CmdArgBuffer& args
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
   compPtr->cmdIn_handlerBase(
     portNum,
@@ -4102,7 +4102,7 @@ void ActiveAsyncProductsComponentBase ::
       const Fw::Success& status
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
   compPtr->productRecvIn_handlerBase(
     portNum,
@@ -4129,7 +4129,7 @@ void ActiveAsyncProductsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
   compPtr->aliasTypedAsync_handlerBase(
     portNum,
@@ -4149,7 +4149,7 @@ Fw::String ActiveAsyncProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
   return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
@@ -4160,7 +4160,7 @@ void ActiveAsyncProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
   compPtr->noArgsAsync_handlerBase(portNum);
 }
@@ -4171,7 +4171,7 @@ void ActiveAsyncProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
   compPtr->noArgsGuarded_handlerBase(portNum);
 }
@@ -4182,7 +4182,7 @@ U32 ActiveAsyncProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
   return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
@@ -4193,7 +4193,7 @@ U32 ActiveAsyncProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
   return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
@@ -4204,7 +4204,7 @@ Fw::String ActiveAsyncProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
   return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
@@ -4215,7 +4215,7 @@ void ActiveAsyncProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
   compPtr->noArgsSync_handlerBase(portNum);
 }
@@ -4233,7 +4233,7 @@ void ActiveAsyncProductsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
   compPtr->typedAliasGuarded_handlerBase(
     portNum,
@@ -4260,7 +4260,7 @@ AliasPrim2 ActiveAsyncProductsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
   return compPtr->typedAliasReturnSync_handlerBase(
     portNum,
@@ -4287,7 +4287,7 @@ Fw::String ActiveAsyncProductsComponentBase ::
       const AnotherAliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
   return compPtr->typedAliasStringReturnSync_handlerBase(
     portNum,
@@ -4314,7 +4314,7 @@ void ActiveAsyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
   compPtr->typedAsync_handlerBase(
     portNum,
@@ -4341,7 +4341,7 @@ void ActiveAsyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
   compPtr->typedAsyncAssert_handlerBase(
     portNum,
@@ -4368,7 +4368,7 @@ void ActiveAsyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
   compPtr->typedAsyncBlockPriority_handlerBase(
     portNum,
@@ -4395,7 +4395,7 @@ void ActiveAsyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
   compPtr->typedAsyncDropPriority_handlerBase(
     portNum,
@@ -4422,7 +4422,7 @@ void ActiveAsyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
   compPtr->typedGuarded_handlerBase(
     portNum,
@@ -4449,7 +4449,7 @@ F32 ActiveAsyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
   return compPtr->typedReturnGuarded_handlerBase(
     portNum,
@@ -4476,7 +4476,7 @@ F32 ActiveAsyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
   return compPtr->typedReturnSync_handlerBase(
     portNum,
@@ -4503,7 +4503,7 @@ void ActiveAsyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveAsyncProductsComponentBase* compPtr = static_cast<ActiveAsyncProductsComponentBase*>(callComp);
   compPtr->typedSync_handlerBase(
     portNum,
@@ -4657,7 +4657,7 @@ void ActiveAsyncProductsComponentBase ::
       this->dpRecv_Container5_handler(container, status.e);
       break;
     default:
-      FW_ASSERT(0);
+      FW_ASSERT(false);
       break;
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveCommandsComponentAc.ref.cpp
@@ -5114,7 +5114,7 @@ void ActiveCommandsComponentBase ::
       Fw::CmdArgBuffer& args
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
   compPtr->cmdIn_handlerBase(
     portNum,
@@ -5141,7 +5141,7 @@ void ActiveCommandsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
   compPtr->aliasTypedAsync_handlerBase(
     portNum,
@@ -5161,7 +5161,7 @@ Fw::String ActiveCommandsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
   return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
@@ -5172,7 +5172,7 @@ void ActiveCommandsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
   compPtr->noArgsAsync_handlerBase(portNum);
 }
@@ -5183,7 +5183,7 @@ void ActiveCommandsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
   compPtr->noArgsGuarded_handlerBase(portNum);
 }
@@ -5194,7 +5194,7 @@ U32 ActiveCommandsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
   return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
@@ -5205,7 +5205,7 @@ U32 ActiveCommandsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
   return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
@@ -5216,7 +5216,7 @@ Fw::String ActiveCommandsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
   return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
@@ -5227,7 +5227,7 @@ void ActiveCommandsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
   compPtr->noArgsSync_handlerBase(portNum);
 }
@@ -5245,7 +5245,7 @@ void ActiveCommandsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
   compPtr->typedAliasGuarded_handlerBase(
     portNum,
@@ -5272,7 +5272,7 @@ AliasPrim2 ActiveCommandsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
   return compPtr->typedAliasReturnSync_handlerBase(
     portNum,
@@ -5299,7 +5299,7 @@ Fw::String ActiveCommandsComponentBase ::
       const AnotherAliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
   return compPtr->typedAliasStringReturnSync_handlerBase(
     portNum,
@@ -5326,7 +5326,7 @@ void ActiveCommandsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
   compPtr->typedAsync_handlerBase(
     portNum,
@@ -5353,7 +5353,7 @@ void ActiveCommandsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
   compPtr->typedAsyncAssert_handlerBase(
     portNum,
@@ -5380,7 +5380,7 @@ void ActiveCommandsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
   compPtr->typedAsyncBlockPriority_handlerBase(
     portNum,
@@ -5407,7 +5407,7 @@ void ActiveCommandsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
   compPtr->typedAsyncDropPriority_handlerBase(
     portNum,
@@ -5434,7 +5434,7 @@ void ActiveCommandsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
   compPtr->typedGuarded_handlerBase(
     portNum,
@@ -5461,7 +5461,7 @@ F32 ActiveCommandsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
   return compPtr->typedReturnGuarded_handlerBase(
     portNum,
@@ -5488,7 +5488,7 @@ F32 ActiveCommandsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
   return compPtr->typedReturnSync_handlerBase(
     portNum,
@@ -5515,7 +5515,7 @@ void ActiveCommandsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveCommandsComponentBase* compPtr = static_cast<ActiveCommandsComponentBase*>(callComp);
   compPtr->typedSync_handlerBase(
     portNum,

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.cpp
@@ -4314,7 +4314,7 @@ void ActiveEventsComponentBase ::
       Fw::CmdArgBuffer& args
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
   compPtr->cmdIn_handlerBase(
     portNum,
@@ -4341,7 +4341,7 @@ void ActiveEventsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
   compPtr->aliasTypedAsync_handlerBase(
     portNum,
@@ -4361,7 +4361,7 @@ Fw::String ActiveEventsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
   return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
@@ -4372,7 +4372,7 @@ void ActiveEventsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
   compPtr->noArgsAsync_handlerBase(portNum);
 }
@@ -4383,7 +4383,7 @@ void ActiveEventsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
   compPtr->noArgsGuarded_handlerBase(portNum);
 }
@@ -4394,7 +4394,7 @@ U32 ActiveEventsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
   return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
@@ -4405,7 +4405,7 @@ U32 ActiveEventsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
   return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
@@ -4416,7 +4416,7 @@ Fw::String ActiveEventsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
   return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
@@ -4427,7 +4427,7 @@ void ActiveEventsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
   compPtr->noArgsSync_handlerBase(portNum);
 }
@@ -4445,7 +4445,7 @@ void ActiveEventsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
   compPtr->typedAliasGuarded_handlerBase(
     portNum,
@@ -4472,7 +4472,7 @@ AliasPrim2 ActiveEventsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
   return compPtr->typedAliasReturnSync_handlerBase(
     portNum,
@@ -4499,7 +4499,7 @@ Fw::String ActiveEventsComponentBase ::
       const AnotherAliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
   return compPtr->typedAliasStringReturnSync_handlerBase(
     portNum,
@@ -4526,7 +4526,7 @@ void ActiveEventsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
   compPtr->typedAsync_handlerBase(
     portNum,
@@ -4553,7 +4553,7 @@ void ActiveEventsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
   compPtr->typedAsyncAssert_handlerBase(
     portNum,
@@ -4580,7 +4580,7 @@ void ActiveEventsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
   compPtr->typedAsyncBlockPriority_handlerBase(
     portNum,
@@ -4607,7 +4607,7 @@ void ActiveEventsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
   compPtr->typedAsyncDropPriority_handlerBase(
     portNum,
@@ -4634,7 +4634,7 @@ void ActiveEventsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
   compPtr->typedGuarded_handlerBase(
     portNum,
@@ -4661,7 +4661,7 @@ F32 ActiveEventsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
   return compPtr->typedReturnGuarded_handlerBase(
     portNum,
@@ -4688,7 +4688,7 @@ F32 ActiveEventsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
   return compPtr->typedReturnSync_handlerBase(
     portNum,
@@ -4715,7 +4715,7 @@ void ActiveEventsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveEventsComponentBase* compPtr = static_cast<ActiveEventsComponentBase*>(callComp);
   compPtr->typedSync_handlerBase(
     portNum,

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveExternalParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveExternalParamsComponentAc.ref.cpp
@@ -4141,7 +4141,7 @@ void ActiveExternalParamsComponentBase ::
       Fw::CmdArgBuffer& args
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
   compPtr->cmdIn_handlerBase(
     portNum,
@@ -4168,7 +4168,7 @@ void ActiveExternalParamsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
   compPtr->aliasTypedAsync_handlerBase(
     portNum,
@@ -4188,7 +4188,7 @@ Fw::String ActiveExternalParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
   return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
@@ -4199,7 +4199,7 @@ void ActiveExternalParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
   compPtr->noArgsAsync_handlerBase(portNum);
 }
@@ -4210,7 +4210,7 @@ void ActiveExternalParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
   compPtr->noArgsGuarded_handlerBase(portNum);
 }
@@ -4221,7 +4221,7 @@ U32 ActiveExternalParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
   return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
@@ -4232,7 +4232,7 @@ U32 ActiveExternalParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
   return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
@@ -4243,7 +4243,7 @@ Fw::String ActiveExternalParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
   return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
@@ -4254,7 +4254,7 @@ void ActiveExternalParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
   compPtr->noArgsSync_handlerBase(portNum);
 }
@@ -4272,7 +4272,7 @@ void ActiveExternalParamsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
   compPtr->typedAliasGuarded_handlerBase(
     portNum,
@@ -4299,7 +4299,7 @@ AliasPrim2 ActiveExternalParamsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
   return compPtr->typedAliasReturnSync_handlerBase(
     portNum,
@@ -4326,7 +4326,7 @@ Fw::String ActiveExternalParamsComponentBase ::
       const AnotherAliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
   return compPtr->typedAliasStringReturnSync_handlerBase(
     portNum,
@@ -4353,7 +4353,7 @@ void ActiveExternalParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
   compPtr->typedAsync_handlerBase(
     portNum,
@@ -4380,7 +4380,7 @@ void ActiveExternalParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
   compPtr->typedAsyncAssert_handlerBase(
     portNum,
@@ -4407,7 +4407,7 @@ void ActiveExternalParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
   compPtr->typedAsyncBlockPriority_handlerBase(
     portNum,
@@ -4434,7 +4434,7 @@ void ActiveExternalParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
   compPtr->typedAsyncDropPriority_handlerBase(
     portNum,
@@ -4461,7 +4461,7 @@ void ActiveExternalParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
   compPtr->typedGuarded_handlerBase(
     portNum,
@@ -4488,7 +4488,7 @@ F32 ActiveExternalParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
   return compPtr->typedReturnGuarded_handlerBase(
     portNum,
@@ -4515,7 +4515,7 @@ F32 ActiveExternalParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
   return compPtr->typedReturnSync_handlerBase(
     portNum,
@@ -4542,7 +4542,7 @@ void ActiveExternalParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveExternalParamsComponentBase* compPtr = static_cast<ActiveExternalParamsComponentBase*>(callComp);
   compPtr->typedSync_handlerBase(
     portNum,

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveGetProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveGetProductsComponentAc.ref.cpp
@@ -3904,7 +3904,7 @@ void ActiveGetProductsComponentBase ::
       Fw::CmdArgBuffer& args
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
   compPtr->cmdIn_handlerBase(
     portNum,
@@ -3931,7 +3931,7 @@ void ActiveGetProductsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
   compPtr->aliasTypedAsync_handlerBase(
     portNum,
@@ -3951,7 +3951,7 @@ Fw::String ActiveGetProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
   return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
@@ -3962,7 +3962,7 @@ void ActiveGetProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
   compPtr->noArgsAsync_handlerBase(portNum);
 }
@@ -3973,7 +3973,7 @@ void ActiveGetProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
   compPtr->noArgsGuarded_handlerBase(portNum);
 }
@@ -3984,7 +3984,7 @@ U32 ActiveGetProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
   return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
@@ -3995,7 +3995,7 @@ U32 ActiveGetProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
   return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
@@ -4006,7 +4006,7 @@ Fw::String ActiveGetProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
   return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
@@ -4017,7 +4017,7 @@ void ActiveGetProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
   compPtr->noArgsSync_handlerBase(portNum);
 }
@@ -4035,7 +4035,7 @@ void ActiveGetProductsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
   compPtr->typedAliasGuarded_handlerBase(
     portNum,
@@ -4062,7 +4062,7 @@ AliasPrim2 ActiveGetProductsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
   return compPtr->typedAliasReturnSync_handlerBase(
     portNum,
@@ -4089,7 +4089,7 @@ Fw::String ActiveGetProductsComponentBase ::
       const AnotherAliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
   return compPtr->typedAliasStringReturnSync_handlerBase(
     portNum,
@@ -4116,7 +4116,7 @@ void ActiveGetProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
   compPtr->typedAsync_handlerBase(
     portNum,
@@ -4143,7 +4143,7 @@ void ActiveGetProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
   compPtr->typedAsyncAssert_handlerBase(
     portNum,
@@ -4170,7 +4170,7 @@ void ActiveGetProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
   compPtr->typedAsyncBlockPriority_handlerBase(
     portNum,
@@ -4197,7 +4197,7 @@ void ActiveGetProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
   compPtr->typedAsyncDropPriority_handlerBase(
     portNum,
@@ -4224,7 +4224,7 @@ void ActiveGetProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
   compPtr->typedGuarded_handlerBase(
     portNum,
@@ -4251,7 +4251,7 @@ F32 ActiveGetProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
   return compPtr->typedReturnGuarded_handlerBase(
     portNum,
@@ -4278,7 +4278,7 @@ F32 ActiveGetProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
   return compPtr->typedReturnSync_handlerBase(
     portNum,
@@ -4305,7 +4305,7 @@ void ActiveGetProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGetProductsComponentBase* compPtr = static_cast<ActiveGetProductsComponentBase*>(callComp);
   compPtr->typedSync_handlerBase(
     portNum,

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveGuardedProductsComponentAc.ref.cpp
@@ -3984,7 +3984,7 @@ void ActiveGuardedProductsComponentBase ::
       Fw::CmdArgBuffer& args
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
   compPtr->cmdIn_handlerBase(
     portNum,
@@ -4003,7 +4003,7 @@ void ActiveGuardedProductsComponentBase ::
       const Fw::Success& status
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
   compPtr->productRecvIn_handlerBase(
     portNum,
@@ -4030,7 +4030,7 @@ void ActiveGuardedProductsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
   compPtr->aliasTypedAsync_handlerBase(
     portNum,
@@ -4050,7 +4050,7 @@ Fw::String ActiveGuardedProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
   return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
@@ -4061,7 +4061,7 @@ void ActiveGuardedProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
   compPtr->noArgsAsync_handlerBase(portNum);
 }
@@ -4072,7 +4072,7 @@ void ActiveGuardedProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
   compPtr->noArgsGuarded_handlerBase(portNum);
 }
@@ -4083,7 +4083,7 @@ U32 ActiveGuardedProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
   return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
@@ -4094,7 +4094,7 @@ U32 ActiveGuardedProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
   return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
@@ -4105,7 +4105,7 @@ Fw::String ActiveGuardedProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
   return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
@@ -4116,7 +4116,7 @@ void ActiveGuardedProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
   compPtr->noArgsSync_handlerBase(portNum);
 }
@@ -4134,7 +4134,7 @@ void ActiveGuardedProductsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
   compPtr->typedAliasGuarded_handlerBase(
     portNum,
@@ -4161,7 +4161,7 @@ AliasPrim2 ActiveGuardedProductsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
   return compPtr->typedAliasReturnSync_handlerBase(
     portNum,
@@ -4188,7 +4188,7 @@ Fw::String ActiveGuardedProductsComponentBase ::
       const AnotherAliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
   return compPtr->typedAliasStringReturnSync_handlerBase(
     portNum,
@@ -4215,7 +4215,7 @@ void ActiveGuardedProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
   compPtr->typedAsync_handlerBase(
     portNum,
@@ -4242,7 +4242,7 @@ void ActiveGuardedProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
   compPtr->typedAsyncAssert_handlerBase(
     portNum,
@@ -4269,7 +4269,7 @@ void ActiveGuardedProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
   compPtr->typedAsyncBlockPriority_handlerBase(
     portNum,
@@ -4296,7 +4296,7 @@ void ActiveGuardedProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
   compPtr->typedAsyncDropPriority_handlerBase(
     portNum,
@@ -4323,7 +4323,7 @@ void ActiveGuardedProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
   compPtr->typedGuarded_handlerBase(
     portNum,
@@ -4350,7 +4350,7 @@ F32 ActiveGuardedProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
   return compPtr->typedReturnGuarded_handlerBase(
     portNum,
@@ -4377,7 +4377,7 @@ F32 ActiveGuardedProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
   return compPtr->typedReturnSync_handlerBase(
     portNum,
@@ -4404,7 +4404,7 @@ void ActiveGuardedProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveGuardedProductsComponentBase* compPtr = static_cast<ActiveGuardedProductsComponentBase*>(callComp);
   compPtr->typedSync_handlerBase(
     portNum,
@@ -4558,7 +4558,7 @@ void ActiveGuardedProductsComponentBase ::
       this->dpRecv_Container5_handler(container, status.e);
       break;
     default:
-      FW_ASSERT(0);
+      FW_ASSERT(false);
       break;
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveNoArgsPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveNoArgsPortsOnlyComponentAc.ref.cpp
@@ -625,7 +625,7 @@ void ActiveNoArgsPortsOnlyComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveNoArgsPortsOnlyComponentBase* compPtr = static_cast<ActiveNoArgsPortsOnlyComponentBase*>(callComp);
   compPtr->noArgsAsync_handlerBase(portNum);
 }
@@ -636,7 +636,7 @@ void ActiveNoArgsPortsOnlyComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveNoArgsPortsOnlyComponentBase* compPtr = static_cast<ActiveNoArgsPortsOnlyComponentBase*>(callComp);
   compPtr->noArgsGuarded_handlerBase(portNum);
 }
@@ -647,7 +647,7 @@ U32 ActiveNoArgsPortsOnlyComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveNoArgsPortsOnlyComponentBase* compPtr = static_cast<ActiveNoArgsPortsOnlyComponentBase*>(callComp);
   return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
@@ -658,7 +658,7 @@ U32 ActiveNoArgsPortsOnlyComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveNoArgsPortsOnlyComponentBase* compPtr = static_cast<ActiveNoArgsPortsOnlyComponentBase*>(callComp);
   return compPtr->noArgsReturnSync_handlerBase(portNum);
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveOverflowComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveOverflowComponentAc.ref.cpp
@@ -2439,7 +2439,7 @@ void ActiveOverflowComponentBase ::
       Fw::CmdArgBuffer& args
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
   compPtr->cmdIn_handlerBase(
     portNum,
@@ -2458,7 +2458,7 @@ void ActiveOverflowComponentBase ::
       const Fw::Success& status
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
   compPtr->productRecvInHook_handlerBase(
     portNum,
@@ -2485,7 +2485,7 @@ void ActiveOverflowComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
   compPtr->assertAsync_handlerBase(
     portNum,
@@ -2512,7 +2512,7 @@ void ActiveOverflowComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
   compPtr->blockAsync_handlerBase(
     portNum,
@@ -2539,7 +2539,7 @@ void ActiveOverflowComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
   compPtr->dropAsync_handlerBase(
     portNum,
@@ -2566,7 +2566,7 @@ void ActiveOverflowComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
   compPtr->hookAsync_handlerBase(
     portNum,
@@ -2593,7 +2593,7 @@ void ActiveOverflowComponentBase ::
       Fw::LinearBufferBase& buffer
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveOverflowComponentBase* compPtr = static_cast<ActiveOverflowComponentBase*>(callComp);
   compPtr->serialAsyncHook_handlerBase(
     portNum,

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.cpp
@@ -4004,7 +4004,7 @@ void ActiveParamsComponentBase ::
       Fw::CmdArgBuffer& args
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
   compPtr->cmdIn_handlerBase(
     portNum,
@@ -4031,7 +4031,7 @@ void ActiveParamsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
   compPtr->aliasTypedAsync_handlerBase(
     portNum,
@@ -4051,7 +4051,7 @@ Fw::String ActiveParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
   return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
@@ -4062,7 +4062,7 @@ void ActiveParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
   compPtr->noArgsAsync_handlerBase(portNum);
 }
@@ -4073,7 +4073,7 @@ void ActiveParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
   compPtr->noArgsGuarded_handlerBase(portNum);
 }
@@ -4084,7 +4084,7 @@ U32 ActiveParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
   return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
@@ -4095,7 +4095,7 @@ U32 ActiveParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
   return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
@@ -4106,7 +4106,7 @@ Fw::String ActiveParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
   return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
@@ -4117,7 +4117,7 @@ void ActiveParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
   compPtr->noArgsSync_handlerBase(portNum);
 }
@@ -4135,7 +4135,7 @@ void ActiveParamsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
   compPtr->typedAliasGuarded_handlerBase(
     portNum,
@@ -4162,7 +4162,7 @@ AliasPrim2 ActiveParamsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
   return compPtr->typedAliasReturnSync_handlerBase(
     portNum,
@@ -4189,7 +4189,7 @@ Fw::String ActiveParamsComponentBase ::
       const AnotherAliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
   return compPtr->typedAliasStringReturnSync_handlerBase(
     portNum,
@@ -4216,7 +4216,7 @@ void ActiveParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
   compPtr->typedAsync_handlerBase(
     portNum,
@@ -4243,7 +4243,7 @@ void ActiveParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
   compPtr->typedAsyncAssert_handlerBase(
     portNum,
@@ -4270,7 +4270,7 @@ void ActiveParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
   compPtr->typedAsyncBlockPriority_handlerBase(
     portNum,
@@ -4297,7 +4297,7 @@ void ActiveParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
   compPtr->typedAsyncDropPriority_handlerBase(
     portNum,
@@ -4324,7 +4324,7 @@ void ActiveParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
   compPtr->typedGuarded_handlerBase(
     portNum,
@@ -4351,7 +4351,7 @@ F32 ActiveParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
   return compPtr->typedReturnGuarded_handlerBase(
     portNum,
@@ -4378,7 +4378,7 @@ F32 ActiveParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
   return compPtr->typedReturnSync_handlerBase(
     portNum,
@@ -4405,7 +4405,7 @@ void ActiveParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveParamsComponentBase* compPtr = static_cast<ActiveParamsComponentBase*>(callComp);
   compPtr->typedSync_handlerBase(
     portNum,

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
@@ -8366,7 +8366,7 @@ void ActiveSerialComponentBase ::
       Fw::CmdArgBuffer& args
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
   compPtr->cmdIn_handlerBase(
     portNum,
@@ -8393,7 +8393,7 @@ void ActiveSerialComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
   compPtr->aliasTypedAsync_handlerBase(
     portNum,
@@ -8413,7 +8413,7 @@ Fw::String ActiveSerialComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
   return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
@@ -8424,7 +8424,7 @@ void ActiveSerialComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
   compPtr->noArgsAsync_handlerBase(portNum);
 }
@@ -8435,7 +8435,7 @@ void ActiveSerialComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
   compPtr->noArgsGuarded_handlerBase(portNum);
 }
@@ -8446,7 +8446,7 @@ U32 ActiveSerialComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
   return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
@@ -8457,7 +8457,7 @@ U32 ActiveSerialComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
   return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
@@ -8468,7 +8468,7 @@ Fw::String ActiveSerialComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
   return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
@@ -8479,7 +8479,7 @@ void ActiveSerialComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
   compPtr->noArgsSync_handlerBase(portNum);
 }
@@ -8497,7 +8497,7 @@ void ActiveSerialComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
   compPtr->typedAliasGuarded_handlerBase(
     portNum,
@@ -8524,7 +8524,7 @@ AliasPrim2 ActiveSerialComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
   return compPtr->typedAliasReturnSync_handlerBase(
     portNum,
@@ -8551,7 +8551,7 @@ Fw::String ActiveSerialComponentBase ::
       const AnotherAliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
   return compPtr->typedAliasStringReturnSync_handlerBase(
     portNum,
@@ -8578,7 +8578,7 @@ void ActiveSerialComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
   compPtr->typedAsync_handlerBase(
     portNum,
@@ -8605,7 +8605,7 @@ void ActiveSerialComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
   compPtr->typedAsyncAssert_handlerBase(
     portNum,
@@ -8632,7 +8632,7 @@ void ActiveSerialComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
   compPtr->typedAsyncBlockPriority_handlerBase(
     portNum,
@@ -8659,7 +8659,7 @@ void ActiveSerialComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
   compPtr->typedAsyncDropPriority_handlerBase(
     portNum,
@@ -8686,7 +8686,7 @@ void ActiveSerialComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
   compPtr->typedGuarded_handlerBase(
     portNum,
@@ -8713,7 +8713,7 @@ F32 ActiveSerialComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
   return compPtr->typedReturnGuarded_handlerBase(
     portNum,
@@ -8740,7 +8740,7 @@ F32 ActiveSerialComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
   return compPtr->typedReturnSync_handlerBase(
     portNum,
@@ -8767,7 +8767,7 @@ void ActiveSerialComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
   compPtr->typedSync_handlerBase(
     portNum,
@@ -8794,7 +8794,7 @@ void ActiveSerialComponentBase ::
       Fw::LinearBufferBase& buffer
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
   compPtr->serialAsync_handlerBase(
     portNum,
@@ -8809,7 +8809,7 @@ void ActiveSerialComponentBase ::
       Fw::LinearBufferBase& buffer
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
   compPtr->serialAsyncAssert_handlerBase(
     portNum,
@@ -8824,7 +8824,7 @@ void ActiveSerialComponentBase ::
       Fw::LinearBufferBase& buffer
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
   compPtr->serialAsyncBlockPriority_handlerBase(
     portNum,
@@ -8839,7 +8839,7 @@ void ActiveSerialComponentBase ::
       Fw::LinearBufferBase& buffer
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
   compPtr->serialAsyncDropPriority_handlerBase(
     portNum,
@@ -8854,7 +8854,7 @@ void ActiveSerialComponentBase ::
       Fw::LinearBufferBase& buffer
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
   compPtr->serialGuarded_handlerBase(
     portNum,
@@ -8869,7 +8869,7 @@ void ActiveSerialComponentBase ::
       Fw::LinearBufferBase& buffer
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSerialComponentBase* compPtr = static_cast<ActiveSerialComponentBase*>(callComp);
   compPtr->serialSync_handlerBase(
     portNum,

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSyncProductsComponentAc.ref.cpp
@@ -3978,7 +3978,7 @@ void ActiveSyncProductsComponentBase ::
       Fw::CmdArgBuffer& args
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
   compPtr->cmdIn_handlerBase(
     portNum,
@@ -3997,7 +3997,7 @@ void ActiveSyncProductsComponentBase ::
       const Fw::Success& status
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
   compPtr->productRecvIn_handlerBase(
     portNum,
@@ -4024,7 +4024,7 @@ void ActiveSyncProductsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
   compPtr->aliasTypedAsync_handlerBase(
     portNum,
@@ -4044,7 +4044,7 @@ Fw::String ActiveSyncProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
   return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
@@ -4055,7 +4055,7 @@ void ActiveSyncProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
   compPtr->noArgsAsync_handlerBase(portNum);
 }
@@ -4066,7 +4066,7 @@ void ActiveSyncProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
   compPtr->noArgsGuarded_handlerBase(portNum);
 }
@@ -4077,7 +4077,7 @@ U32 ActiveSyncProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
   return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
@@ -4088,7 +4088,7 @@ U32 ActiveSyncProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
   return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
@@ -4099,7 +4099,7 @@ Fw::String ActiveSyncProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
   return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
@@ -4110,7 +4110,7 @@ void ActiveSyncProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
   compPtr->noArgsSync_handlerBase(portNum);
 }
@@ -4128,7 +4128,7 @@ void ActiveSyncProductsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
   compPtr->typedAliasGuarded_handlerBase(
     portNum,
@@ -4155,7 +4155,7 @@ AliasPrim2 ActiveSyncProductsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
   return compPtr->typedAliasReturnSync_handlerBase(
     portNum,
@@ -4182,7 +4182,7 @@ Fw::String ActiveSyncProductsComponentBase ::
       const AnotherAliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
   return compPtr->typedAliasStringReturnSync_handlerBase(
     portNum,
@@ -4209,7 +4209,7 @@ void ActiveSyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
   compPtr->typedAsync_handlerBase(
     portNum,
@@ -4236,7 +4236,7 @@ void ActiveSyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
   compPtr->typedAsyncAssert_handlerBase(
     portNum,
@@ -4263,7 +4263,7 @@ void ActiveSyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
   compPtr->typedAsyncBlockPriority_handlerBase(
     portNum,
@@ -4290,7 +4290,7 @@ void ActiveSyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
   compPtr->typedAsyncDropPriority_handlerBase(
     portNum,
@@ -4317,7 +4317,7 @@ void ActiveSyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
   compPtr->typedGuarded_handlerBase(
     portNum,
@@ -4344,7 +4344,7 @@ F32 ActiveSyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
   return compPtr->typedReturnGuarded_handlerBase(
     portNum,
@@ -4371,7 +4371,7 @@ F32 ActiveSyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
   return compPtr->typedReturnSync_handlerBase(
     portNum,
@@ -4398,7 +4398,7 @@ void ActiveSyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveSyncProductsComponentBase* compPtr = static_cast<ActiveSyncProductsComponentBase*>(callComp);
   compPtr->typedSync_handlerBase(
     portNum,
@@ -4552,7 +4552,7 @@ void ActiveSyncProductsComponentBase ::
       this->dpRecv_Container5_handler(container, status.e);
       break;
     default:
-      FW_ASSERT(0);
+      FW_ASSERT(false);
       break;
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.cpp
@@ -3893,7 +3893,7 @@ void ActiveTelemetryComponentBase ::
       Fw::CmdArgBuffer& args
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
   compPtr->cmdIn_handlerBase(
     portNum,
@@ -3920,7 +3920,7 @@ void ActiveTelemetryComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
   compPtr->aliasTypedAsync_handlerBase(
     portNum,
@@ -3940,7 +3940,7 @@ Fw::String ActiveTelemetryComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
   return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
@@ -3951,7 +3951,7 @@ void ActiveTelemetryComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
   compPtr->noArgsAsync_handlerBase(portNum);
 }
@@ -3962,7 +3962,7 @@ void ActiveTelemetryComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
   compPtr->noArgsGuarded_handlerBase(portNum);
 }
@@ -3973,7 +3973,7 @@ U32 ActiveTelemetryComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
   return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
@@ -3984,7 +3984,7 @@ U32 ActiveTelemetryComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
   return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
@@ -3995,7 +3995,7 @@ Fw::String ActiveTelemetryComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
   return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
@@ -4006,7 +4006,7 @@ void ActiveTelemetryComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
   compPtr->noArgsSync_handlerBase(portNum);
 }
@@ -4024,7 +4024,7 @@ void ActiveTelemetryComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
   compPtr->typedAliasGuarded_handlerBase(
     portNum,
@@ -4051,7 +4051,7 @@ AliasPrim2 ActiveTelemetryComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
   return compPtr->typedAliasReturnSync_handlerBase(
     portNum,
@@ -4078,7 +4078,7 @@ Fw::String ActiveTelemetryComponentBase ::
       const AnotherAliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
   return compPtr->typedAliasStringReturnSync_handlerBase(
     portNum,
@@ -4105,7 +4105,7 @@ void ActiveTelemetryComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
   compPtr->typedAsync_handlerBase(
     portNum,
@@ -4132,7 +4132,7 @@ void ActiveTelemetryComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
   compPtr->typedAsyncAssert_handlerBase(
     portNum,
@@ -4159,7 +4159,7 @@ void ActiveTelemetryComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
   compPtr->typedAsyncBlockPriority_handlerBase(
     portNum,
@@ -4186,7 +4186,7 @@ void ActiveTelemetryComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
   compPtr->typedAsyncDropPriority_handlerBase(
     portNum,
@@ -4213,7 +4213,7 @@ void ActiveTelemetryComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
   compPtr->typedGuarded_handlerBase(
     portNum,
@@ -4240,7 +4240,7 @@ F32 ActiveTelemetryComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
   return compPtr->typedReturnGuarded_handlerBase(
     portNum,
@@ -4267,7 +4267,7 @@ F32 ActiveTelemetryComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
   return compPtr->typedReturnSync_handlerBase(
     portNum,
@@ -4294,7 +4294,7 @@ void ActiveTelemetryComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   ActiveTelemetryComponentBase* compPtr = static_cast<ActiveTelemetryComponentBase*>(callComp);
   compPtr->typedSync_handlerBase(
     portNum,

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
@@ -8188,7 +8188,7 @@ namespace M {
         Fw::CmdArgBuffer& args
     )
   {
-    FW_ASSERT(callComp);
+    FW_ASSERT(callComp != nullptr);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     compPtr->cmdIn_handlerBase(
       portNum,
@@ -8207,7 +8207,7 @@ namespace M {
         const Fw::Success& status
     )
   {
-    FW_ASSERT(callComp);
+    FW_ASSERT(callComp != nullptr);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     compPtr->productRecvIn_handlerBase(
       portNum,
@@ -8234,7 +8234,7 @@ namespace M {
         const AliasStruct& s
     )
   {
-    FW_ASSERT(callComp);
+    FW_ASSERT(callComp != nullptr);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     compPtr->aliasTypedAsync_handlerBase(
       portNum,
@@ -8254,7 +8254,7 @@ namespace M {
         FwIndexType portNum
     )
   {
-    FW_ASSERT(callComp);
+    FW_ASSERT(callComp != nullptr);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
   }
@@ -8265,7 +8265,7 @@ namespace M {
         FwIndexType portNum
     )
   {
-    FW_ASSERT(callComp);
+    FW_ASSERT(callComp != nullptr);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     compPtr->noArgsAsync_handlerBase(portNum);
   }
@@ -8276,7 +8276,7 @@ namespace M {
         FwIndexType portNum
     )
   {
-    FW_ASSERT(callComp);
+    FW_ASSERT(callComp != nullptr);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     compPtr->noArgsGuarded_handlerBase(portNum);
   }
@@ -8287,7 +8287,7 @@ namespace M {
         FwIndexType portNum
     )
   {
-    FW_ASSERT(callComp);
+    FW_ASSERT(callComp != nullptr);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     return compPtr->noArgsReturnGuarded_handlerBase(portNum);
   }
@@ -8298,7 +8298,7 @@ namespace M {
         FwIndexType portNum
     )
   {
-    FW_ASSERT(callComp);
+    FW_ASSERT(callComp != nullptr);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     return compPtr->noArgsReturnSync_handlerBase(portNum);
   }
@@ -8309,7 +8309,7 @@ namespace M {
         FwIndexType portNum
     )
   {
-    FW_ASSERT(callComp);
+    FW_ASSERT(callComp != nullptr);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     return compPtr->noArgsStringReturnSync_handlerBase(portNum);
   }
@@ -8320,7 +8320,7 @@ namespace M {
         FwIndexType portNum
     )
   {
-    FW_ASSERT(callComp);
+    FW_ASSERT(callComp != nullptr);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     compPtr->noArgsSync_handlerBase(portNum);
   }
@@ -8338,7 +8338,7 @@ namespace M {
         const AliasStruct& s
     )
   {
-    FW_ASSERT(callComp);
+    FW_ASSERT(callComp != nullptr);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     compPtr->typedAliasGuarded_handlerBase(
       portNum,
@@ -8365,7 +8365,7 @@ namespace M {
         const AliasStruct& s
     )
   {
-    FW_ASSERT(callComp);
+    FW_ASSERT(callComp != nullptr);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     return compPtr->typedAliasReturnSync_handlerBase(
       portNum,
@@ -8392,7 +8392,7 @@ namespace M {
         const AnotherAliasStruct& s
     )
   {
-    FW_ASSERT(callComp);
+    FW_ASSERT(callComp != nullptr);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     return compPtr->typedAliasStringReturnSync_handlerBase(
       portNum,
@@ -8419,7 +8419,7 @@ namespace M {
         const S& s
     )
   {
-    FW_ASSERT(callComp);
+    FW_ASSERT(callComp != nullptr);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     compPtr->typedAsync_handlerBase(
       portNum,
@@ -8446,7 +8446,7 @@ namespace M {
         const S& s
     )
   {
-    FW_ASSERT(callComp);
+    FW_ASSERT(callComp != nullptr);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     compPtr->typedAsyncAssert_handlerBase(
       portNum,
@@ -8473,7 +8473,7 @@ namespace M {
         const S& s
     )
   {
-    FW_ASSERT(callComp);
+    FW_ASSERT(callComp != nullptr);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     compPtr->typedAsyncBlockPriority_handlerBase(
       portNum,
@@ -8500,7 +8500,7 @@ namespace M {
         const S& s
     )
   {
-    FW_ASSERT(callComp);
+    FW_ASSERT(callComp != nullptr);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     compPtr->typedAsyncDropPriority_handlerBase(
       portNum,
@@ -8527,7 +8527,7 @@ namespace M {
         const S& s
     )
   {
-    FW_ASSERT(callComp);
+    FW_ASSERT(callComp != nullptr);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     compPtr->typedGuarded_handlerBase(
       portNum,
@@ -8554,7 +8554,7 @@ namespace M {
         const S& s
     )
   {
-    FW_ASSERT(callComp);
+    FW_ASSERT(callComp != nullptr);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     return compPtr->typedReturnGuarded_handlerBase(
       portNum,
@@ -8581,7 +8581,7 @@ namespace M {
         const S& s
     )
   {
-    FW_ASSERT(callComp);
+    FW_ASSERT(callComp != nullptr);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     return compPtr->typedReturnSync_handlerBase(
       portNum,
@@ -8608,7 +8608,7 @@ namespace M {
         const S& s
     )
   {
-    FW_ASSERT(callComp);
+    FW_ASSERT(callComp != nullptr);
     ActiveTestComponentBase* compPtr = static_cast<ActiveTestComponentBase*>(callComp);
     compPtr->typedSync_handlerBase(
       portNum,
@@ -9616,7 +9616,7 @@ namespace M {
         this->dpRecv_Container5_handler(container, status.e);
         break;
       default:
-        FW_ASSERT(0);
+        FW_ASSERT(false);
         break;
     }
   }

--- a/compiler/tools/fpp-to-cpp/test/component/base/NoArgsReturnPortAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/NoArgsReturnPortAc.ref.cpp
@@ -72,7 +72,7 @@ namespace Ports {
     // For ports with a return type, invokeSerial is not used
     (void) _buffer;
 
-    FW_ASSERT(0);
+    FW_ASSERT(false);
     return Fw::FW_SERIALIZE_OK;
   }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveCommandsComponentAc.ref.cpp
@@ -3014,7 +3014,7 @@ void PassiveCommandsComponentBase ::
       Fw::CmdArgBuffer& args
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveCommandsComponentBase* compPtr = static_cast<PassiveCommandsComponentBase*>(callComp);
   compPtr->cmdIn_handlerBase(
     portNum,
@@ -3034,7 +3034,7 @@ Fw::String PassiveCommandsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveCommandsComponentBase* compPtr = static_cast<PassiveCommandsComponentBase*>(callComp);
   return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
@@ -3045,7 +3045,7 @@ void PassiveCommandsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveCommandsComponentBase* compPtr = static_cast<PassiveCommandsComponentBase*>(callComp);
   compPtr->noArgsGuarded_handlerBase(portNum);
 }
@@ -3056,7 +3056,7 @@ U32 PassiveCommandsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveCommandsComponentBase* compPtr = static_cast<PassiveCommandsComponentBase*>(callComp);
   return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
@@ -3067,7 +3067,7 @@ U32 PassiveCommandsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveCommandsComponentBase* compPtr = static_cast<PassiveCommandsComponentBase*>(callComp);
   return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
@@ -3078,7 +3078,7 @@ Fw::String PassiveCommandsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveCommandsComponentBase* compPtr = static_cast<PassiveCommandsComponentBase*>(callComp);
   return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
@@ -3089,7 +3089,7 @@ void PassiveCommandsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveCommandsComponentBase* compPtr = static_cast<PassiveCommandsComponentBase*>(callComp);
   compPtr->noArgsSync_handlerBase(portNum);
 }
@@ -3107,7 +3107,7 @@ void PassiveCommandsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveCommandsComponentBase* compPtr = static_cast<PassiveCommandsComponentBase*>(callComp);
   compPtr->typedAliasGuarded_handlerBase(
     portNum,
@@ -3134,7 +3134,7 @@ AliasPrim2 PassiveCommandsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveCommandsComponentBase* compPtr = static_cast<PassiveCommandsComponentBase*>(callComp);
   return compPtr->typedAliasReturnSync_handlerBase(
     portNum,
@@ -3161,7 +3161,7 @@ Fw::String PassiveCommandsComponentBase ::
       const AnotherAliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveCommandsComponentBase* compPtr = static_cast<PassiveCommandsComponentBase*>(callComp);
   return compPtr->typedAliasStringReturnSync_handlerBase(
     portNum,
@@ -3188,7 +3188,7 @@ void PassiveCommandsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveCommandsComponentBase* compPtr = static_cast<PassiveCommandsComponentBase*>(callComp);
   compPtr->typedGuarded_handlerBase(
     portNum,
@@ -3215,7 +3215,7 @@ F32 PassiveCommandsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveCommandsComponentBase* compPtr = static_cast<PassiveCommandsComponentBase*>(callComp);
   return compPtr->typedReturnGuarded_handlerBase(
     portNum,
@@ -3242,7 +3242,7 @@ F32 PassiveCommandsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveCommandsComponentBase* compPtr = static_cast<PassiveCommandsComponentBase*>(callComp);
   return compPtr->typedReturnSync_handlerBase(
     portNum,
@@ -3269,7 +3269,7 @@ void PassiveCommandsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveCommandsComponentBase* compPtr = static_cast<PassiveCommandsComponentBase*>(callComp);
   compPtr->typedSync_handlerBase(
     portNum,

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveEventsComponentAc.ref.cpp
@@ -2928,7 +2928,7 @@ void PassiveEventsComponentBase ::
       Fw::CmdArgBuffer& args
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveEventsComponentBase* compPtr = static_cast<PassiveEventsComponentBase*>(callComp);
   compPtr->cmdIn_handlerBase(
     portNum,
@@ -2948,7 +2948,7 @@ Fw::String PassiveEventsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveEventsComponentBase* compPtr = static_cast<PassiveEventsComponentBase*>(callComp);
   return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
@@ -2959,7 +2959,7 @@ void PassiveEventsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveEventsComponentBase* compPtr = static_cast<PassiveEventsComponentBase*>(callComp);
   compPtr->noArgsGuarded_handlerBase(portNum);
 }
@@ -2970,7 +2970,7 @@ U32 PassiveEventsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveEventsComponentBase* compPtr = static_cast<PassiveEventsComponentBase*>(callComp);
   return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
@@ -2981,7 +2981,7 @@ U32 PassiveEventsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveEventsComponentBase* compPtr = static_cast<PassiveEventsComponentBase*>(callComp);
   return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
@@ -2992,7 +2992,7 @@ Fw::String PassiveEventsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveEventsComponentBase* compPtr = static_cast<PassiveEventsComponentBase*>(callComp);
   return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
@@ -3003,7 +3003,7 @@ void PassiveEventsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveEventsComponentBase* compPtr = static_cast<PassiveEventsComponentBase*>(callComp);
   compPtr->noArgsSync_handlerBase(portNum);
 }
@@ -3021,7 +3021,7 @@ void PassiveEventsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveEventsComponentBase* compPtr = static_cast<PassiveEventsComponentBase*>(callComp);
   compPtr->typedAliasGuarded_handlerBase(
     portNum,
@@ -3048,7 +3048,7 @@ AliasPrim2 PassiveEventsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveEventsComponentBase* compPtr = static_cast<PassiveEventsComponentBase*>(callComp);
   return compPtr->typedAliasReturnSync_handlerBase(
     portNum,
@@ -3075,7 +3075,7 @@ Fw::String PassiveEventsComponentBase ::
       const AnotherAliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveEventsComponentBase* compPtr = static_cast<PassiveEventsComponentBase*>(callComp);
   return compPtr->typedAliasStringReturnSync_handlerBase(
     portNum,
@@ -3102,7 +3102,7 @@ void PassiveEventsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveEventsComponentBase* compPtr = static_cast<PassiveEventsComponentBase*>(callComp);
   compPtr->typedGuarded_handlerBase(
     portNum,
@@ -3129,7 +3129,7 @@ F32 PassiveEventsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveEventsComponentBase* compPtr = static_cast<PassiveEventsComponentBase*>(callComp);
   return compPtr->typedReturnGuarded_handlerBase(
     portNum,
@@ -3156,7 +3156,7 @@ F32 PassiveEventsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveEventsComponentBase* compPtr = static_cast<PassiveEventsComponentBase*>(callComp);
   return compPtr->typedReturnSync_handlerBase(
     portNum,
@@ -3183,7 +3183,7 @@ void PassiveEventsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveEventsComponentBase* compPtr = static_cast<PassiveEventsComponentBase*>(callComp);
   compPtr->typedSync_handlerBase(
     portNum,

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveExternalParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveExternalParamsComponentAc.ref.cpp
@@ -2755,7 +2755,7 @@ void PassiveExternalParamsComponentBase ::
       Fw::CmdArgBuffer& args
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveExternalParamsComponentBase* compPtr = static_cast<PassiveExternalParamsComponentBase*>(callComp);
   compPtr->cmdIn_handlerBase(
     portNum,
@@ -2775,7 +2775,7 @@ Fw::String PassiveExternalParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveExternalParamsComponentBase* compPtr = static_cast<PassiveExternalParamsComponentBase*>(callComp);
   return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
@@ -2786,7 +2786,7 @@ void PassiveExternalParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveExternalParamsComponentBase* compPtr = static_cast<PassiveExternalParamsComponentBase*>(callComp);
   compPtr->noArgsGuarded_handlerBase(portNum);
 }
@@ -2797,7 +2797,7 @@ U32 PassiveExternalParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveExternalParamsComponentBase* compPtr = static_cast<PassiveExternalParamsComponentBase*>(callComp);
   return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
@@ -2808,7 +2808,7 @@ U32 PassiveExternalParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveExternalParamsComponentBase* compPtr = static_cast<PassiveExternalParamsComponentBase*>(callComp);
   return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
@@ -2819,7 +2819,7 @@ Fw::String PassiveExternalParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveExternalParamsComponentBase* compPtr = static_cast<PassiveExternalParamsComponentBase*>(callComp);
   return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
@@ -2830,7 +2830,7 @@ void PassiveExternalParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveExternalParamsComponentBase* compPtr = static_cast<PassiveExternalParamsComponentBase*>(callComp);
   compPtr->noArgsSync_handlerBase(portNum);
 }
@@ -2848,7 +2848,7 @@ void PassiveExternalParamsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveExternalParamsComponentBase* compPtr = static_cast<PassiveExternalParamsComponentBase*>(callComp);
   compPtr->typedAliasGuarded_handlerBase(
     portNum,
@@ -2875,7 +2875,7 @@ AliasPrim2 PassiveExternalParamsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveExternalParamsComponentBase* compPtr = static_cast<PassiveExternalParamsComponentBase*>(callComp);
   return compPtr->typedAliasReturnSync_handlerBase(
     portNum,
@@ -2902,7 +2902,7 @@ Fw::String PassiveExternalParamsComponentBase ::
       const AnotherAliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveExternalParamsComponentBase* compPtr = static_cast<PassiveExternalParamsComponentBase*>(callComp);
   return compPtr->typedAliasStringReturnSync_handlerBase(
     portNum,
@@ -2929,7 +2929,7 @@ void PassiveExternalParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveExternalParamsComponentBase* compPtr = static_cast<PassiveExternalParamsComponentBase*>(callComp);
   compPtr->typedGuarded_handlerBase(
     portNum,
@@ -2956,7 +2956,7 @@ F32 PassiveExternalParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveExternalParamsComponentBase* compPtr = static_cast<PassiveExternalParamsComponentBase*>(callComp);
   return compPtr->typedReturnGuarded_handlerBase(
     portNum,
@@ -2983,7 +2983,7 @@ F32 PassiveExternalParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveExternalParamsComponentBase* compPtr = static_cast<PassiveExternalParamsComponentBase*>(callComp);
   return compPtr->typedReturnSync_handlerBase(
     portNum,
@@ -3010,7 +3010,7 @@ void PassiveExternalParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveExternalParamsComponentBase* compPtr = static_cast<PassiveExternalParamsComponentBase*>(callComp);
   compPtr->typedSync_handlerBase(
     portNum,

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveGetProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveGetProductsComponentAc.ref.cpp
@@ -2518,7 +2518,7 @@ void PassiveGetProductsComponentBase ::
       Fw::CmdArgBuffer& args
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveGetProductsComponentBase* compPtr = static_cast<PassiveGetProductsComponentBase*>(callComp);
   compPtr->cmdIn_handlerBase(
     portNum,
@@ -2538,7 +2538,7 @@ Fw::String PassiveGetProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveGetProductsComponentBase* compPtr = static_cast<PassiveGetProductsComponentBase*>(callComp);
   return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
@@ -2549,7 +2549,7 @@ void PassiveGetProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveGetProductsComponentBase* compPtr = static_cast<PassiveGetProductsComponentBase*>(callComp);
   compPtr->noArgsGuarded_handlerBase(portNum);
 }
@@ -2560,7 +2560,7 @@ U32 PassiveGetProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveGetProductsComponentBase* compPtr = static_cast<PassiveGetProductsComponentBase*>(callComp);
   return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
@@ -2571,7 +2571,7 @@ U32 PassiveGetProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveGetProductsComponentBase* compPtr = static_cast<PassiveGetProductsComponentBase*>(callComp);
   return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
@@ -2582,7 +2582,7 @@ Fw::String PassiveGetProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveGetProductsComponentBase* compPtr = static_cast<PassiveGetProductsComponentBase*>(callComp);
   return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
@@ -2593,7 +2593,7 @@ void PassiveGetProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveGetProductsComponentBase* compPtr = static_cast<PassiveGetProductsComponentBase*>(callComp);
   compPtr->noArgsSync_handlerBase(portNum);
 }
@@ -2611,7 +2611,7 @@ void PassiveGetProductsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveGetProductsComponentBase* compPtr = static_cast<PassiveGetProductsComponentBase*>(callComp);
   compPtr->typedAliasGuarded_handlerBase(
     portNum,
@@ -2638,7 +2638,7 @@ AliasPrim2 PassiveGetProductsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveGetProductsComponentBase* compPtr = static_cast<PassiveGetProductsComponentBase*>(callComp);
   return compPtr->typedAliasReturnSync_handlerBase(
     portNum,
@@ -2665,7 +2665,7 @@ Fw::String PassiveGetProductsComponentBase ::
       const AnotherAliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveGetProductsComponentBase* compPtr = static_cast<PassiveGetProductsComponentBase*>(callComp);
   return compPtr->typedAliasStringReturnSync_handlerBase(
     portNum,
@@ -2692,7 +2692,7 @@ void PassiveGetProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveGetProductsComponentBase* compPtr = static_cast<PassiveGetProductsComponentBase*>(callComp);
   compPtr->typedGuarded_handlerBase(
     portNum,
@@ -2719,7 +2719,7 @@ F32 PassiveGetProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveGetProductsComponentBase* compPtr = static_cast<PassiveGetProductsComponentBase*>(callComp);
   return compPtr->typedReturnGuarded_handlerBase(
     portNum,
@@ -2746,7 +2746,7 @@ F32 PassiveGetProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveGetProductsComponentBase* compPtr = static_cast<PassiveGetProductsComponentBase*>(callComp);
   return compPtr->typedReturnSync_handlerBase(
     portNum,
@@ -2773,7 +2773,7 @@ void PassiveGetProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveGetProductsComponentBase* compPtr = static_cast<PassiveGetProductsComponentBase*>(callComp);
   compPtr->typedSync_handlerBase(
     portNum,

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveGuardedProductsComponentAc.ref.cpp
@@ -2598,7 +2598,7 @@ void PassiveGuardedProductsComponentBase ::
       Fw::CmdArgBuffer& args
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveGuardedProductsComponentBase* compPtr = static_cast<PassiveGuardedProductsComponentBase*>(callComp);
   compPtr->cmdIn_handlerBase(
     portNum,
@@ -2617,7 +2617,7 @@ void PassiveGuardedProductsComponentBase ::
       const Fw::Success& status
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveGuardedProductsComponentBase* compPtr = static_cast<PassiveGuardedProductsComponentBase*>(callComp);
   compPtr->productRecvIn_handlerBase(
     portNum,
@@ -2637,7 +2637,7 @@ Fw::String PassiveGuardedProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveGuardedProductsComponentBase* compPtr = static_cast<PassiveGuardedProductsComponentBase*>(callComp);
   return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
@@ -2648,7 +2648,7 @@ void PassiveGuardedProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveGuardedProductsComponentBase* compPtr = static_cast<PassiveGuardedProductsComponentBase*>(callComp);
   compPtr->noArgsGuarded_handlerBase(portNum);
 }
@@ -2659,7 +2659,7 @@ U32 PassiveGuardedProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveGuardedProductsComponentBase* compPtr = static_cast<PassiveGuardedProductsComponentBase*>(callComp);
   return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
@@ -2670,7 +2670,7 @@ U32 PassiveGuardedProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveGuardedProductsComponentBase* compPtr = static_cast<PassiveGuardedProductsComponentBase*>(callComp);
   return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
@@ -2681,7 +2681,7 @@ Fw::String PassiveGuardedProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveGuardedProductsComponentBase* compPtr = static_cast<PassiveGuardedProductsComponentBase*>(callComp);
   return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
@@ -2692,7 +2692,7 @@ void PassiveGuardedProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveGuardedProductsComponentBase* compPtr = static_cast<PassiveGuardedProductsComponentBase*>(callComp);
   compPtr->noArgsSync_handlerBase(portNum);
 }
@@ -2710,7 +2710,7 @@ void PassiveGuardedProductsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveGuardedProductsComponentBase* compPtr = static_cast<PassiveGuardedProductsComponentBase*>(callComp);
   compPtr->typedAliasGuarded_handlerBase(
     portNum,
@@ -2737,7 +2737,7 @@ AliasPrim2 PassiveGuardedProductsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveGuardedProductsComponentBase* compPtr = static_cast<PassiveGuardedProductsComponentBase*>(callComp);
   return compPtr->typedAliasReturnSync_handlerBase(
     portNum,
@@ -2764,7 +2764,7 @@ Fw::String PassiveGuardedProductsComponentBase ::
       const AnotherAliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveGuardedProductsComponentBase* compPtr = static_cast<PassiveGuardedProductsComponentBase*>(callComp);
   return compPtr->typedAliasStringReturnSync_handlerBase(
     portNum,
@@ -2791,7 +2791,7 @@ void PassiveGuardedProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveGuardedProductsComponentBase* compPtr = static_cast<PassiveGuardedProductsComponentBase*>(callComp);
   compPtr->typedGuarded_handlerBase(
     portNum,
@@ -2818,7 +2818,7 @@ F32 PassiveGuardedProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveGuardedProductsComponentBase* compPtr = static_cast<PassiveGuardedProductsComponentBase*>(callComp);
   return compPtr->typedReturnGuarded_handlerBase(
     portNum,
@@ -2845,7 +2845,7 @@ F32 PassiveGuardedProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveGuardedProductsComponentBase* compPtr = static_cast<PassiveGuardedProductsComponentBase*>(callComp);
   return compPtr->typedReturnSync_handlerBase(
     portNum,
@@ -2872,7 +2872,7 @@ void PassiveGuardedProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveGuardedProductsComponentBase* compPtr = static_cast<PassiveGuardedProductsComponentBase*>(callComp);
   compPtr->typedSync_handlerBase(
     portNum,
@@ -3026,7 +3026,7 @@ void PassiveGuardedProductsComponentBase ::
       this->dpRecv_Container5_handler(container, status.e);
       break;
     default:
-      FW_ASSERT(0);
+      FW_ASSERT(false);
       break;
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveParamsComponentAc.ref.cpp
@@ -2618,7 +2618,7 @@ void PassiveParamsComponentBase ::
       Fw::CmdArgBuffer& args
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveParamsComponentBase* compPtr = static_cast<PassiveParamsComponentBase*>(callComp);
   compPtr->cmdIn_handlerBase(
     portNum,
@@ -2638,7 +2638,7 @@ Fw::String PassiveParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveParamsComponentBase* compPtr = static_cast<PassiveParamsComponentBase*>(callComp);
   return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
@@ -2649,7 +2649,7 @@ void PassiveParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveParamsComponentBase* compPtr = static_cast<PassiveParamsComponentBase*>(callComp);
   compPtr->noArgsGuarded_handlerBase(portNum);
 }
@@ -2660,7 +2660,7 @@ U32 PassiveParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveParamsComponentBase* compPtr = static_cast<PassiveParamsComponentBase*>(callComp);
   return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
@@ -2671,7 +2671,7 @@ U32 PassiveParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveParamsComponentBase* compPtr = static_cast<PassiveParamsComponentBase*>(callComp);
   return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
@@ -2682,7 +2682,7 @@ Fw::String PassiveParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveParamsComponentBase* compPtr = static_cast<PassiveParamsComponentBase*>(callComp);
   return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
@@ -2693,7 +2693,7 @@ void PassiveParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveParamsComponentBase* compPtr = static_cast<PassiveParamsComponentBase*>(callComp);
   compPtr->noArgsSync_handlerBase(portNum);
 }
@@ -2711,7 +2711,7 @@ void PassiveParamsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveParamsComponentBase* compPtr = static_cast<PassiveParamsComponentBase*>(callComp);
   compPtr->typedAliasGuarded_handlerBase(
     portNum,
@@ -2738,7 +2738,7 @@ AliasPrim2 PassiveParamsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveParamsComponentBase* compPtr = static_cast<PassiveParamsComponentBase*>(callComp);
   return compPtr->typedAliasReturnSync_handlerBase(
     portNum,
@@ -2765,7 +2765,7 @@ Fw::String PassiveParamsComponentBase ::
       const AnotherAliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveParamsComponentBase* compPtr = static_cast<PassiveParamsComponentBase*>(callComp);
   return compPtr->typedAliasStringReturnSync_handlerBase(
     portNum,
@@ -2792,7 +2792,7 @@ void PassiveParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveParamsComponentBase* compPtr = static_cast<PassiveParamsComponentBase*>(callComp);
   compPtr->typedGuarded_handlerBase(
     portNum,
@@ -2819,7 +2819,7 @@ F32 PassiveParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveParamsComponentBase* compPtr = static_cast<PassiveParamsComponentBase*>(callComp);
   return compPtr->typedReturnGuarded_handlerBase(
     portNum,
@@ -2846,7 +2846,7 @@ F32 PassiveParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveParamsComponentBase* compPtr = static_cast<PassiveParamsComponentBase*>(callComp);
   return compPtr->typedReturnSync_handlerBase(
     portNum,
@@ -2873,7 +2873,7 @@ void PassiveParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveParamsComponentBase* compPtr = static_cast<PassiveParamsComponentBase*>(callComp);
   compPtr->typedSync_handlerBase(
     portNum,

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
@@ -5318,7 +5318,7 @@ void PassiveSerialComponentBase ::
       Fw::CmdArgBuffer& args
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveSerialComponentBase* compPtr = static_cast<PassiveSerialComponentBase*>(callComp);
   compPtr->cmdIn_handlerBase(
     portNum,
@@ -5338,7 +5338,7 @@ Fw::String PassiveSerialComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveSerialComponentBase* compPtr = static_cast<PassiveSerialComponentBase*>(callComp);
   return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
@@ -5349,7 +5349,7 @@ void PassiveSerialComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveSerialComponentBase* compPtr = static_cast<PassiveSerialComponentBase*>(callComp);
   compPtr->noArgsGuarded_handlerBase(portNum);
 }
@@ -5360,7 +5360,7 @@ U32 PassiveSerialComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveSerialComponentBase* compPtr = static_cast<PassiveSerialComponentBase*>(callComp);
   return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
@@ -5371,7 +5371,7 @@ U32 PassiveSerialComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveSerialComponentBase* compPtr = static_cast<PassiveSerialComponentBase*>(callComp);
   return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
@@ -5382,7 +5382,7 @@ Fw::String PassiveSerialComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveSerialComponentBase* compPtr = static_cast<PassiveSerialComponentBase*>(callComp);
   return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
@@ -5393,7 +5393,7 @@ void PassiveSerialComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveSerialComponentBase* compPtr = static_cast<PassiveSerialComponentBase*>(callComp);
   compPtr->noArgsSync_handlerBase(portNum);
 }
@@ -5411,7 +5411,7 @@ void PassiveSerialComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveSerialComponentBase* compPtr = static_cast<PassiveSerialComponentBase*>(callComp);
   compPtr->typedAliasGuarded_handlerBase(
     portNum,
@@ -5438,7 +5438,7 @@ AliasPrim2 PassiveSerialComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveSerialComponentBase* compPtr = static_cast<PassiveSerialComponentBase*>(callComp);
   return compPtr->typedAliasReturnSync_handlerBase(
     portNum,
@@ -5465,7 +5465,7 @@ Fw::String PassiveSerialComponentBase ::
       const AnotherAliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveSerialComponentBase* compPtr = static_cast<PassiveSerialComponentBase*>(callComp);
   return compPtr->typedAliasStringReturnSync_handlerBase(
     portNum,
@@ -5492,7 +5492,7 @@ void PassiveSerialComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveSerialComponentBase* compPtr = static_cast<PassiveSerialComponentBase*>(callComp);
   compPtr->typedGuarded_handlerBase(
     portNum,
@@ -5519,7 +5519,7 @@ F32 PassiveSerialComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveSerialComponentBase* compPtr = static_cast<PassiveSerialComponentBase*>(callComp);
   return compPtr->typedReturnGuarded_handlerBase(
     portNum,
@@ -5546,7 +5546,7 @@ F32 PassiveSerialComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveSerialComponentBase* compPtr = static_cast<PassiveSerialComponentBase*>(callComp);
   return compPtr->typedReturnSync_handlerBase(
     portNum,
@@ -5573,7 +5573,7 @@ void PassiveSerialComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveSerialComponentBase* compPtr = static_cast<PassiveSerialComponentBase*>(callComp);
   compPtr->typedSync_handlerBase(
     portNum,
@@ -5600,7 +5600,7 @@ void PassiveSerialComponentBase ::
       Fw::LinearBufferBase& buffer
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveSerialComponentBase* compPtr = static_cast<PassiveSerialComponentBase*>(callComp);
   compPtr->serialGuarded_handlerBase(
     portNum,
@@ -5615,7 +5615,7 @@ void PassiveSerialComponentBase ::
       Fw::LinearBufferBase& buffer
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveSerialComponentBase* compPtr = static_cast<PassiveSerialComponentBase*>(callComp);
   compPtr->serialSync_handlerBase(
     portNum,

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductPortsOnlyComponentAc.ref.cpp
@@ -270,7 +270,7 @@ void PassiveSyncProductPortsOnlyComponentBase ::
       const Fw::Success& status
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveSyncProductPortsOnlyComponentBase* compPtr = static_cast<PassiveSyncProductPortsOnlyComponentBase*>(callComp);
   compPtr->productRecvIn_handlerBase(
     portNum,

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductsComponentAc.ref.cpp
@@ -2592,7 +2592,7 @@ void PassiveSyncProductsComponentBase ::
       Fw::CmdArgBuffer& args
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveSyncProductsComponentBase* compPtr = static_cast<PassiveSyncProductsComponentBase*>(callComp);
   compPtr->cmdIn_handlerBase(
     portNum,
@@ -2611,7 +2611,7 @@ void PassiveSyncProductsComponentBase ::
       const Fw::Success& status
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveSyncProductsComponentBase* compPtr = static_cast<PassiveSyncProductsComponentBase*>(callComp);
   compPtr->productRecvIn_handlerBase(
     portNum,
@@ -2631,7 +2631,7 @@ Fw::String PassiveSyncProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveSyncProductsComponentBase* compPtr = static_cast<PassiveSyncProductsComponentBase*>(callComp);
   return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
@@ -2642,7 +2642,7 @@ void PassiveSyncProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveSyncProductsComponentBase* compPtr = static_cast<PassiveSyncProductsComponentBase*>(callComp);
   compPtr->noArgsGuarded_handlerBase(portNum);
 }
@@ -2653,7 +2653,7 @@ U32 PassiveSyncProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveSyncProductsComponentBase* compPtr = static_cast<PassiveSyncProductsComponentBase*>(callComp);
   return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
@@ -2664,7 +2664,7 @@ U32 PassiveSyncProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveSyncProductsComponentBase* compPtr = static_cast<PassiveSyncProductsComponentBase*>(callComp);
   return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
@@ -2675,7 +2675,7 @@ Fw::String PassiveSyncProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveSyncProductsComponentBase* compPtr = static_cast<PassiveSyncProductsComponentBase*>(callComp);
   return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
@@ -2686,7 +2686,7 @@ void PassiveSyncProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveSyncProductsComponentBase* compPtr = static_cast<PassiveSyncProductsComponentBase*>(callComp);
   compPtr->noArgsSync_handlerBase(portNum);
 }
@@ -2704,7 +2704,7 @@ void PassiveSyncProductsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveSyncProductsComponentBase* compPtr = static_cast<PassiveSyncProductsComponentBase*>(callComp);
   compPtr->typedAliasGuarded_handlerBase(
     portNum,
@@ -2731,7 +2731,7 @@ AliasPrim2 PassiveSyncProductsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveSyncProductsComponentBase* compPtr = static_cast<PassiveSyncProductsComponentBase*>(callComp);
   return compPtr->typedAliasReturnSync_handlerBase(
     portNum,
@@ -2758,7 +2758,7 @@ Fw::String PassiveSyncProductsComponentBase ::
       const AnotherAliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveSyncProductsComponentBase* compPtr = static_cast<PassiveSyncProductsComponentBase*>(callComp);
   return compPtr->typedAliasStringReturnSync_handlerBase(
     portNum,
@@ -2785,7 +2785,7 @@ void PassiveSyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveSyncProductsComponentBase* compPtr = static_cast<PassiveSyncProductsComponentBase*>(callComp);
   compPtr->typedGuarded_handlerBase(
     portNum,
@@ -2812,7 +2812,7 @@ F32 PassiveSyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveSyncProductsComponentBase* compPtr = static_cast<PassiveSyncProductsComponentBase*>(callComp);
   return compPtr->typedReturnGuarded_handlerBase(
     portNum,
@@ -2839,7 +2839,7 @@ F32 PassiveSyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveSyncProductsComponentBase* compPtr = static_cast<PassiveSyncProductsComponentBase*>(callComp);
   return compPtr->typedReturnSync_handlerBase(
     portNum,
@@ -2866,7 +2866,7 @@ void PassiveSyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveSyncProductsComponentBase* compPtr = static_cast<PassiveSyncProductsComponentBase*>(callComp);
   compPtr->typedSync_handlerBase(
     portNum,
@@ -3020,7 +3020,7 @@ void PassiveSyncProductsComponentBase ::
       this->dpRecv_Container5_handler(container, status.e);
       break;
     default:
-      FW_ASSERT(0);
+      FW_ASSERT(false);
       break;
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTelemetryComponentAc.ref.cpp
@@ -2507,7 +2507,7 @@ void PassiveTelemetryComponentBase ::
       Fw::CmdArgBuffer& args
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveTelemetryComponentBase* compPtr = static_cast<PassiveTelemetryComponentBase*>(callComp);
   compPtr->cmdIn_handlerBase(
     portNum,
@@ -2527,7 +2527,7 @@ Fw::String PassiveTelemetryComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveTelemetryComponentBase* compPtr = static_cast<PassiveTelemetryComponentBase*>(callComp);
   return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
@@ -2538,7 +2538,7 @@ void PassiveTelemetryComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveTelemetryComponentBase* compPtr = static_cast<PassiveTelemetryComponentBase*>(callComp);
   compPtr->noArgsGuarded_handlerBase(portNum);
 }
@@ -2549,7 +2549,7 @@ U32 PassiveTelemetryComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveTelemetryComponentBase* compPtr = static_cast<PassiveTelemetryComponentBase*>(callComp);
   return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
@@ -2560,7 +2560,7 @@ U32 PassiveTelemetryComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveTelemetryComponentBase* compPtr = static_cast<PassiveTelemetryComponentBase*>(callComp);
   return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
@@ -2571,7 +2571,7 @@ Fw::String PassiveTelemetryComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveTelemetryComponentBase* compPtr = static_cast<PassiveTelemetryComponentBase*>(callComp);
   return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
@@ -2582,7 +2582,7 @@ void PassiveTelemetryComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveTelemetryComponentBase* compPtr = static_cast<PassiveTelemetryComponentBase*>(callComp);
   compPtr->noArgsSync_handlerBase(portNum);
 }
@@ -2600,7 +2600,7 @@ void PassiveTelemetryComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveTelemetryComponentBase* compPtr = static_cast<PassiveTelemetryComponentBase*>(callComp);
   compPtr->typedAliasGuarded_handlerBase(
     portNum,
@@ -2627,7 +2627,7 @@ AliasPrim2 PassiveTelemetryComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveTelemetryComponentBase* compPtr = static_cast<PassiveTelemetryComponentBase*>(callComp);
   return compPtr->typedAliasReturnSync_handlerBase(
     portNum,
@@ -2654,7 +2654,7 @@ Fw::String PassiveTelemetryComponentBase ::
       const AnotherAliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveTelemetryComponentBase* compPtr = static_cast<PassiveTelemetryComponentBase*>(callComp);
   return compPtr->typedAliasStringReturnSync_handlerBase(
     portNum,
@@ -2681,7 +2681,7 @@ void PassiveTelemetryComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveTelemetryComponentBase* compPtr = static_cast<PassiveTelemetryComponentBase*>(callComp);
   compPtr->typedGuarded_handlerBase(
     portNum,
@@ -2708,7 +2708,7 @@ F32 PassiveTelemetryComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveTelemetryComponentBase* compPtr = static_cast<PassiveTelemetryComponentBase*>(callComp);
   return compPtr->typedReturnGuarded_handlerBase(
     portNum,
@@ -2735,7 +2735,7 @@ F32 PassiveTelemetryComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveTelemetryComponentBase* compPtr = static_cast<PassiveTelemetryComponentBase*>(callComp);
   return compPtr->typedReturnSync_handlerBase(
     portNum,
@@ -2762,7 +2762,7 @@ void PassiveTelemetryComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveTelemetryComponentBase* compPtr = static_cast<PassiveTelemetryComponentBase*>(callComp);
   compPtr->typedSync_handlerBase(
     portNum,

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
@@ -5528,7 +5528,7 @@ void PassiveTestComponentBase ::
       Fw::CmdArgBuffer& args
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveTestComponentBase* compPtr = static_cast<PassiveTestComponentBase*>(callComp);
   compPtr->cmdIn_handlerBase(
     portNum,
@@ -5547,7 +5547,7 @@ void PassiveTestComponentBase ::
       const Fw::Success& status
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveTestComponentBase* compPtr = static_cast<PassiveTestComponentBase*>(callComp);
   compPtr->productRecvIn_handlerBase(
     portNum,
@@ -5567,7 +5567,7 @@ Fw::String PassiveTestComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveTestComponentBase* compPtr = static_cast<PassiveTestComponentBase*>(callComp);
   return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
@@ -5578,7 +5578,7 @@ void PassiveTestComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveTestComponentBase* compPtr = static_cast<PassiveTestComponentBase*>(callComp);
   compPtr->noArgsGuarded_handlerBase(portNum);
 }
@@ -5589,7 +5589,7 @@ U32 PassiveTestComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveTestComponentBase* compPtr = static_cast<PassiveTestComponentBase*>(callComp);
   return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
@@ -5600,7 +5600,7 @@ U32 PassiveTestComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveTestComponentBase* compPtr = static_cast<PassiveTestComponentBase*>(callComp);
   return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
@@ -5611,7 +5611,7 @@ Fw::String PassiveTestComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveTestComponentBase* compPtr = static_cast<PassiveTestComponentBase*>(callComp);
   return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
@@ -5622,7 +5622,7 @@ void PassiveTestComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveTestComponentBase* compPtr = static_cast<PassiveTestComponentBase*>(callComp);
   compPtr->noArgsSync_handlerBase(portNum);
 }
@@ -5640,7 +5640,7 @@ void PassiveTestComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveTestComponentBase* compPtr = static_cast<PassiveTestComponentBase*>(callComp);
   compPtr->typedAliasGuarded_handlerBase(
     portNum,
@@ -5667,7 +5667,7 @@ AliasPrim2 PassiveTestComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveTestComponentBase* compPtr = static_cast<PassiveTestComponentBase*>(callComp);
   return compPtr->typedAliasReturnSync_handlerBase(
     portNum,
@@ -5694,7 +5694,7 @@ Fw::String PassiveTestComponentBase ::
       const AnotherAliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveTestComponentBase* compPtr = static_cast<PassiveTestComponentBase*>(callComp);
   return compPtr->typedAliasStringReturnSync_handlerBase(
     portNum,
@@ -5721,7 +5721,7 @@ void PassiveTestComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveTestComponentBase* compPtr = static_cast<PassiveTestComponentBase*>(callComp);
   compPtr->typedGuarded_handlerBase(
     portNum,
@@ -5748,7 +5748,7 @@ F32 PassiveTestComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveTestComponentBase* compPtr = static_cast<PassiveTestComponentBase*>(callComp);
   return compPtr->typedReturnGuarded_handlerBase(
     portNum,
@@ -5775,7 +5775,7 @@ F32 PassiveTestComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveTestComponentBase* compPtr = static_cast<PassiveTestComponentBase*>(callComp);
   return compPtr->typedReturnSync_handlerBase(
     portNum,
@@ -5802,7 +5802,7 @@ void PassiveTestComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   PassiveTestComponentBase* compPtr = static_cast<PassiveTestComponentBase*>(callComp);
   compPtr->typedSync_handlerBase(
     portNum,
@@ -6810,7 +6810,7 @@ void PassiveTestComponentBase ::
       this->dpRecv_Container5_handler(container, status.e);
       break;
     default:
-      FW_ASSERT(0);
+      FW_ASSERT(false);
       break;
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductPortsOnlyComponentAc.ref.cpp
@@ -509,7 +509,7 @@ void QueuedAsyncProductPortsOnlyComponentBase ::
       const Fw::Success& status
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedAsyncProductPortsOnlyComponentBase* compPtr = static_cast<QueuedAsyncProductPortsOnlyComponentBase*>(callComp);
   compPtr->productRecvIn_handlerBase(
     portNum,

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductsComponentAc.ref.cpp
@@ -4083,7 +4083,7 @@ void QueuedAsyncProductsComponentBase ::
       Fw::CmdArgBuffer& args
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
   compPtr->cmdIn_handlerBase(
     portNum,
@@ -4102,7 +4102,7 @@ void QueuedAsyncProductsComponentBase ::
       const Fw::Success& status
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
   compPtr->productRecvIn_handlerBase(
     portNum,
@@ -4129,7 +4129,7 @@ void QueuedAsyncProductsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
   compPtr->aliasTypedAsync_handlerBase(
     portNum,
@@ -4149,7 +4149,7 @@ Fw::String QueuedAsyncProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
   return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
@@ -4160,7 +4160,7 @@ void QueuedAsyncProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
   compPtr->noArgsAsync_handlerBase(portNum);
 }
@@ -4171,7 +4171,7 @@ void QueuedAsyncProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
   compPtr->noArgsGuarded_handlerBase(portNum);
 }
@@ -4182,7 +4182,7 @@ U32 QueuedAsyncProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
   return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
@@ -4193,7 +4193,7 @@ U32 QueuedAsyncProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
   return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
@@ -4204,7 +4204,7 @@ Fw::String QueuedAsyncProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
   return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
@@ -4215,7 +4215,7 @@ void QueuedAsyncProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
   compPtr->noArgsSync_handlerBase(portNum);
 }
@@ -4233,7 +4233,7 @@ void QueuedAsyncProductsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
   compPtr->typedAliasGuarded_handlerBase(
     portNum,
@@ -4260,7 +4260,7 @@ AliasPrim2 QueuedAsyncProductsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
   return compPtr->typedAliasReturnSync_handlerBase(
     portNum,
@@ -4287,7 +4287,7 @@ Fw::String QueuedAsyncProductsComponentBase ::
       const AnotherAliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
   return compPtr->typedAliasStringReturnSync_handlerBase(
     portNum,
@@ -4314,7 +4314,7 @@ void QueuedAsyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
   compPtr->typedAsync_handlerBase(
     portNum,
@@ -4341,7 +4341,7 @@ void QueuedAsyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
   compPtr->typedAsyncAssert_handlerBase(
     portNum,
@@ -4368,7 +4368,7 @@ void QueuedAsyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
   compPtr->typedAsyncBlockPriority_handlerBase(
     portNum,
@@ -4395,7 +4395,7 @@ void QueuedAsyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
   compPtr->typedAsyncDropPriority_handlerBase(
     portNum,
@@ -4422,7 +4422,7 @@ void QueuedAsyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
   compPtr->typedGuarded_handlerBase(
     portNum,
@@ -4449,7 +4449,7 @@ F32 QueuedAsyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
   return compPtr->typedReturnGuarded_handlerBase(
     portNum,
@@ -4476,7 +4476,7 @@ F32 QueuedAsyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
   return compPtr->typedReturnSync_handlerBase(
     portNum,
@@ -4503,7 +4503,7 @@ void QueuedAsyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedAsyncProductsComponentBase* compPtr = static_cast<QueuedAsyncProductsComponentBase*>(callComp);
   compPtr->typedSync_handlerBase(
     portNum,
@@ -4657,7 +4657,7 @@ void QueuedAsyncProductsComponentBase ::
       this->dpRecv_Container5_handler(container, status.e);
       break;
     default:
-      FW_ASSERT(0);
+      FW_ASSERT(false);
       break;
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedCommandsComponentAc.ref.cpp
@@ -5138,7 +5138,7 @@ void QueuedCommandsComponentBase ::
       Fw::CmdArgBuffer& args
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
   compPtr->cmdIn_handlerBase(
     portNum,
@@ -5165,7 +5165,7 @@ void QueuedCommandsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
   compPtr->aliasTypedAsync_handlerBase(
     portNum,
@@ -5185,7 +5185,7 @@ Fw::String QueuedCommandsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
   return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
@@ -5196,7 +5196,7 @@ void QueuedCommandsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
   compPtr->noArgsAsync_handlerBase(portNum);
 }
@@ -5207,7 +5207,7 @@ void QueuedCommandsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
   compPtr->noArgsGuarded_handlerBase(portNum);
 }
@@ -5218,7 +5218,7 @@ U32 QueuedCommandsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
   return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
@@ -5229,7 +5229,7 @@ U32 QueuedCommandsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
   return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
@@ -5240,7 +5240,7 @@ Fw::String QueuedCommandsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
   return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
@@ -5251,7 +5251,7 @@ void QueuedCommandsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
   compPtr->noArgsSync_handlerBase(portNum);
 }
@@ -5269,7 +5269,7 @@ void QueuedCommandsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
   compPtr->typedAliasGuarded_handlerBase(
     portNum,
@@ -5296,7 +5296,7 @@ AliasPrim2 QueuedCommandsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
   return compPtr->typedAliasReturnSync_handlerBase(
     portNum,
@@ -5323,7 +5323,7 @@ Fw::String QueuedCommandsComponentBase ::
       const AnotherAliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
   return compPtr->typedAliasStringReturnSync_handlerBase(
     portNum,
@@ -5350,7 +5350,7 @@ void QueuedCommandsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
   compPtr->typedAsync_handlerBase(
     portNum,
@@ -5377,7 +5377,7 @@ void QueuedCommandsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
   compPtr->typedAsyncAssert_handlerBase(
     portNum,
@@ -5404,7 +5404,7 @@ void QueuedCommandsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
   compPtr->typedAsyncBlockPriority_handlerBase(
     portNum,
@@ -5431,7 +5431,7 @@ void QueuedCommandsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
   compPtr->typedAsyncDropPriority_handlerBase(
     portNum,
@@ -5458,7 +5458,7 @@ void QueuedCommandsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
   compPtr->typedGuarded_handlerBase(
     portNum,
@@ -5485,7 +5485,7 @@ F32 QueuedCommandsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
   return compPtr->typedReturnGuarded_handlerBase(
     portNum,
@@ -5512,7 +5512,7 @@ F32 QueuedCommandsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
   return compPtr->typedReturnSync_handlerBase(
     portNum,
@@ -5539,7 +5539,7 @@ void QueuedCommandsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedCommandsComponentBase* compPtr = static_cast<QueuedCommandsComponentBase*>(callComp);
   compPtr->typedSync_handlerBase(
     portNum,

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.cpp
@@ -4338,7 +4338,7 @@ void QueuedEventsComponentBase ::
       Fw::CmdArgBuffer& args
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
   compPtr->cmdIn_handlerBase(
     portNum,
@@ -4365,7 +4365,7 @@ void QueuedEventsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
   compPtr->aliasTypedAsync_handlerBase(
     portNum,
@@ -4385,7 +4385,7 @@ Fw::String QueuedEventsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
   return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
@@ -4396,7 +4396,7 @@ void QueuedEventsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
   compPtr->noArgsAsync_handlerBase(portNum);
 }
@@ -4407,7 +4407,7 @@ void QueuedEventsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
   compPtr->noArgsGuarded_handlerBase(portNum);
 }
@@ -4418,7 +4418,7 @@ U32 QueuedEventsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
   return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
@@ -4429,7 +4429,7 @@ U32 QueuedEventsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
   return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
@@ -4440,7 +4440,7 @@ Fw::String QueuedEventsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
   return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
@@ -4451,7 +4451,7 @@ void QueuedEventsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
   compPtr->noArgsSync_handlerBase(portNum);
 }
@@ -4469,7 +4469,7 @@ void QueuedEventsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
   compPtr->typedAliasGuarded_handlerBase(
     portNum,
@@ -4496,7 +4496,7 @@ AliasPrim2 QueuedEventsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
   return compPtr->typedAliasReturnSync_handlerBase(
     portNum,
@@ -4523,7 +4523,7 @@ Fw::String QueuedEventsComponentBase ::
       const AnotherAliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
   return compPtr->typedAliasStringReturnSync_handlerBase(
     portNum,
@@ -4550,7 +4550,7 @@ void QueuedEventsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
   compPtr->typedAsync_handlerBase(
     portNum,
@@ -4577,7 +4577,7 @@ void QueuedEventsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
   compPtr->typedAsyncAssert_handlerBase(
     portNum,
@@ -4604,7 +4604,7 @@ void QueuedEventsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
   compPtr->typedAsyncBlockPriority_handlerBase(
     portNum,
@@ -4631,7 +4631,7 @@ void QueuedEventsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
   compPtr->typedAsyncDropPriority_handlerBase(
     portNum,
@@ -4658,7 +4658,7 @@ void QueuedEventsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
   compPtr->typedGuarded_handlerBase(
     portNum,
@@ -4685,7 +4685,7 @@ F32 QueuedEventsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
   return compPtr->typedReturnGuarded_handlerBase(
     portNum,
@@ -4712,7 +4712,7 @@ F32 QueuedEventsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
   return compPtr->typedReturnSync_handlerBase(
     portNum,
@@ -4739,7 +4739,7 @@ void QueuedEventsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedEventsComponentBase* compPtr = static_cast<QueuedEventsComponentBase*>(callComp);
   compPtr->typedSync_handlerBase(
     portNum,

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedExternalParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedExternalParamsComponentAc.ref.cpp
@@ -4165,7 +4165,7 @@ void QueuedExternalParamsComponentBase ::
       Fw::CmdArgBuffer& args
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
   compPtr->cmdIn_handlerBase(
     portNum,
@@ -4192,7 +4192,7 @@ void QueuedExternalParamsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
   compPtr->aliasTypedAsync_handlerBase(
     portNum,
@@ -4212,7 +4212,7 @@ Fw::String QueuedExternalParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
   return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
@@ -4223,7 +4223,7 @@ void QueuedExternalParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
   compPtr->noArgsAsync_handlerBase(portNum);
 }
@@ -4234,7 +4234,7 @@ void QueuedExternalParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
   compPtr->noArgsGuarded_handlerBase(portNum);
 }
@@ -4245,7 +4245,7 @@ U32 QueuedExternalParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
   return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
@@ -4256,7 +4256,7 @@ U32 QueuedExternalParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
   return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
@@ -4267,7 +4267,7 @@ Fw::String QueuedExternalParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
   return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
@@ -4278,7 +4278,7 @@ void QueuedExternalParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
   compPtr->noArgsSync_handlerBase(portNum);
 }
@@ -4296,7 +4296,7 @@ void QueuedExternalParamsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
   compPtr->typedAliasGuarded_handlerBase(
     portNum,
@@ -4323,7 +4323,7 @@ AliasPrim2 QueuedExternalParamsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
   return compPtr->typedAliasReturnSync_handlerBase(
     portNum,
@@ -4350,7 +4350,7 @@ Fw::String QueuedExternalParamsComponentBase ::
       const AnotherAliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
   return compPtr->typedAliasStringReturnSync_handlerBase(
     portNum,
@@ -4377,7 +4377,7 @@ void QueuedExternalParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
   compPtr->typedAsync_handlerBase(
     portNum,
@@ -4404,7 +4404,7 @@ void QueuedExternalParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
   compPtr->typedAsyncAssert_handlerBase(
     portNum,
@@ -4431,7 +4431,7 @@ void QueuedExternalParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
   compPtr->typedAsyncBlockPriority_handlerBase(
     portNum,
@@ -4458,7 +4458,7 @@ void QueuedExternalParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
   compPtr->typedAsyncDropPriority_handlerBase(
     portNum,
@@ -4485,7 +4485,7 @@ void QueuedExternalParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
   compPtr->typedGuarded_handlerBase(
     portNum,
@@ -4512,7 +4512,7 @@ F32 QueuedExternalParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
   return compPtr->typedReturnGuarded_handlerBase(
     portNum,
@@ -4539,7 +4539,7 @@ F32 QueuedExternalParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
   return compPtr->typedReturnSync_handlerBase(
     portNum,
@@ -4566,7 +4566,7 @@ void QueuedExternalParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedExternalParamsComponentBase* compPtr = static_cast<QueuedExternalParamsComponentBase*>(callComp);
   compPtr->typedSync_handlerBase(
     portNum,

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedGetProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedGetProductsComponentAc.ref.cpp
@@ -3904,7 +3904,7 @@ void QueuedGetProductsComponentBase ::
       Fw::CmdArgBuffer& args
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
   compPtr->cmdIn_handlerBase(
     portNum,
@@ -3931,7 +3931,7 @@ void QueuedGetProductsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
   compPtr->aliasTypedAsync_handlerBase(
     portNum,
@@ -3951,7 +3951,7 @@ Fw::String QueuedGetProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
   return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
@@ -3962,7 +3962,7 @@ void QueuedGetProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
   compPtr->noArgsAsync_handlerBase(portNum);
 }
@@ -3973,7 +3973,7 @@ void QueuedGetProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
   compPtr->noArgsGuarded_handlerBase(portNum);
 }
@@ -3984,7 +3984,7 @@ U32 QueuedGetProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
   return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
@@ -3995,7 +3995,7 @@ U32 QueuedGetProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
   return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
@@ -4006,7 +4006,7 @@ Fw::String QueuedGetProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
   return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
@@ -4017,7 +4017,7 @@ void QueuedGetProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
   compPtr->noArgsSync_handlerBase(portNum);
 }
@@ -4035,7 +4035,7 @@ void QueuedGetProductsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
   compPtr->typedAliasGuarded_handlerBase(
     portNum,
@@ -4062,7 +4062,7 @@ AliasPrim2 QueuedGetProductsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
   return compPtr->typedAliasReturnSync_handlerBase(
     portNum,
@@ -4089,7 +4089,7 @@ Fw::String QueuedGetProductsComponentBase ::
       const AnotherAliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
   return compPtr->typedAliasStringReturnSync_handlerBase(
     portNum,
@@ -4116,7 +4116,7 @@ void QueuedGetProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
   compPtr->typedAsync_handlerBase(
     portNum,
@@ -4143,7 +4143,7 @@ void QueuedGetProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
   compPtr->typedAsyncAssert_handlerBase(
     portNum,
@@ -4170,7 +4170,7 @@ void QueuedGetProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
   compPtr->typedAsyncBlockPriority_handlerBase(
     portNum,
@@ -4197,7 +4197,7 @@ void QueuedGetProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
   compPtr->typedAsyncDropPriority_handlerBase(
     portNum,
@@ -4224,7 +4224,7 @@ void QueuedGetProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
   compPtr->typedGuarded_handlerBase(
     portNum,
@@ -4251,7 +4251,7 @@ F32 QueuedGetProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
   return compPtr->typedReturnGuarded_handlerBase(
     portNum,
@@ -4278,7 +4278,7 @@ F32 QueuedGetProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
   return compPtr->typedReturnSync_handlerBase(
     portNum,
@@ -4305,7 +4305,7 @@ void QueuedGetProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGetProductsComponentBase* compPtr = static_cast<QueuedGetProductsComponentBase*>(callComp);
   compPtr->typedSync_handlerBase(
     portNum,

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedGuardedProductsComponentAc.ref.cpp
@@ -3984,7 +3984,7 @@ void QueuedGuardedProductsComponentBase ::
       Fw::CmdArgBuffer& args
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
   compPtr->cmdIn_handlerBase(
     portNum,
@@ -4003,7 +4003,7 @@ void QueuedGuardedProductsComponentBase ::
       const Fw::Success& status
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
   compPtr->productRecvIn_handlerBase(
     portNum,
@@ -4030,7 +4030,7 @@ void QueuedGuardedProductsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
   compPtr->aliasTypedAsync_handlerBase(
     portNum,
@@ -4050,7 +4050,7 @@ Fw::String QueuedGuardedProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
   return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
@@ -4061,7 +4061,7 @@ void QueuedGuardedProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
   compPtr->noArgsAsync_handlerBase(portNum);
 }
@@ -4072,7 +4072,7 @@ void QueuedGuardedProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
   compPtr->noArgsGuarded_handlerBase(portNum);
 }
@@ -4083,7 +4083,7 @@ U32 QueuedGuardedProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
   return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
@@ -4094,7 +4094,7 @@ U32 QueuedGuardedProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
   return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
@@ -4105,7 +4105,7 @@ Fw::String QueuedGuardedProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
   return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
@@ -4116,7 +4116,7 @@ void QueuedGuardedProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
   compPtr->noArgsSync_handlerBase(portNum);
 }
@@ -4134,7 +4134,7 @@ void QueuedGuardedProductsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
   compPtr->typedAliasGuarded_handlerBase(
     portNum,
@@ -4161,7 +4161,7 @@ AliasPrim2 QueuedGuardedProductsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
   return compPtr->typedAliasReturnSync_handlerBase(
     portNum,
@@ -4188,7 +4188,7 @@ Fw::String QueuedGuardedProductsComponentBase ::
       const AnotherAliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
   return compPtr->typedAliasStringReturnSync_handlerBase(
     portNum,
@@ -4215,7 +4215,7 @@ void QueuedGuardedProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
   compPtr->typedAsync_handlerBase(
     portNum,
@@ -4242,7 +4242,7 @@ void QueuedGuardedProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
   compPtr->typedAsyncAssert_handlerBase(
     portNum,
@@ -4269,7 +4269,7 @@ void QueuedGuardedProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
   compPtr->typedAsyncBlockPriority_handlerBase(
     portNum,
@@ -4296,7 +4296,7 @@ void QueuedGuardedProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
   compPtr->typedAsyncDropPriority_handlerBase(
     portNum,
@@ -4323,7 +4323,7 @@ void QueuedGuardedProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
   compPtr->typedGuarded_handlerBase(
     portNum,
@@ -4350,7 +4350,7 @@ F32 QueuedGuardedProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
   return compPtr->typedReturnGuarded_handlerBase(
     portNum,
@@ -4377,7 +4377,7 @@ F32 QueuedGuardedProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
   return compPtr->typedReturnSync_handlerBase(
     portNum,
@@ -4404,7 +4404,7 @@ void QueuedGuardedProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedGuardedProductsComponentBase* compPtr = static_cast<QueuedGuardedProductsComponentBase*>(callComp);
   compPtr->typedSync_handlerBase(
     portNum,
@@ -4558,7 +4558,7 @@ void QueuedGuardedProductsComponentBase ::
       this->dpRecv_Container5_handler(container, status.e);
       break;
     default:
-      FW_ASSERT(0);
+      FW_ASSERT(false);
       break;
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedNoArgsPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedNoArgsPortsOnlyComponentAc.ref.cpp
@@ -649,7 +649,7 @@ void QueuedNoArgsPortsOnlyComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedNoArgsPortsOnlyComponentBase* compPtr = static_cast<QueuedNoArgsPortsOnlyComponentBase*>(callComp);
   compPtr->noArgsAsync_handlerBase(portNum);
 }
@@ -660,7 +660,7 @@ void QueuedNoArgsPortsOnlyComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedNoArgsPortsOnlyComponentBase* compPtr = static_cast<QueuedNoArgsPortsOnlyComponentBase*>(callComp);
   compPtr->noArgsGuarded_handlerBase(portNum);
 }
@@ -671,7 +671,7 @@ U32 QueuedNoArgsPortsOnlyComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedNoArgsPortsOnlyComponentBase* compPtr = static_cast<QueuedNoArgsPortsOnlyComponentBase*>(callComp);
   return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
@@ -682,7 +682,7 @@ U32 QueuedNoArgsPortsOnlyComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedNoArgsPortsOnlyComponentBase* compPtr = static_cast<QueuedNoArgsPortsOnlyComponentBase*>(callComp);
   return compPtr->noArgsReturnSync_handlerBase(portNum);
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedOverflowComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedOverflowComponentAc.ref.cpp
@@ -2463,7 +2463,7 @@ void QueuedOverflowComponentBase ::
       Fw::CmdArgBuffer& args
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
   compPtr->cmdIn_handlerBase(
     portNum,
@@ -2482,7 +2482,7 @@ void QueuedOverflowComponentBase ::
       const Fw::Success& status
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
   compPtr->productRecvInHook_handlerBase(
     portNum,
@@ -2509,7 +2509,7 @@ void QueuedOverflowComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
   compPtr->assertAsync_handlerBase(
     portNum,
@@ -2536,7 +2536,7 @@ void QueuedOverflowComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
   compPtr->blockAsync_handlerBase(
     portNum,
@@ -2563,7 +2563,7 @@ void QueuedOverflowComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
   compPtr->dropAsync_handlerBase(
     portNum,
@@ -2590,7 +2590,7 @@ void QueuedOverflowComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
   compPtr->hookAsync_handlerBase(
     portNum,
@@ -2617,7 +2617,7 @@ void QueuedOverflowComponentBase ::
       Fw::LinearBufferBase& buffer
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedOverflowComponentBase* compPtr = static_cast<QueuedOverflowComponentBase*>(callComp);
   compPtr->serialAsyncHook_handlerBase(
     portNum,

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.cpp
@@ -4028,7 +4028,7 @@ void QueuedParamsComponentBase ::
       Fw::CmdArgBuffer& args
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
   compPtr->cmdIn_handlerBase(
     portNum,
@@ -4055,7 +4055,7 @@ void QueuedParamsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
   compPtr->aliasTypedAsync_handlerBase(
     portNum,
@@ -4075,7 +4075,7 @@ Fw::String QueuedParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
   return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
@@ -4086,7 +4086,7 @@ void QueuedParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
   compPtr->noArgsAsync_handlerBase(portNum);
 }
@@ -4097,7 +4097,7 @@ void QueuedParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
   compPtr->noArgsGuarded_handlerBase(portNum);
 }
@@ -4108,7 +4108,7 @@ U32 QueuedParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
   return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
@@ -4119,7 +4119,7 @@ U32 QueuedParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
   return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
@@ -4130,7 +4130,7 @@ Fw::String QueuedParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
   return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
@@ -4141,7 +4141,7 @@ void QueuedParamsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
   compPtr->noArgsSync_handlerBase(portNum);
 }
@@ -4159,7 +4159,7 @@ void QueuedParamsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
   compPtr->typedAliasGuarded_handlerBase(
     portNum,
@@ -4186,7 +4186,7 @@ AliasPrim2 QueuedParamsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
   return compPtr->typedAliasReturnSync_handlerBase(
     portNum,
@@ -4213,7 +4213,7 @@ Fw::String QueuedParamsComponentBase ::
       const AnotherAliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
   return compPtr->typedAliasStringReturnSync_handlerBase(
     portNum,
@@ -4240,7 +4240,7 @@ void QueuedParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
   compPtr->typedAsync_handlerBase(
     portNum,
@@ -4267,7 +4267,7 @@ void QueuedParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
   compPtr->typedAsyncAssert_handlerBase(
     portNum,
@@ -4294,7 +4294,7 @@ void QueuedParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
   compPtr->typedAsyncBlockPriority_handlerBase(
     portNum,
@@ -4321,7 +4321,7 @@ void QueuedParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
   compPtr->typedAsyncDropPriority_handlerBase(
     portNum,
@@ -4348,7 +4348,7 @@ void QueuedParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
   compPtr->typedGuarded_handlerBase(
     portNum,
@@ -4375,7 +4375,7 @@ F32 QueuedParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
   return compPtr->typedReturnGuarded_handlerBase(
     portNum,
@@ -4402,7 +4402,7 @@ F32 QueuedParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
   return compPtr->typedReturnSync_handlerBase(
     portNum,
@@ -4429,7 +4429,7 @@ void QueuedParamsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedParamsComponentBase* compPtr = static_cast<QueuedParamsComponentBase*>(callComp);
   compPtr->typedSync_handlerBase(
     portNum,

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
@@ -8390,7 +8390,7 @@ void QueuedSerialComponentBase ::
       Fw::CmdArgBuffer& args
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
   compPtr->cmdIn_handlerBase(
     portNum,
@@ -8417,7 +8417,7 @@ void QueuedSerialComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
   compPtr->aliasTypedAsync_handlerBase(
     portNum,
@@ -8437,7 +8437,7 @@ Fw::String QueuedSerialComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
   return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
@@ -8448,7 +8448,7 @@ void QueuedSerialComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
   compPtr->noArgsAsync_handlerBase(portNum);
 }
@@ -8459,7 +8459,7 @@ void QueuedSerialComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
   compPtr->noArgsGuarded_handlerBase(portNum);
 }
@@ -8470,7 +8470,7 @@ U32 QueuedSerialComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
   return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
@@ -8481,7 +8481,7 @@ U32 QueuedSerialComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
   return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
@@ -8492,7 +8492,7 @@ Fw::String QueuedSerialComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
   return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
@@ -8503,7 +8503,7 @@ void QueuedSerialComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
   compPtr->noArgsSync_handlerBase(portNum);
 }
@@ -8521,7 +8521,7 @@ void QueuedSerialComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
   compPtr->typedAliasGuarded_handlerBase(
     portNum,
@@ -8548,7 +8548,7 @@ AliasPrim2 QueuedSerialComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
   return compPtr->typedAliasReturnSync_handlerBase(
     portNum,
@@ -8575,7 +8575,7 @@ Fw::String QueuedSerialComponentBase ::
       const AnotherAliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
   return compPtr->typedAliasStringReturnSync_handlerBase(
     portNum,
@@ -8602,7 +8602,7 @@ void QueuedSerialComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
   compPtr->typedAsync_handlerBase(
     portNum,
@@ -8629,7 +8629,7 @@ void QueuedSerialComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
   compPtr->typedAsyncAssert_handlerBase(
     portNum,
@@ -8656,7 +8656,7 @@ void QueuedSerialComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
   compPtr->typedAsyncBlockPriority_handlerBase(
     portNum,
@@ -8683,7 +8683,7 @@ void QueuedSerialComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
   compPtr->typedAsyncDropPriority_handlerBase(
     portNum,
@@ -8710,7 +8710,7 @@ void QueuedSerialComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
   compPtr->typedGuarded_handlerBase(
     portNum,
@@ -8737,7 +8737,7 @@ F32 QueuedSerialComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
   return compPtr->typedReturnGuarded_handlerBase(
     portNum,
@@ -8764,7 +8764,7 @@ F32 QueuedSerialComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
   return compPtr->typedReturnSync_handlerBase(
     portNum,
@@ -8791,7 +8791,7 @@ void QueuedSerialComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
   compPtr->typedSync_handlerBase(
     portNum,
@@ -8818,7 +8818,7 @@ void QueuedSerialComponentBase ::
       Fw::LinearBufferBase& buffer
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
   compPtr->serialAsync_handlerBase(
     portNum,
@@ -8833,7 +8833,7 @@ void QueuedSerialComponentBase ::
       Fw::LinearBufferBase& buffer
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
   compPtr->serialAsyncAssert_handlerBase(
     portNum,
@@ -8848,7 +8848,7 @@ void QueuedSerialComponentBase ::
       Fw::LinearBufferBase& buffer
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
   compPtr->serialAsyncBlockPriority_handlerBase(
     portNum,
@@ -8863,7 +8863,7 @@ void QueuedSerialComponentBase ::
       Fw::LinearBufferBase& buffer
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
   compPtr->serialAsyncDropPriority_handlerBase(
     portNum,
@@ -8878,7 +8878,7 @@ void QueuedSerialComponentBase ::
       Fw::LinearBufferBase& buffer
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
   compPtr->serialGuarded_handlerBase(
     portNum,
@@ -8893,7 +8893,7 @@ void QueuedSerialComponentBase ::
       Fw::LinearBufferBase& buffer
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSerialComponentBase* compPtr = static_cast<QueuedSerialComponentBase*>(callComp);
   compPtr->serialSync_handlerBase(
     portNum,

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSyncProductsComponentAc.ref.cpp
@@ -3978,7 +3978,7 @@ void QueuedSyncProductsComponentBase ::
       Fw::CmdArgBuffer& args
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
   compPtr->cmdIn_handlerBase(
     portNum,
@@ -3997,7 +3997,7 @@ void QueuedSyncProductsComponentBase ::
       const Fw::Success& status
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
   compPtr->productRecvIn_handlerBase(
     portNum,
@@ -4024,7 +4024,7 @@ void QueuedSyncProductsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
   compPtr->aliasTypedAsync_handlerBase(
     portNum,
@@ -4044,7 +4044,7 @@ Fw::String QueuedSyncProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
   return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
@@ -4055,7 +4055,7 @@ void QueuedSyncProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
   compPtr->noArgsAsync_handlerBase(portNum);
 }
@@ -4066,7 +4066,7 @@ void QueuedSyncProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
   compPtr->noArgsGuarded_handlerBase(portNum);
 }
@@ -4077,7 +4077,7 @@ U32 QueuedSyncProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
   return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
@@ -4088,7 +4088,7 @@ U32 QueuedSyncProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
   return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
@@ -4099,7 +4099,7 @@ Fw::String QueuedSyncProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
   return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
@@ -4110,7 +4110,7 @@ void QueuedSyncProductsComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
   compPtr->noArgsSync_handlerBase(portNum);
 }
@@ -4128,7 +4128,7 @@ void QueuedSyncProductsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
   compPtr->typedAliasGuarded_handlerBase(
     portNum,
@@ -4155,7 +4155,7 @@ AliasPrim2 QueuedSyncProductsComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
   return compPtr->typedAliasReturnSync_handlerBase(
     portNum,
@@ -4182,7 +4182,7 @@ Fw::String QueuedSyncProductsComponentBase ::
       const AnotherAliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
   return compPtr->typedAliasStringReturnSync_handlerBase(
     portNum,
@@ -4209,7 +4209,7 @@ void QueuedSyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
   compPtr->typedAsync_handlerBase(
     portNum,
@@ -4236,7 +4236,7 @@ void QueuedSyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
   compPtr->typedAsyncAssert_handlerBase(
     portNum,
@@ -4263,7 +4263,7 @@ void QueuedSyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
   compPtr->typedAsyncBlockPriority_handlerBase(
     portNum,
@@ -4290,7 +4290,7 @@ void QueuedSyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
   compPtr->typedAsyncDropPriority_handlerBase(
     portNum,
@@ -4317,7 +4317,7 @@ void QueuedSyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
   compPtr->typedGuarded_handlerBase(
     portNum,
@@ -4344,7 +4344,7 @@ F32 QueuedSyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
   return compPtr->typedReturnGuarded_handlerBase(
     portNum,
@@ -4371,7 +4371,7 @@ F32 QueuedSyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
   return compPtr->typedReturnSync_handlerBase(
     portNum,
@@ -4398,7 +4398,7 @@ void QueuedSyncProductsComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedSyncProductsComponentBase* compPtr = static_cast<QueuedSyncProductsComponentBase*>(callComp);
   compPtr->typedSync_handlerBase(
     portNum,
@@ -4552,7 +4552,7 @@ void QueuedSyncProductsComponentBase ::
       this->dpRecv_Container5_handler(container, status.e);
       break;
     default:
-      FW_ASSERT(0);
+      FW_ASSERT(false);
       break;
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.cpp
@@ -3917,7 +3917,7 @@ void QueuedTelemetryComponentBase ::
       Fw::CmdArgBuffer& args
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
   compPtr->cmdIn_handlerBase(
     portNum,
@@ -3944,7 +3944,7 @@ void QueuedTelemetryComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
   compPtr->aliasTypedAsync_handlerBase(
     portNum,
@@ -3964,7 +3964,7 @@ Fw::String QueuedTelemetryComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
   return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
@@ -3975,7 +3975,7 @@ void QueuedTelemetryComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
   compPtr->noArgsAsync_handlerBase(portNum);
 }
@@ -3986,7 +3986,7 @@ void QueuedTelemetryComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
   compPtr->noArgsGuarded_handlerBase(portNum);
 }
@@ -3997,7 +3997,7 @@ U32 QueuedTelemetryComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
   return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
@@ -4008,7 +4008,7 @@ U32 QueuedTelemetryComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
   return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
@@ -4019,7 +4019,7 @@ Fw::String QueuedTelemetryComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
   return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
@@ -4030,7 +4030,7 @@ void QueuedTelemetryComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
   compPtr->noArgsSync_handlerBase(portNum);
 }
@@ -4048,7 +4048,7 @@ void QueuedTelemetryComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
   compPtr->typedAliasGuarded_handlerBase(
     portNum,
@@ -4075,7 +4075,7 @@ AliasPrim2 QueuedTelemetryComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
   return compPtr->typedAliasReturnSync_handlerBase(
     portNum,
@@ -4102,7 +4102,7 @@ Fw::String QueuedTelemetryComponentBase ::
       const AnotherAliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
   return compPtr->typedAliasStringReturnSync_handlerBase(
     portNum,
@@ -4129,7 +4129,7 @@ void QueuedTelemetryComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
   compPtr->typedAsync_handlerBase(
     portNum,
@@ -4156,7 +4156,7 @@ void QueuedTelemetryComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
   compPtr->typedAsyncAssert_handlerBase(
     portNum,
@@ -4183,7 +4183,7 @@ void QueuedTelemetryComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
   compPtr->typedAsyncBlockPriority_handlerBase(
     portNum,
@@ -4210,7 +4210,7 @@ void QueuedTelemetryComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
   compPtr->typedAsyncDropPriority_handlerBase(
     portNum,
@@ -4237,7 +4237,7 @@ void QueuedTelemetryComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
   compPtr->typedGuarded_handlerBase(
     portNum,
@@ -4264,7 +4264,7 @@ F32 QueuedTelemetryComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
   return compPtr->typedReturnGuarded_handlerBase(
     portNum,
@@ -4291,7 +4291,7 @@ F32 QueuedTelemetryComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
   return compPtr->typedReturnSync_handlerBase(
     portNum,
@@ -4318,7 +4318,7 @@ void QueuedTelemetryComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTelemetryComponentBase* compPtr = static_cast<QueuedTelemetryComponentBase*>(callComp);
   compPtr->typedSync_handlerBase(
     portNum,

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
@@ -8210,7 +8210,7 @@ void QueuedTestComponentBase ::
       Fw::CmdArgBuffer& args
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
   compPtr->cmdIn_handlerBase(
     portNum,
@@ -8229,7 +8229,7 @@ void QueuedTestComponentBase ::
       const Fw::Success& status
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
   compPtr->productRecvIn_handlerBase(
     portNum,
@@ -8256,7 +8256,7 @@ void QueuedTestComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
   compPtr->aliasTypedAsync_handlerBase(
     portNum,
@@ -8276,7 +8276,7 @@ Fw::String QueuedTestComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
   return compPtr->noArgsAliasStringReturnSync_handlerBase(portNum);
 }
@@ -8287,7 +8287,7 @@ void QueuedTestComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
   compPtr->noArgsAsync_handlerBase(portNum);
 }
@@ -8298,7 +8298,7 @@ void QueuedTestComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
   compPtr->noArgsGuarded_handlerBase(portNum);
 }
@@ -8309,7 +8309,7 @@ U32 QueuedTestComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
   return compPtr->noArgsReturnGuarded_handlerBase(portNum);
 }
@@ -8320,7 +8320,7 @@ U32 QueuedTestComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
   return compPtr->noArgsReturnSync_handlerBase(portNum);
 }
@@ -8331,7 +8331,7 @@ Fw::String QueuedTestComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
   return compPtr->noArgsStringReturnSync_handlerBase(portNum);
 }
@@ -8342,7 +8342,7 @@ void QueuedTestComponentBase ::
       FwIndexType portNum
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
   compPtr->noArgsSync_handlerBase(portNum);
 }
@@ -8360,7 +8360,7 @@ void QueuedTestComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
   compPtr->typedAliasGuarded_handlerBase(
     portNum,
@@ -8387,7 +8387,7 @@ AliasPrim2 QueuedTestComponentBase ::
       const AliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
   return compPtr->typedAliasReturnSync_handlerBase(
     portNum,
@@ -8414,7 +8414,7 @@ Fw::String QueuedTestComponentBase ::
       const AnotherAliasStruct& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
   return compPtr->typedAliasStringReturnSync_handlerBase(
     portNum,
@@ -8441,7 +8441,7 @@ void QueuedTestComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
   compPtr->typedAsync_handlerBase(
     portNum,
@@ -8468,7 +8468,7 @@ void QueuedTestComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
   compPtr->typedAsyncAssert_handlerBase(
     portNum,
@@ -8495,7 +8495,7 @@ void QueuedTestComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
   compPtr->typedAsyncBlockPriority_handlerBase(
     portNum,
@@ -8522,7 +8522,7 @@ void QueuedTestComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
   compPtr->typedAsyncDropPriority_handlerBase(
     portNum,
@@ -8549,7 +8549,7 @@ void QueuedTestComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
   compPtr->typedGuarded_handlerBase(
     portNum,
@@ -8576,7 +8576,7 @@ F32 QueuedTestComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
   return compPtr->typedReturnGuarded_handlerBase(
     portNum,
@@ -8603,7 +8603,7 @@ F32 QueuedTestComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
   return compPtr->typedReturnSync_handlerBase(
     portNum,
@@ -8630,7 +8630,7 @@ void QueuedTestComponentBase ::
       const S& s
   )
 {
-  FW_ASSERT(callComp);
+  FW_ASSERT(callComp != nullptr);
   QueuedTestComponentBase* compPtr = static_cast<QueuedTestComponentBase*>(callComp);
   compPtr->typedSync_handlerBase(
     portNum,
@@ -9638,7 +9638,7 @@ void QueuedTestComponentBase ::
       this->dpRecv_Container5_handler(container, status.e);
       break;
     default:
-      FW_ASSERT(0);
+      FW_ASSERT(false);
       break;
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/SmChoiceActiveComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SmChoiceActiveComponentAc.ref.cpp
@@ -913,7 +913,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(smId));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(smId));
         break;
     }
   }
@@ -955,7 +955,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -980,7 +980,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -1001,7 +1001,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -1022,7 +1022,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -1058,7 +1058,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -1079,7 +1079,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -1104,7 +1104,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -1125,7 +1125,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }

--- a/compiler/tools/fpp-to-cpp/test/component/base/SmChoiceQueuedComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SmChoiceQueuedComponentAc.ref.cpp
@@ -808,7 +808,7 @@ namespace FppTest {
         U32 context
     )
   {
-    FW_ASSERT(callComp);
+    FW_ASSERT(callComp != nullptr);
     SmChoiceQueuedComponentBase* compPtr = static_cast<SmChoiceQueuedComponentBase*>(callComp);
     compPtr->schedIn_handlerBase(
       portNum,
@@ -1026,7 +1026,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(smId));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(smId));
         break;
     }
   }
@@ -1068,7 +1068,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -1093,7 +1093,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -1114,7 +1114,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -1135,7 +1135,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -1171,7 +1171,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -1192,7 +1192,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -1217,7 +1217,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -1238,7 +1238,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }

--- a/compiler/tools/fpp-to-cpp/test/component/base/SmInitialActiveComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SmInitialActiveComponentAc.ref.cpp
@@ -464,7 +464,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(smId));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(smId));
         break;
     }
   }
@@ -499,7 +499,7 @@ namespace FppTest {
   {
     switch (signal) {
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -513,7 +513,7 @@ namespace FppTest {
   {
     switch (signal) {
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -527,7 +527,7 @@ namespace FppTest {
   {
     switch (signal) {
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -541,7 +541,7 @@ namespace FppTest {
   {
     switch (signal) {
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -555,7 +555,7 @@ namespace FppTest {
   {
     switch (signal) {
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -569,7 +569,7 @@ namespace FppTest {
   {
     switch (signal) {
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }

--- a/compiler/tools/fpp-to-cpp/test/component/base/SmInitialQueuedComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SmInitialQueuedComponentAc.ref.cpp
@@ -513,7 +513,7 @@ namespace FppTest {
         U32 context
     )
   {
-    FW_ASSERT(callComp);
+    FW_ASSERT(callComp != nullptr);
     SmInitialQueuedComponentBase* compPtr = static_cast<SmInitialQueuedComponentBase*>(callComp);
     compPtr->schedIn_handlerBase(
       portNum,
@@ -577,7 +577,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(smId));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(smId));
         break;
     }
   }
@@ -612,7 +612,7 @@ namespace FppTest {
   {
     switch (signal) {
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -626,7 +626,7 @@ namespace FppTest {
   {
     switch (signal) {
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -640,7 +640,7 @@ namespace FppTest {
   {
     switch (signal) {
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -654,7 +654,7 @@ namespace FppTest {
   {
     switch (signal) {
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -668,7 +668,7 @@ namespace FppTest {
   {
     switch (signal) {
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -682,7 +682,7 @@ namespace FppTest {
   {
     switch (signal) {
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }

--- a/compiler/tools/fpp-to-cpp/test/component/base/SmStateActiveComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SmStateActiveComponentAc.ref.cpp
@@ -2147,7 +2147,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(smId));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(smId));
         break;
     }
   }
@@ -2189,7 +2189,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2210,7 +2210,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2236,7 +2236,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2261,7 +2261,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2286,7 +2286,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2311,7 +2311,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2336,7 +2336,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2361,7 +2361,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2382,7 +2382,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2403,7 +2403,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2441,7 +2441,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2466,7 +2466,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2491,7 +2491,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2516,7 +2516,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2541,7 +2541,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2566,7 +2566,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2594,7 +2594,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2622,7 +2622,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2650,7 +2650,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2685,7 +2685,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2713,7 +2713,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2748,7 +2748,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2769,7 +2769,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }

--- a/compiler/tools/fpp-to-cpp/test/component/base/SmStateQueuedComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/SmStateQueuedComponentAc.ref.cpp
@@ -1731,7 +1731,7 @@ namespace FppTest {
         U32 context
     )
   {
-    FW_ASSERT(callComp);
+    FW_ASSERT(callComp != nullptr);
     SmStateQueuedComponentBase* compPtr = static_cast<SmStateQueuedComponentBase*>(callComp);
     compPtr->schedIn_handlerBase(
       portNum,
@@ -2260,7 +2260,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(smId));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(smId));
         break;
     }
   }
@@ -2302,7 +2302,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2323,7 +2323,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2349,7 +2349,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2374,7 +2374,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2399,7 +2399,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2424,7 +2424,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2449,7 +2449,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2474,7 +2474,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2495,7 +2495,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2516,7 +2516,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2554,7 +2554,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2579,7 +2579,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2604,7 +2604,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2629,7 +2629,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2654,7 +2654,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2679,7 +2679,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2707,7 +2707,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2735,7 +2735,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2763,7 +2763,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2798,7 +2798,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2826,7 +2826,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2861,7 +2861,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }
@@ -2882,7 +2882,7 @@ namespace FppTest {
         break;
       }
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(signal));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(signal));
         break;
     }
   }

--- a/compiler/tools/fpp-to-cpp/test/component/base/TypedReturnPortAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/TypedReturnPortAc.ref.cpp
@@ -80,7 +80,7 @@ namespace Ports {
     // For ports with a return type, invokeSerial is not used
     (void) _buffer;
 
-    FW_ASSERT(0);
+    FW_ASSERT(false);
     return Fw::FW_SERIALIZE_OK;
   }
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsTesterBase.ref.cpp
@@ -2479,7 +2479,7 @@ void ActiveEventsTesterBase ::
     }
 
     default: {
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
     }
   }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveExternalParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveExternalParamsTesterBase.ref.cpp
@@ -54,7 +54,7 @@ Fw::SerializeStatus ActiveExternalParamsTesterBase::ActiveExternalParamsComponen
       break;
     default:
       // Unknown ID; should not have gotten here
-      FW_ASSERT(0, static_cast<FwAssertArgType>(localId));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(localId));
   }
 
   return stat;
@@ -99,7 +99,7 @@ Fw::SerializeStatus ActiveExternalParamsTesterBase::ActiveExternalParamsComponen
       break;
     default:
       // Unknown ID; should not have gotten here
-      FW_ASSERT(0, static_cast<FwAssertArgType>(localId));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(localId));
   }
 
   return stat;
@@ -2943,7 +2943,7 @@ Fw::ParamValid ActiveExternalParamsTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
   }
 
@@ -3054,7 +3054,7 @@ void ActiveExternalParamsTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsTesterBase.ref.cpp
@@ -2847,7 +2847,7 @@ Fw::ParamValid ActiveParamsTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
   }
 
@@ -2958,7 +2958,7 @@ void ActiveParamsTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.cpp
@@ -54,7 +54,7 @@ Fw::SerializeStatus ActiveSerialTesterBase::ActiveSerialComponentBaseParamExtern
       break;
     default:
       // Unknown ID; should not have gotten here
-      FW_ASSERT(0, static_cast<FwAssertArgType>(localId));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(localId));
   }
 
   return stat;
@@ -99,7 +99,7 @@ Fw::SerializeStatus ActiveSerialTesterBase::ActiveSerialComponentBaseParamExtern
       break;
     default:
       // Unknown ID; should not have gotten here
-      FW_ASSERT(0, static_cast<FwAssertArgType>(localId));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(localId));
   }
 
   return stat;
@@ -3785,7 +3785,7 @@ void ActiveSerialTesterBase ::
     }
 
     default: {
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
     }
   }
@@ -4066,7 +4066,7 @@ void ActiveSerialTesterBase ::
     }
 
     default: {
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
     }
   }
@@ -5397,7 +5397,7 @@ Fw::ParamValid ActiveSerialTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
   }
 
@@ -5592,7 +5592,7 @@ void ActiveSerialTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryTesterBase.ref.cpp
@@ -2254,7 +2254,7 @@ void ActiveTelemetryTesterBase ::
     }
 
     default: {
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
     }
   }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.cpp
@@ -56,7 +56,7 @@ namespace M {
         break;
       default:
         // Unknown ID; should not have gotten here
-        FW_ASSERT(0, static_cast<FwAssertArgType>(localId));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(localId));
     }
 
     return stat;
@@ -101,7 +101,7 @@ namespace M {
         break;
       default:
         // Unknown ID; should not have gotten here
-        FW_ASSERT(0, static_cast<FwAssertArgType>(localId));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(localId));
     }
 
     return stat;
@@ -3483,7 +3483,7 @@ namespace M {
       }
 
       default: {
-        FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(id));
         break;
       }
     }
@@ -3764,7 +3764,7 @@ namespace M {
       }
 
       default: {
-        FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(id));
         break;
       }
     }
@@ -5151,7 +5151,7 @@ namespace M {
       };
 
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(id));
         break;
     }
 
@@ -5346,7 +5346,7 @@ namespace M {
       };
 
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(id));
         break;
     }
   }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsTesterBase.ref.cpp
@@ -2064,7 +2064,7 @@ void PassiveEventsTesterBase ::
     }
 
     default: {
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
     }
   }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveExternalParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveExternalParamsTesterBase.ref.cpp
@@ -54,7 +54,7 @@ Fw::SerializeStatus PassiveExternalParamsTesterBase::PassiveExternalParamsCompon
       break;
     default:
       // Unknown ID; should not have gotten here
-      FW_ASSERT(0, static_cast<FwAssertArgType>(localId));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(localId));
   }
 
   return stat;
@@ -99,7 +99,7 @@ Fw::SerializeStatus PassiveExternalParamsTesterBase::PassiveExternalParamsCompon
       break;
     default:
       // Unknown ID; should not have gotten here
-      FW_ASSERT(0, static_cast<FwAssertArgType>(localId));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(localId));
   }
 
   return stat;
@@ -2502,7 +2502,7 @@ Fw::ParamValid PassiveExternalParamsTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
   }
 
@@ -2613,7 +2613,7 @@ void PassiveExternalParamsTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsTesterBase.ref.cpp
@@ -2406,7 +2406,7 @@ Fw::ParamValid PassiveParamsTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
   }
 
@@ -2517,7 +2517,7 @@ void PassiveParamsTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.cpp
@@ -54,7 +54,7 @@ Fw::SerializeStatus PassiveSerialTesterBase::PassiveSerialComponentBaseParamExte
       break;
     default:
       // Unknown ID; should not have gotten here
-      FW_ASSERT(0, static_cast<FwAssertArgType>(localId));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(localId));
   }
 
   return stat;
@@ -99,7 +99,7 @@ Fw::SerializeStatus PassiveSerialTesterBase::PassiveSerialComponentBaseParamExte
       break;
     default:
       // Unknown ID; should not have gotten here
-      FW_ASSERT(0, static_cast<FwAssertArgType>(localId));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(localId));
   }
 
   return stat;
@@ -2987,7 +2987,7 @@ void PassiveSerialTesterBase ::
     }
 
     default: {
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
     }
   }
@@ -3268,7 +3268,7 @@ void PassiveSerialTesterBase ::
     }
 
     default: {
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
     }
   }
@@ -4573,7 +4573,7 @@ Fw::ParamValid PassiveSerialTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
   }
 
@@ -4768,7 +4768,7 @@ void PassiveSerialTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryTesterBase.ref.cpp
@@ -1839,7 +1839,7 @@ void PassiveTelemetryTesterBase ::
     }
 
     default: {
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
     }
   }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.cpp
@@ -54,7 +54,7 @@ Fw::SerializeStatus PassiveTestTesterBase::PassiveTestComponentBaseParamExternal
       break;
     default:
       // Unknown ID; should not have gotten here
-      FW_ASSERT(0, static_cast<FwAssertArgType>(localId));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(localId));
   }
 
   return stat;
@@ -99,7 +99,7 @@ Fw::SerializeStatus PassiveTestTesterBase::PassiveTestComponentBaseParamExternal
       break;
     default:
       // Unknown ID; should not have gotten here
-      FW_ASSERT(0, static_cast<FwAssertArgType>(localId));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(localId));
   }
 
   return stat;
@@ -2923,7 +2923,7 @@ void PassiveTestTesterBase ::
     }
 
     default: {
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
     }
   }
@@ -3204,7 +3204,7 @@ void PassiveTestTesterBase ::
     }
 
     default: {
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
     }
   }
@@ -4565,7 +4565,7 @@ Fw::ParamValid PassiveTestTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
   }
 
@@ -4760,7 +4760,7 @@ void PassiveTestTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsTesterBase.ref.cpp
@@ -2479,7 +2479,7 @@ void QueuedEventsTesterBase ::
     }
 
     default: {
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
     }
   }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedExternalParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedExternalParamsTesterBase.ref.cpp
@@ -54,7 +54,7 @@ Fw::SerializeStatus QueuedExternalParamsTesterBase::QueuedExternalParamsComponen
       break;
     default:
       // Unknown ID; should not have gotten here
-      FW_ASSERT(0, static_cast<FwAssertArgType>(localId));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(localId));
   }
 
   return stat;
@@ -99,7 +99,7 @@ Fw::SerializeStatus QueuedExternalParamsTesterBase::QueuedExternalParamsComponen
       break;
     default:
       // Unknown ID; should not have gotten here
-      FW_ASSERT(0, static_cast<FwAssertArgType>(localId));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(localId));
   }
 
   return stat;
@@ -2917,7 +2917,7 @@ Fw::ParamValid QueuedExternalParamsTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
   }
 
@@ -3028,7 +3028,7 @@ void QueuedExternalParamsTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsTesterBase.ref.cpp
@@ -2821,7 +2821,7 @@ Fw::ParamValid QueuedParamsTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
   }
 
@@ -2932,7 +2932,7 @@ void QueuedParamsTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.cpp
@@ -54,7 +54,7 @@ Fw::SerializeStatus QueuedSerialTesterBase::QueuedSerialComponentBaseParamExtern
       break;
     default:
       // Unknown ID; should not have gotten here
-      FW_ASSERT(0, static_cast<FwAssertArgType>(localId));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(localId));
   }
 
   return stat;
@@ -99,7 +99,7 @@ Fw::SerializeStatus QueuedSerialTesterBase::QueuedSerialComponentBaseParamExtern
       break;
     default:
       // Unknown ID; should not have gotten here
-      FW_ASSERT(0, static_cast<FwAssertArgType>(localId));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(localId));
   }
 
   return stat;
@@ -3785,7 +3785,7 @@ void QueuedSerialTesterBase ::
     }
 
     default: {
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
     }
   }
@@ -4066,7 +4066,7 @@ void QueuedSerialTesterBase ::
     }
 
     default: {
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
     }
   }
@@ -5371,7 +5371,7 @@ Fw::ParamValid QueuedSerialTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
   }
 
@@ -5566,7 +5566,7 @@ void QueuedSerialTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryTesterBase.ref.cpp
@@ -2254,7 +2254,7 @@ void QueuedTelemetryTesterBase ::
     }
 
     default: {
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
     }
   }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.cpp
@@ -54,7 +54,7 @@ Fw::SerializeStatus QueuedTestTesterBase::QueuedTestComponentBaseParamExternalDe
       break;
     default:
       // Unknown ID; should not have gotten here
-      FW_ASSERT(0, static_cast<FwAssertArgType>(localId));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(localId));
   }
 
   return stat;
@@ -99,7 +99,7 @@ Fw::SerializeStatus QueuedTestTesterBase::QueuedTestComponentBaseParamExternalDe
       break;
     default:
       // Unknown ID; should not have gotten here
-      FW_ASSERT(0, static_cast<FwAssertArgType>(localId));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(localId));
   }
 
   return stat;
@@ -3481,7 +3481,7 @@ void QueuedTestTesterBase ::
     }
 
     default: {
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
     }
   }
@@ -3762,7 +3762,7 @@ void QueuedTestTesterBase ::
     }
 
     default: {
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
     }
   }
@@ -5123,7 +5123,7 @@ Fw::ParamValid QueuedTestTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
   }
 
@@ -5318,7 +5318,7 @@ void QueuedTestTesterBase ::
     };
 
     default:
-      FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(id));
       break;
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/port/ReturnTypePortAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/port/ReturnTypePortAc.ref.cpp
@@ -72,7 +72,7 @@ namespace M {
     // For ports with a return type, invokeSerial is not used
     (void) _buffer;
 
-    FW_ASSERT(0);
+    FW_ASSERT(false);
     return Fw::FW_SERIALIZE_OK;
   }
 

--- a/compiler/tools/fpp-to-cpp/test/port/StringReturnTypePortAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/port/StringReturnTypePortAc.ref.cpp
@@ -72,7 +72,7 @@ namespace M {
     // For ports with a return type, invokeSerial is not used
     (void) _buffer;
 
-    FW_ASSERT(0);
+    FW_ASSERT(false);
     return Fw::FW_SERIALIZE_OK;
   }
 

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/BasicStateMachineAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/BasicStateMachineAc.ref.cpp
@@ -66,7 +66,7 @@ namespace FppTest {
         case State::S3:
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/BasicU32StateMachineAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/BasicU32StateMachineAc.ref.cpp
@@ -66,7 +66,7 @@ namespace FppTest {
         case State::S3:
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/ChoiceToChoiceStateMachineAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/ChoiceToChoiceStateMachineAc.ref.cpp
@@ -66,7 +66,7 @@ namespace FppTest {
         case State::S2_S4:
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/ChoiceToStateStateMachineAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/ChoiceToStateStateMachineAc.ref.cpp
@@ -64,7 +64,7 @@ namespace FppTest {
         case State::S2_S3:
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/InputPairU16U32StateMachineAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/InputPairU16U32StateMachineAc.ref.cpp
@@ -66,7 +66,7 @@ namespace FppTest {
         case State::S3:
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }
@@ -84,7 +84,7 @@ namespace FppTest {
         case State::S3:
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/SequenceStateMachineAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/SequenceStateMachineAc.ref.cpp
@@ -68,7 +68,7 @@ namespace FppTest {
         case State::S4:
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }

--- a/compiler/tools/fpp-to-cpp/test/state-machine/choice/SequenceU32StateMachineAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/choice/SequenceU32StateMachineAc.ref.cpp
@@ -68,7 +68,7 @@ namespace FppTest {
         case State::S4:
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardStateMachineAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardStateMachineAc.ref.cpp
@@ -70,7 +70,7 @@ namespace FppTest {
         case State::T:
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardStringStateMachineAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardStringStateMachineAc.ref.cpp
@@ -68,7 +68,7 @@ namespace FppTest {
         case State::T:
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestAbsTypeStateMachineAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestAbsTypeStateMachineAc.ref.cpp
@@ -68,7 +68,7 @@ namespace FppTest {
         case State::T:
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestArrayStateMachineAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestArrayStateMachineAc.ref.cpp
@@ -68,7 +68,7 @@ namespace FppTest {
         case State::T:
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestEnumStateMachineAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestEnumStateMachineAc.ref.cpp
@@ -68,7 +68,7 @@ namespace FppTest {
         case State::T:
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestStructStateMachineAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardTestStructStateMachineAc.ref.cpp
@@ -68,7 +68,7 @@ namespace FppTest {
         case State::T:
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardU32StateMachineAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicGuardU32StateMachineAc.ref.cpp
@@ -68,7 +68,7 @@ namespace FppTest {
         case State::T:
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicInternalStateMachineAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicInternalStateMachineAc.ref.cpp
@@ -62,7 +62,7 @@ namespace FppTest {
           this->action_a(Signal::s);
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicSelfStateMachineAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicSelfStateMachineAc.ref.cpp
@@ -68,7 +68,7 @@ namespace FppTest {
           this->enter_S(Signal::s);
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicStateMachineAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicStateMachineAc.ref.cpp
@@ -68,7 +68,7 @@ namespace FppTest {
         case State::T:
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicStringStateMachineAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicStringStateMachineAc.ref.cpp
@@ -68,7 +68,7 @@ namespace FppTest {
         case State::T:
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }
@@ -82,7 +82,7 @@ namespace FppTest {
         case State::T:
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestAbsTypeStateMachineAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestAbsTypeStateMachineAc.ref.cpp
@@ -68,7 +68,7 @@ namespace FppTest {
         case State::T:
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestArrayStateMachineAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestArrayStateMachineAc.ref.cpp
@@ -68,7 +68,7 @@ namespace FppTest {
         case State::T:
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestEnumStateMachineAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestEnumStateMachineAc.ref.cpp
@@ -68,7 +68,7 @@ namespace FppTest {
         case State::T:
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestStructStateMachineAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicTestStructStateMachineAc.ref.cpp
@@ -68,7 +68,7 @@ namespace FppTest {
         case State::T:
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicU32StateMachineAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/BasicU32StateMachineAc.ref.cpp
@@ -68,7 +68,7 @@ namespace FppTest {
         case State::T:
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/InternalStateMachineAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/InternalStateMachineAc.ref.cpp
@@ -66,7 +66,7 @@ namespace FppTest {
           this->action_a(Signal::S1_internal);
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }
@@ -82,7 +82,7 @@ namespace FppTest {
         case State::S1_S3:
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/PolymorphismStateMachineAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/PolymorphismStateMachineAc.ref.cpp
@@ -70,7 +70,7 @@ namespace FppTest {
         case State::S5:
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }
@@ -90,7 +90,7 @@ namespace FppTest {
         case State::S5:
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToChildStateMachineAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToChildStateMachineAc.ref.cpp
@@ -72,7 +72,7 @@ namespace FppTest {
           this->enter_S1_S2(Signal::S1_to_S2);
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }
@@ -90,7 +90,7 @@ namespace FppTest {
         case State::S1_S3:
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToChoiceStateMachineAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToChoiceStateMachineAc.ref.cpp
@@ -78,7 +78,7 @@ namespace FppTest {
         case State::S4_S6:
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }
@@ -110,7 +110,7 @@ namespace FppTest {
         case State::S4_S6:
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }
@@ -132,7 +132,7 @@ namespace FppTest {
         case State::S4_S6:
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToSelfStateMachineAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToSelfStateMachineAc.ref.cpp
@@ -74,7 +74,7 @@ namespace FppTest {
           this->enter_S1(Signal::S1_to_S1);
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }
@@ -92,7 +92,7 @@ namespace FppTest {
         case State::S1_S3:
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }

--- a/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToStateStateMachineAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/state-machine/state/StateToStateStateMachineAc.ref.cpp
@@ -76,7 +76,7 @@ namespace FppTest {
         case State::S4_S5:
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }
@@ -106,7 +106,7 @@ namespace FppTest {
         case State::S4_S5:
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }
@@ -126,7 +126,7 @@ namespace FppTest {
         case State::S4_S5:
           break;
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(this->m_state));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(this->m_state));
           break;
       }
     }

--- a/compiler/tools/fpp-to-cpp/test/top/basic/BasicTopologyAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/top/basic/BasicTopologyAc.ref.cpp
@@ -188,7 +188,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -225,7 +225,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -236,7 +236,7 @@ namespace M {
             active1.p_handlerBase(0);
             break;
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;
@@ -246,7 +246,7 @@ namespace M {
             M::active2.p_handlerBase(0);
             break;
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;

--- a/compiler/tools/fpp-to-cpp/test/top/commands/CommandsTopologyAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/top/commands/CommandsTopologyAc.ref.cpp
@@ -159,7 +159,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -194,7 +194,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -231,7 +231,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -245,14 +245,14 @@ namespace M {
             );
             break;
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;
       case ::M::InstanceIds::M_c2:
         switch (portNum) {
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;
@@ -274,7 +274,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -290,14 +290,14 @@ namespace M {
             );
             break;
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;
       case ::M::InstanceIds::M_c2:
         switch (portNum) {
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;
@@ -346,7 +346,7 @@ namespace M {
         );
         break;
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
   }

--- a/compiler/tools/fpp-to-cpp/test/top/dp/DpTopologyAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/top/dp/DpTopologyAc.ref.cpp
@@ -162,7 +162,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -197,7 +197,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -232,7 +232,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -267,7 +267,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -304,7 +304,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -320,14 +320,14 @@ namespace M {
             );
             break;
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;
       case ::M::InstanceIds::M_c2:
         switch (portNum) {
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;
@@ -349,7 +349,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -364,14 +364,14 @@ namespace M {
             );
             break;
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;
       case ::M::InstanceIds::M_c2:
         switch (portNum) {
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;
@@ -392,7 +392,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -407,14 +407,14 @@ namespace M {
             );
             break;
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;
       case ::M::InstanceIds::M_c2:
         switch (portNum) {
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;
@@ -434,7 +434,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -442,14 +442,14 @@ namespace M {
       case ::M::InstanceIds::M_c1:
         switch (portNum) {
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;
       case ::M::InstanceIds::M_c2:
         switch (portNum) {
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;
@@ -498,7 +498,7 @@ namespace M {
         );
         break;
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
   }
@@ -560,7 +560,7 @@ namespace M {
     );
     switch (portNum) {
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
   }

--- a/compiler/tools/fpp-to-cpp/test/top/events/EventsTopologyAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/top/events/EventsTopologyAc.ref.cpp
@@ -150,7 +150,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -187,7 +187,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -221,7 +221,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -258,7 +258,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -275,14 +275,14 @@ namespace M {
             );
             break;
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;
       case ::M::InstanceIds::M_c2:
         switch (portNum) {
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;
@@ -307,7 +307,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -315,14 +315,14 @@ namespace M {
       case ::M::InstanceIds::M_c1:
         switch (portNum) {
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;
       case ::M::InstanceIds::M_c2:
         switch (portNum) {
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;
@@ -344,7 +344,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -352,14 +352,14 @@ namespace M {
       case ::M::InstanceIds::M_c1:
         switch (portNum) {
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;
       case ::M::InstanceIds::M_c2:
         switch (portNum) {
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;
@@ -427,7 +427,7 @@ namespace M {
     );
     switch (portNum) {
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
   }

--- a/compiler/tools/fpp-to-cpp/test/top/health/HealthTopologyAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/top/health/HealthTopologyAc.ref.cpp
@@ -176,7 +176,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -216,7 +216,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -230,7 +230,7 @@ namespace M {
             );
             break;
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;
@@ -243,7 +243,7 @@ namespace M {
             );
             break;
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;
@@ -297,7 +297,7 @@ namespace Svc {
         );
         break;
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
   }

--- a/compiler/tools/fpp-to-cpp/test/top/params/ParamsTopologyAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/top/params/ParamsTopologyAc.ref.cpp
@@ -133,7 +133,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -165,7 +165,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -197,7 +197,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -229,7 +229,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -263,7 +263,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -271,14 +271,14 @@ namespace M {
       case ::M::InstanceIds::M_c1:
         switch (portNum) {
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;
       case ::M::InstanceIds::M_c2:
         switch (portNum) {
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;
@@ -300,7 +300,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -308,14 +308,14 @@ namespace M {
       case ::M::InstanceIds::M_c1:
         switch (portNum) {
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;
       case ::M::InstanceIds::M_c2:
         switch (portNum) {
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;
@@ -337,7 +337,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -345,14 +345,14 @@ namespace M {
       case ::M::InstanceIds::M_c1:
         switch (portNum) {
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;
       case ::M::InstanceIds::M_c2:
         switch (portNum) {
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;
@@ -374,7 +374,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -382,14 +382,14 @@ namespace M {
       case ::M::InstanceIds::M_c1:
         switch (portNum) {
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;
       case ::M::InstanceIds::M_c2:
         switch (portNum) {
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;

--- a/compiler/tools/fpp-to-cpp/test/top/ports/Ports1TopologyAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/top/ports/Ports1TopologyAc.ref.cpp
@@ -182,7 +182,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -216,7 +216,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -227,14 +227,14 @@ namespace M {
             active1.p_handlerBase(0);
             break;
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;
       case ::M::InstanceIds::M_passive2:
         switch (portNum) {
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;

--- a/compiler/tools/fpp-to-cpp/test/top/ports/Ports2TopologyAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/top/ports/Ports2TopologyAc.ref.cpp
@@ -188,7 +188,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -225,7 +225,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -236,7 +236,7 @@ namespace M {
             active1.p_handlerBase(0);
             break;
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;
@@ -246,7 +246,7 @@ namespace M {
             M::active2.p_handlerBase(0);
             break;
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;

--- a/compiler/tools/fpp-to-cpp/test/top/serial_ports_active/SerialPortsActiveTopologyAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/top/serial_ports_active/SerialPortsActiveTopologyAc.ref.cpp
@@ -342,7 +342,7 @@ namespace SerialPortsActive {
         );
         break;
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
     return _result;
@@ -409,7 +409,7 @@ namespace SerialPortsActive {
         }
         break;
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
   }

--- a/compiler/tools/fpp-to-cpp/test/top/serial_ports_passive/SerialPortsPassiveTopologyAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/top/serial_ports_passive/SerialPortsPassiveTopologyAc.ref.cpp
@@ -337,7 +337,7 @@ namespace SerialPortsPassive {
         );
         break;
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
     return _result;
@@ -404,7 +404,7 @@ namespace SerialPortsPassive {
         }
         break;
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
   }

--- a/compiler/tools/fpp-to-cpp/test/top/serial_ports_queued/SerialPortsQueuedTopologyAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/top/serial_ports_queued/SerialPortsQueuedTopologyAc.ref.cpp
@@ -337,7 +337,7 @@ namespace SerialPortsQueued {
         );
         break;
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
     return _result;
@@ -404,7 +404,7 @@ namespace SerialPortsQueued {
         }
         break;
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
   }

--- a/compiler/tools/fpp-to-cpp/test/top/tlm/TlmTopologyAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/top/tlm/TlmTopologyAc.ref.cpp
@@ -150,7 +150,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -182,7 +182,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -219,7 +219,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -227,14 +227,14 @@ namespace M {
       case ::M::InstanceIds::M_c1:
         switch (portNum) {
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;
       case ::M::InstanceIds::M_c2:
         switch (portNum) {
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;
@@ -256,7 +256,7 @@ namespace M {
     switch (instance) {
       default:
 #ifdef FW_STRICT_ASSERTIONS
-        FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
         break;
 #else
         // Fall through
@@ -272,14 +272,14 @@ namespace M {
             );
             break;
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;
       case ::M::InstanceIds::M_c2:
         switch (portNum) {
           default:
-            FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+            FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
             break;
         }
         break;
@@ -329,7 +329,7 @@ namespace M {
     );
     switch (portNum) {
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
   }

--- a/compiler/tools/fpp-to-cpp/test/top/tlm_packets/OneInstanceTopologyAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/top/tlm_packets/OneInstanceTopologyAc.ref.cpp
@@ -140,7 +140,7 @@ void CComponentBase::timeGetOut_out(
   );
   switch (portNum) {
     default:
-      FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
       break;
   }
 }
@@ -158,7 +158,7 @@ void CComponentBase::tlmOut_out(
   );
   switch (portNum) {
     default:
-      FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
       break;
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/top/tlm_packets/TwoInstancesTopologyAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/top/tlm_packets/TwoInstancesTopologyAc.ref.cpp
@@ -121,7 +121,7 @@ bool CComponentBase::isConnected_timeGetOut_OutputPort(FwIndexType portNum) cons
   switch (instance) {
     default:
 #ifdef FW_STRICT_ASSERTIONS
-      FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
       break;
 #else
       // Fall through
@@ -153,7 +153,7 @@ bool CComponentBase::isConnected_tlmOut_OutputPort(FwIndexType portNum) const {
   switch (instance) {
     default:
 #ifdef FW_STRICT_ASSERTIONS
-      FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
       break;
 #else
       // Fall through
@@ -187,7 +187,7 @@ void CComponentBase::timeGetOut_out(
   switch (instance) {
     default:
 #ifdef FW_STRICT_ASSERTIONS
-      FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
       break;
 #else
       // Fall through
@@ -195,14 +195,14 @@ void CComponentBase::timeGetOut_out(
     case ::N::InstanceIds::M_c1:
       switch (portNum) {
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
           break;
       }
       break;
     case ::N::InstanceIds::M_c2:
       switch (portNum) {
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
           break;
       }
       break;
@@ -224,7 +224,7 @@ void CComponentBase::tlmOut_out(
   switch (instance) {
     default:
 #ifdef FW_STRICT_ASSERTIONS
-      FW_ASSERT(0, static_cast<FwAssertArgType>(instance));
+      FW_ASSERT(false, static_cast<FwAssertArgType>(instance));
       break;
 #else
       // Fall through
@@ -232,14 +232,14 @@ void CComponentBase::tlmOut_out(
     case ::N::InstanceIds::M_c1:
       switch (portNum) {
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
           break;
       }
       break;
     case ::N::InstanceIds::M_c2:
       switch (portNum) {
         default:
-          FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+          FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
           break;
       }
       break;

--- a/compiler/tools/fpp-to-cpp/test/top/typed_ports_active/TypedPortsActiveTopologyAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/top/typed_ports_active/TypedPortsActiveTopologyAc.ref.cpp
@@ -387,7 +387,7 @@ namespace TypedPortsActive {
         );
         break;
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
   }
@@ -416,7 +416,7 @@ namespace TypedPortsActive {
         );
         break;
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
     return _result;
@@ -446,7 +446,7 @@ namespace TypedPortsActive {
         );
         break;
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
     return _result;
@@ -476,7 +476,7 @@ namespace TypedPortsActive {
         );
         break;
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
     return _result;
@@ -506,7 +506,7 @@ namespace TypedPortsActive {
         );
         break;
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
     return _result;
@@ -536,7 +536,7 @@ namespace TypedPortsActive {
         );
         break;
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
     return _result;
@@ -566,7 +566,7 @@ namespace TypedPortsActive {
         );
         break;
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
     return _result;
@@ -596,7 +596,7 @@ namespace TypedPortsActive {
         );
         break;
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
     return _result;

--- a/compiler/tools/fpp-to-cpp/test/top/typed_ports_passive/TypedPortsPassiveTopologyAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/top/typed_ports_passive/TypedPortsPassiveTopologyAc.ref.cpp
@@ -382,7 +382,7 @@ namespace TypedPortsPassive {
         );
         break;
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
   }
@@ -411,7 +411,7 @@ namespace TypedPortsPassive {
         );
         break;
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
     return _result;
@@ -441,7 +441,7 @@ namespace TypedPortsPassive {
         );
         break;
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
     return _result;
@@ -471,7 +471,7 @@ namespace TypedPortsPassive {
         );
         break;
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
     return _result;
@@ -501,7 +501,7 @@ namespace TypedPortsPassive {
         );
         break;
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
     return _result;
@@ -531,7 +531,7 @@ namespace TypedPortsPassive {
         );
         break;
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
     return _result;
@@ -561,7 +561,7 @@ namespace TypedPortsPassive {
         );
         break;
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
     return _result;
@@ -591,7 +591,7 @@ namespace TypedPortsPassive {
         );
         break;
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
     return _result;

--- a/compiler/tools/fpp-to-cpp/test/top/typed_ports_queued/TypedPortsQueuedTopologyAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/top/typed_ports_queued/TypedPortsQueuedTopologyAc.ref.cpp
@@ -382,7 +382,7 @@ namespace TypedPortsQueued {
         );
         break;
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
   }
@@ -411,7 +411,7 @@ namespace TypedPortsQueued {
         );
         break;
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
     return _result;
@@ -441,7 +441,7 @@ namespace TypedPortsQueued {
         );
         break;
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
     return _result;
@@ -471,7 +471,7 @@ namespace TypedPortsQueued {
         );
         break;
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
     return _result;
@@ -501,7 +501,7 @@ namespace TypedPortsQueued {
         );
         break;
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
     return _result;
@@ -531,7 +531,7 @@ namespace TypedPortsQueued {
         );
         break;
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
     return _result;
@@ -561,7 +561,7 @@ namespace TypedPortsQueued {
         );
         break;
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
     return _result;
@@ -591,7 +591,7 @@ namespace TypedPortsQueued {
         );
         break;
       default:
-        FW_ASSERT(0, static_cast<FwAssertArgType>(portNum));
+        FW_ASSERT(false, static_cast<FwAssertArgType>(portNum));
         break;
     }
     return _result;


### PR DESCRIPTION
## Summary

Makes all generated `FW_ASSERT` conditions explicitly boolean:

- `callComp` checks become `callComp != nullptr`
- unreachable `0` checks become `false`

This resolves the non-boolean assertion findings reported for generated C++ while preserving the assertion behavior.

Fixes #1030
Part of #1032

## Validation

- `./fpp-sbt test` — 586 tests passed
- `compiler/tools/fpp-to-cpp/test/test` — all generator tests passed
- `compiler/tools/fpp-to-cpp/test/check-cpp` — generated C++ compilation sweep passed

Golden outputs were refreshed with the repository-provided `update-ref` workflow.