### PR TITLE
Explicitly discard generated event format status

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentEvents.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentEvents.scala
@@ -311,7 +311,7 @@ case class ComponentEvents (
             List.concat(
               lines(
                 s"""|Fw::TextLogString _logString;
-                    |_logString.format(
+                    |(void) _logString.format(
                     |  _formatString,
                     |#if FW_OBJECT_NAMES == 1
                     |  this->m_objName.toChar(),

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.cpp
@@ -3128,7 +3128,7 @@ void ActiveEventsComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -3253,7 +3253,7 @@ void ActiveEventsComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -3342,7 +3342,7 @@ void ActiveEventsComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -3428,7 +3428,7 @@ void ActiveEventsComponentBase ::
     e.toString(eStr);
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -3534,7 +3534,7 @@ void ActiveEventsComponentBase ::
     a.toString(aStr);
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -3619,7 +3619,7 @@ void ActiveEventsComponentBase ::
     s.toString(sStr);
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -3693,7 +3693,7 @@ void ActiveEventsComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -3783,7 +3783,7 @@ void ActiveEventsComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
@@ -6052,7 +6052,7 @@ void ActiveSerialComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -6177,7 +6177,7 @@ void ActiveSerialComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -6266,7 +6266,7 @@ void ActiveSerialComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -6352,7 +6352,7 @@ void ActiveSerialComponentBase ::
     e.toString(eStr);
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -6458,7 +6458,7 @@ void ActiveSerialComponentBase ::
     a.toString(aStr);
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -6543,7 +6543,7 @@ void ActiveSerialComponentBase ::
     s.toString(sStr);
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -6617,7 +6617,7 @@ void ActiveSerialComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -6707,7 +6707,7 @@ void ActiveSerialComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
@@ -5884,7 +5884,7 @@ namespace M {
 #endif
 
       Fw::TextLogString _logString;
-      _logString.format(
+      (void) _logString.format(
         _formatString,
 #if FW_OBJECT_NAMES == 1
         this->m_objName.toChar(),
@@ -6009,7 +6009,7 @@ namespace M {
 #endif
 
       Fw::TextLogString _logString;
-      _logString.format(
+      (void) _logString.format(
         _formatString,
 #if FW_OBJECT_NAMES == 1
         this->m_objName.toChar(),
@@ -6098,7 +6098,7 @@ namespace M {
 #endif
 
       Fw::TextLogString _logString;
-      _logString.format(
+      (void) _logString.format(
         _formatString,
 #if FW_OBJECT_NAMES == 1
         this->m_objName.toChar(),
@@ -6184,7 +6184,7 @@ namespace M {
       e.toString(eStr);
 
       Fw::TextLogString _logString;
-      _logString.format(
+      (void) _logString.format(
         _formatString,
 #if FW_OBJECT_NAMES == 1
         this->m_objName.toChar(),
@@ -6290,7 +6290,7 @@ namespace M {
       a.toString(aStr);
 
       Fw::TextLogString _logString;
-      _logString.format(
+      (void) _logString.format(
         _formatString,
 #if FW_OBJECT_NAMES == 1
         this->m_objName.toChar(),
@@ -6375,7 +6375,7 @@ namespace M {
       s.toString(sStr);
 
       Fw::TextLogString _logString;
-      _logString.format(
+      (void) _logString.format(
         _formatString,
 #if FW_OBJECT_NAMES == 1
         this->m_objName.toChar(),
@@ -6449,7 +6449,7 @@ namespace M {
 #endif
 
       Fw::TextLogString _logString;
-      _logString.format(
+      (void) _logString.format(
         _formatString,
 #if FW_OBJECT_NAMES == 1
         this->m_objName.toChar(),
@@ -6539,7 +6539,7 @@ namespace M {
 #endif
 
       Fw::TextLogString _logString;
-      _logString.format(
+      (void) _logString.format(
         _formatString,
 #if FW_OBJECT_NAMES == 1
         this->m_objName.toChar(),

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveEventsComponentAc.ref.cpp
@@ -2166,7 +2166,7 @@ void PassiveEventsComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -2291,7 +2291,7 @@ void PassiveEventsComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -2380,7 +2380,7 @@ void PassiveEventsComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -2466,7 +2466,7 @@ void PassiveEventsComponentBase ::
     e.toString(eStr);
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -2572,7 +2572,7 @@ void PassiveEventsComponentBase ::
     a.toString(aStr);
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -2657,7 +2657,7 @@ void PassiveEventsComponentBase ::
     s.toString(sStr);
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -2731,7 +2731,7 @@ void PassiveEventsComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -2821,7 +2821,7 @@ void PassiveEventsComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
@@ -3950,7 +3950,7 @@ void PassiveSerialComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -4075,7 +4075,7 @@ void PassiveSerialComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -4164,7 +4164,7 @@ void PassiveSerialComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -4250,7 +4250,7 @@ void PassiveSerialComponentBase ::
     e.toString(eStr);
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -4356,7 +4356,7 @@ void PassiveSerialComponentBase ::
     a.toString(aStr);
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -4441,7 +4441,7 @@ void PassiveSerialComponentBase ::
     s.toString(sStr);
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -4515,7 +4515,7 @@ void PassiveSerialComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -4605,7 +4605,7 @@ void PassiveSerialComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
@@ -4130,7 +4130,7 @@ void PassiveTestComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -4255,7 +4255,7 @@ void PassiveTestComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -4344,7 +4344,7 @@ void PassiveTestComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -4430,7 +4430,7 @@ void PassiveTestComponentBase ::
     e.toString(eStr);
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -4536,7 +4536,7 @@ void PassiveTestComponentBase ::
     a.toString(aStr);
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -4621,7 +4621,7 @@ void PassiveTestComponentBase ::
     s.toString(sStr);
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -4695,7 +4695,7 @@ void PassiveTestComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -4785,7 +4785,7 @@ void PassiveTestComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.cpp
@@ -3128,7 +3128,7 @@ void QueuedEventsComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -3253,7 +3253,7 @@ void QueuedEventsComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -3342,7 +3342,7 @@ void QueuedEventsComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -3428,7 +3428,7 @@ void QueuedEventsComponentBase ::
     e.toString(eStr);
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -3534,7 +3534,7 @@ void QueuedEventsComponentBase ::
     a.toString(aStr);
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -3619,7 +3619,7 @@ void QueuedEventsComponentBase ::
     s.toString(sStr);
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -3693,7 +3693,7 @@ void QueuedEventsComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -3783,7 +3783,7 @@ void QueuedEventsComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
@@ -6052,7 +6052,7 @@ void QueuedSerialComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -6177,7 +6177,7 @@ void QueuedSerialComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -6266,7 +6266,7 @@ void QueuedSerialComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -6352,7 +6352,7 @@ void QueuedSerialComponentBase ::
     e.toString(eStr);
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -6458,7 +6458,7 @@ void QueuedSerialComponentBase ::
     a.toString(aStr);
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -6543,7 +6543,7 @@ void QueuedSerialComponentBase ::
     s.toString(sStr);
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -6617,7 +6617,7 @@ void QueuedSerialComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -6707,7 +6707,7 @@ void QueuedSerialComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
@@ -5882,7 +5882,7 @@ void QueuedTestComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -6007,7 +6007,7 @@ void QueuedTestComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -6096,7 +6096,7 @@ void QueuedTestComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -6182,7 +6182,7 @@ void QueuedTestComponentBase ::
     e.toString(eStr);
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -6288,7 +6288,7 @@ void QueuedTestComponentBase ::
     a.toString(aStr);
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -6373,7 +6373,7 @@ void QueuedTestComponentBase ::
     s.toString(sStr);
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -6447,7 +6447,7 @@ void QueuedTestComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),
@@ -6537,7 +6537,7 @@ void QueuedTestComponentBase ::
 #endif
 
     Fw::TextLogString _logString;
-    _logString.format(
+    (void) _logString.format(
       _formatString,
 #if FW_OBJECT_NAMES == 1
       this->m_objName.toChar(),


### PR DESCRIPTION
## Summary

Adds an explicit `(void)` cast to the `Fw::TextLogString::format()` result in generated event handlers. This documents that the return value is intentionally ignored and resolves the JPL unchecked-return-value finding without altering event logging behavior.

Fixes #1031
Part of #1032

## Validation

- `./fpp-sbt test` — 586 tests passed
- `compiler/tools/fpp-to-cpp/test/component/base/run` — 8 generated component cases passed

Golden outputs were regenerated with the repository-provided workflow.