### PR TITLE
Add FPP contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,3 +20,7 @@ For FPP contributions:
 
 Keep pull requests focused on one approved issue, explain the rationale for
 the change, and run the relevant tests before submitting.
+
+Maintainers may decline or close a contribution that does not align with the
+project's direction, even when the work itself is sound. They will try to
+explain the reasoning and, where possible, suggest a path forward.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing to FPP
+
+FPP is part of the F´ ecosystem. Before contributing, please read the
+[F´ contribution guide](https://github.com/nasa/fprime/blob/devel/CONTRIBUTING.md),
+which describes the shared contribution process and review expectations.
+
+For FPP contributions:
+
+1. Work from an existing, approved, and unassigned issue, or open an issue and
+   obtain approval through the F´ Change Control Board process described in the
+   F´ guide.
+2. For changes that are more than a simple bug fix, consult the FPP maintainers
+   before beginning implementation. They can help confirm scope and identify
+   the appropriate design and test approach.
+
+Keep pull requests focused on one approved issue, explain the rationale for
+the change, and run the relevant tests before submitting.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,11 @@ For FPP contributions:
 2. Unless the issue is very simple (for example, a simple bug fix), consult the
    FPP maintainers before beginning implementation. They can help confirm scope
    and identify the appropriate design and test approach.
+   To consult the FPP maintainers, you can post a comment on the open issue stating
+   what you intend to do and asking for further guidance.
+3. The [FPP wiki](https://github.com/nasa/fpp/wiki) has useful information for
+   contributors, including a primer on programming in Scala and a process to
+   follow for adding new features to FPP.
 
 Keep pull requests focused on one approved issue, explain the rationale for
 the change, and run the relevant tests before submitting.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,8 @@ For FPP contributions:
 Keep pull requests focused on one approved issue, explain the rationale for
 the change, and run the relevant tests before submitting.
 
-Maintainers may decline or close a contribution that does not align with the
-project's direction, even when the work itself is sound. They will try to
-explain the reasoning and, where possible, suggest a path forward.
+If you don't follow the process above, then we may not be able to accept your
+contribution. In particular, the FPP maintainers may decline or close an
+unsolicited contribution that does not align with the project's direction,
+even if the work itself is sound. In this case, they will try to explain the
+reasoning and, where possible, suggest a path forward.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,9 +9,9 @@ For FPP contributions:
 1. Work from an existing, approved, and unassigned issue, or open an issue and
    obtain approval through the F´ Change Control Board process described in the
    F´ guide.
-2. For changes that are more than a simple bug fix, consult the FPP maintainers
-   before beginning implementation. They can help confirm scope and identify
-   the appropriate design and test approach.
+2. Unless the issue is very simple (for example, a simple bug fix), consult the
+   FPP maintainers before beginning implementation. They can help confirm scope
+   and identify the appropriate design and test approach.
 
 Keep pull requests focused on one approved issue, explain the rationale for
 the change, and run the relevant tests before submitting.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,4 @@ Keep pull requests focused on one approved issue, explain the rationale for
 the change, and run the relevant tests before submitting.
 
 If you don't follow the process above, then we may not be able to accept your
-contribution. In particular, the FPP maintainers may decline or close an
-unsolicited contribution that does not align with the project's direction,
-even if the work itself is sound. In this case, they will try to explain the
-reasoning and, where possible, suggest a path forward.
+contribution.


### PR DESCRIPTION
## Summary

Adds the short FPP contribution guide requested in #970. It directs contributors to the authoritative F´ guide, requires approved unassigned issues, and asks contributors to consult maintainers before non-simple changes.

Fixes #970

## Validation

- `git diff --check`