### PR TITLE
Allow zero-sized strings

### DIFF
--- a/compiler/lib/src/main/scala/analysis/Semantics/Type.scala
+++ b/compiler/lib/src/main/scala/analysis/Semantics/Type.scala
@@ -183,7 +183,7 @@ object Type {
 
   object String {
 
-    def isValidSize(size: BigInt) = size > 0 && size <= Int.MaxValue
+    def isValidSize(size: BigInt) = size >= 0 && size <= Int.MaxValue
 
   }
 

--- a/compiler/tools/fpp-check/test/type/string_size_zero_ok.fpp
+++ b/compiler/tools/fpp-check/test/type/string_size_zero_ok.fpp
@@ -1,0 +1,3 @@
+type FwSizeStoreType = U16
+
+array A = [3] string size 0

--- a/compiler/tools/fpp-check/test/type/tests.sh
+++ b/compiler/tools/fpp-check/test/type/tests.sh
@@ -8,7 +8,7 @@ string_missing_fw_size_store_type
 string_size_negative
 string_size_not_numeric
 string_size_too_large
+string_size_zero_ok
 string_size_type_shadowed
 uses_ok
 "
-

--- a/compiler/tools/fpp-to-cpp/test/alias/BasicSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/alias/BasicSerializableAc.ref.cpp
@@ -17,7 +17,8 @@ Basic ::
     m_A(),
     m_B(),
     m_C(m___fprime_ac_C_buffer, sizeof m___fprime_ac_C_buffer, Fw::String("")),
-    m_D(m___fprime_ac_D_buffer, sizeof m___fprime_ac_D_buffer, Fw::String(""))
+    m_D(m___fprime_ac_D_buffer, sizeof m___fprime_ac_D_buffer, Fw::String("")),
+    m_E(m___fprime_ac_E_buffer, sizeof m___fprime_ac_E_buffer, Fw::String(""))
 {
 
 }
@@ -27,13 +28,15 @@ Basic ::
       TU32 A,
       TF32 B,
       const Fw::StringBase& C,
-      const Fw::StringBase& D
+      const Fw::StringBase& D,
+      const Fw::StringBase& E
   ) :
     Serializable(),
     m_A(A),
     m_B(B),
     m_C(m___fprime_ac_C_buffer, sizeof m___fprime_ac_C_buffer, C),
-    m_D(m___fprime_ac_D_buffer, sizeof m___fprime_ac_D_buffer, D)
+    m_D(m___fprime_ac_D_buffer, sizeof m___fprime_ac_D_buffer, D),
+    m_E(m___fprime_ac_E_buffer, sizeof m___fprime_ac_E_buffer, E)
 {
 
 }
@@ -44,7 +47,8 @@ Basic ::
     m_A(obj.m_A),
     m_B(obj.m_B),
     m_C(m___fprime_ac_C_buffer, sizeof m___fprime_ac_C_buffer, obj.m_C),
-    m_D(m___fprime_ac_D_buffer, sizeof m___fprime_ac_D_buffer, obj.m_D)
+    m_D(m___fprime_ac_D_buffer, sizeof m___fprime_ac_D_buffer, obj.m_D),
+    m_E(m___fprime_ac_E_buffer, sizeof m___fprime_ac_E_buffer, obj.m_E)
 {
 
 }
@@ -60,7 +64,7 @@ Basic& Basic ::
     return *this;
   }
 
-  set(obj.m_A, obj.m_B, obj.m_C, obj.m_D);
+  set(obj.m_A, obj.m_B, obj.m_C, obj.m_D, obj.m_E);
   return *this;
 }
 
@@ -72,7 +76,8 @@ bool Basic ::
     (this->m_A == obj.m_A) &&
     (this->m_B == obj.m_B) &&
     (this->m_C == obj.m_C) &&
-    (this->m_D == obj.m_D)
+    (this->m_D == obj.m_D) &&
+    (this->m_E == obj.m_E)
   );
 }
 
@@ -121,6 +126,10 @@ Fw::SerializeStatus Basic ::
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
+  status = buffer.serializeFrom(this->m_E, mode);
+  if (status != Fw::FW_SERIALIZE_OK) {
+    return status;
+  }
 
   return status;
 }
@@ -149,6 +158,10 @@ Fw::SerializeStatus Basic ::
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
+  status = buffer.deserializeTo(this->m_E, mode);
+  if (status != Fw::FW_SERIALIZE_OK) {
+    return status;
+  }
 
   return status;
 }
@@ -161,6 +174,7 @@ FwSizeType Basic ::
   size += sizeof(TF32);
   size += this->m_C.serializedSize();
   size += this->m_D.serializedSize();
+  size += this->m_E.serializedSize();
   return size;
 }
 
@@ -192,6 +206,11 @@ void Basic ::
   // Format D
   sb += "D = ";
   sb += this->m_D;
+  sb += ", ";
+
+  // Format E
+  sb += "E = ";
+  sb += this->m_E;
   sb += " )";
 }
 
@@ -206,13 +225,15 @@ void Basic ::
       TU32 A,
       TF32 B,
       const Fw::StringBase& C,
-      const Fw::StringBase& D
+      const Fw::StringBase& D,
+      const Fw::StringBase& E
   )
 {
   this->m_A = A;
   this->m_B = B;
   this->m_C = C;
   this->m_D = D;
+  this->m_E = E;
 }
 
 void Basic ::
@@ -237,4 +258,10 @@ void Basic ::
   set_D(const Fw::StringBase& D)
 {
   this->m_D = D;
+}
+
+void Basic ::
+  set_E(const Fw::StringBase& E)
+{
+  this->m_E = E;
 }

--- a/compiler/tools/fpp-to-cpp/test/alias/BasicSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/alias/BasicSerializableAc.ref.hpp
@@ -14,6 +14,7 @@
 #include "TF32AliasAc.hpp"
 #include "TStringAliasAc.hpp"
 #include "TStringSizeAliasAc.hpp"
+#include "TStringSizeZeroAliasAc.hpp"
 #include "TU32AliasAc.hpp"
 
 class Basic :
@@ -32,7 +33,8 @@ class Basic :
         sizeof(TU32) +
         sizeof(TF32) +
         Fw::StringBase::STATIC_SERIALIZED_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)) +
-        Fw::StringBase::STATIC_SERIALIZED_SIZE(2)
+        Fw::StringBase::STATIC_SERIALIZED_SIZE(2) +
+        Fw::StringBase::STATIC_SERIALIZED_SIZE(0)
     };
 
   public:
@@ -49,7 +51,8 @@ class Basic :
         TU32 A,
         TF32 B,
         const Fw::StringBase& C,
-        const Fw::StringBase& D
+        const Fw::StringBase& D,
+        const Fw::StringBase& E
     );
 
     //! Copy constructor
@@ -158,6 +161,18 @@ class Basic :
       return this->m_D;
     }
 
+    //! Get member E
+    Fw::ExternalString& get_E()
+    {
+      return this->m_E;
+    }
+
+    //! Get member E (const)
+    const Fw::ExternalString& get_E() const
+    {
+      return this->m_E;
+    }
+
     // ----------------------------------------------------------------------
     // Setter functions
     // ----------------------------------------------------------------------
@@ -167,7 +182,8 @@ class Basic :
         TU32 A,
         TF32 B,
         const Fw::StringBase& C,
-        const Fw::StringBase& D
+        const Fw::StringBase& D,
+        const Fw::StringBase& E
     );
 
     //! Set member A
@@ -182,6 +198,9 @@ class Basic :
     //! Set member D
     void set_D(const Fw::StringBase& D);
 
+    //! Set member E
+    void set_E(const Fw::StringBase& E);
+
   protected:
 
     // ----------------------------------------------------------------------
@@ -194,6 +213,8 @@ class Basic :
     Fw::ExternalString m_C;
     char m___fprime_ac_D_buffer[Fw::StringBase::BUFFER_SIZE(2)];
     Fw::ExternalString m_D;
+    char m___fprime_ac_E_buffer[Fw::StringBase::BUFFER_SIZE(0)];
+    Fw::ExternalString m_E;
 
 };
 

--- a/compiler/tools/fpp-to-cpp/test/alias/basic.fpp
+++ b/compiler/tools/fpp-to-cpp/test/alias/basic.fpp
@@ -2,10 +2,12 @@ type TU32 = U32
 type TF32 = F32
 type TString = string
 type TStringSize = string size 2
+type TStringSizeZero = string size 0
 
 struct Basic {
     A: TU32,
     B: TF32,
     C: TString,
     D: TStringSize
+    E: TStringSizeZero
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/StructWithAliasSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/StructWithAliasSerializableAc.ref.cpp
@@ -16,6 +16,7 @@ StructWithAlias ::
     Serializable(),
     m_x(),
     m_y(m___fprime_ac_y_buffer, sizeof m___fprime_ac_y_buffer, Fw::String("")),
+    m_y0(m___fprime_ac_y0_buffer, sizeof m___fprime_ac_y0_buffer, Fw::String("")),
     m_z(),
     m_w(),
     m_q()
@@ -27,6 +28,7 @@ StructWithAlias ::
   StructWithAlias(
       AliasPrim1 x,
       const Fw::StringBase& y,
+      const Fw::StringBase& y0,
       const AliasArray& z,
       const AliasAliasArray& w,
       const AliasArrayAliasArray& q
@@ -34,6 +36,7 @@ StructWithAlias ::
     Serializable(),
     m_x(x),
     m_y(m___fprime_ac_y_buffer, sizeof m___fprime_ac_y_buffer, y),
+    m_y0(m___fprime_ac_y0_buffer, sizeof m___fprime_ac_y0_buffer, y0),
     m_z(z),
     m_w(w),
     m_q(q)
@@ -46,6 +49,7 @@ StructWithAlias ::
     Serializable(),
     m_x(obj.m_x),
     m_y(m___fprime_ac_y_buffer, sizeof m___fprime_ac_y_buffer, obj.m_y),
+    m_y0(m___fprime_ac_y0_buffer, sizeof m___fprime_ac_y0_buffer, obj.m_y0),
     m_z(obj.m_z),
     m_w(obj.m_w),
     m_q(obj.m_q)
@@ -64,7 +68,7 @@ StructWithAlias& StructWithAlias ::
     return *this;
   }
 
-  set(obj.m_x, obj.m_y, obj.m_z, obj.m_w, obj.m_q);
+  set(obj.m_x, obj.m_y, obj.m_y0, obj.m_z, obj.m_w, obj.m_q);
   return *this;
 }
 
@@ -75,6 +79,7 @@ bool StructWithAlias ::
   return (
     (this->m_x == obj.m_x) &&
     (this->m_y == obj.m_y) &&
+    (this->m_y0 == obj.m_y0) &&
     (this->m_z == obj.m_z) &&
     (this->m_w == obj.m_w) &&
     (this->m_q == obj.m_q)
@@ -118,6 +123,10 @@ Fw::SerializeStatus StructWithAlias ::
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
+  status = buffer.serializeFrom(this->m_y0, mode);
+  if (status != Fw::FW_SERIALIZE_OK) {
+    return status;
+  }
   status = buffer.serializeFrom(this->m_z, mode);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
@@ -150,6 +159,10 @@ Fw::SerializeStatus StructWithAlias ::
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
+  status = buffer.deserializeTo(this->m_y0, mode);
+  if (status != Fw::FW_SERIALIZE_OK) {
+    return status;
+  }
   status = buffer.deserializeTo(this->m_z, mode);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
@@ -172,6 +185,7 @@ FwSizeType StructWithAlias ::
   FwSizeType size = 0;
   size += sizeof(AliasPrim1);
   size += this->m_y.serializedSize();
+  size += this->m_y0.serializedSize();
   size += this->m_z.serializedSize();
   size += this->m_w.serializedSize();
   size += this->m_q.serializedSize();
@@ -195,6 +209,11 @@ void StructWithAlias ::
   // Format y
   sb += "y = ";
   sb += this->m_y;
+  sb += ", ";
+
+  // Format y0
+  sb += "y0 = ";
+  sb += this->m_y0;
   sb += ", ";
 
   // Format z
@@ -226,6 +245,7 @@ void StructWithAlias ::
   set(
       AliasPrim1 x,
       const Fw::StringBase& y,
+      const Fw::StringBase& y0,
       const AliasArray& z,
       const AliasAliasArray& w,
       const AliasArrayAliasArray& q
@@ -233,6 +253,7 @@ void StructWithAlias ::
 {
   this->m_x = x;
   this->m_y = y;
+  this->m_y0 = y0;
   this->m_z = z;
   this->m_w = w;
   this->m_q = q;
@@ -248,6 +269,12 @@ void StructWithAlias ::
   set_y(const Fw::StringBase& y)
 {
   this->m_y = y;
+}
+
+void StructWithAlias ::
+  set_y0(const Fw::StringBase& y0)
+{
+  this->m_y0 = y0;
 }
 
 void StructWithAlias ::

--- a/compiler/tools/fpp-to-cpp/test/component/base/StructWithAliasSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/StructWithAliasSerializableAc.ref.hpp
@@ -12,6 +12,7 @@
 #include "AliasArrayAliasArrayAliasAc.hpp"
 #include "AliasPrim1AliasAc.hpp"
 #include "AliasStringAliasAc.hpp"
+#include "AliasStringZeroAliasAc.hpp"
 #include "Fw/FPrimeBasicTypes.hpp"
 #include "Fw/Types/ExternalString.hpp"
 #include "Fw/Types/Serializable.hpp"
@@ -32,6 +33,7 @@ class StructWithAlias :
       SERIALIZED_SIZE =
         sizeof(AliasPrim1) +
         Fw::StringBase::STATIC_SERIALIZED_SIZE(32) +
+        Fw::StringBase::STATIC_SERIALIZED_SIZE(0) +
         AliasArray::SERIALIZED_SIZE +
         AliasAliasArray::SERIALIZED_SIZE +
         AliasArrayAliasArray::SERIALIZED_SIZE
@@ -50,6 +52,7 @@ class StructWithAlias :
     StructWithAlias(
         AliasPrim1 x,
         const Fw::StringBase& y,
+        const Fw::StringBase& y0,
         const AliasArray& z,
         const AliasAliasArray& w,
         const AliasArrayAliasArray& q
@@ -143,6 +146,18 @@ class StructWithAlias :
       return this->m_y;
     }
 
+    //! Get member y0
+    Fw::ExternalString& get_y0()
+    {
+      return this->m_y0;
+    }
+
+    //! Get member y0 (const)
+    const Fw::ExternalString& get_y0() const
+    {
+      return this->m_y0;
+    }
+
     //! Get member z
     AliasArray& get_z()
     {
@@ -187,6 +202,7 @@ class StructWithAlias :
     void set(
         AliasPrim1 x,
         const Fw::StringBase& y,
+        const Fw::StringBase& y0,
         const AliasArray& z,
         const AliasAliasArray& w,
         const AliasArrayAliasArray& q
@@ -197,6 +213,9 @@ class StructWithAlias :
 
     //! Set member y
     void set_y(const Fw::StringBase& y);
+
+    //! Set member y0
+    void set_y0(const Fw::StringBase& y0);
 
     //! Set member z
     void set_z(const AliasArray& z);
@@ -216,6 +235,8 @@ class StructWithAlias :
     AliasPrim1 m_x;
     char m___fprime_ac_y_buffer[Fw::StringBase::BUFFER_SIZE(32)];
     Fw::ExternalString m_y;
+    char m___fprime_ac_y0_buffer[Fw::StringBase::BUFFER_SIZE(0)];
+    Fw::ExternalString m_y0;
     AliasArray m_z;
     AliasAliasArray m_w;
     AliasArrayAliasArray m_q;

--- a/compiler/tools/fpp-to-cpp/test/component/types.fpp
+++ b/compiler/tools/fpp-to-cpp/test/component/types.fpp
@@ -33,10 +33,12 @@ type AliasEnum = E
 
 @ Alias of a string
 type AliasString = string size 32
+type AliasStringZero = string size 0
 
 struct StructWithAlias {
   x: AliasPrim1,
   y: AliasString,
+  y0: AliasStringZero,
   z: AliasArray
   w: AliasAliasArray
   q: AliasArrayAliasArray

--- a/compiler/tools/fpp-to-cpp/test/port/StringPortAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/port/StringPortAc.ref.cpp
@@ -15,6 +15,8 @@ StringPortSerializer ::
   StringPortSerializer() :
     m_str80(m___fprime_ac_str80_buffer, sizeof m___fprime_ac_str80_buffer),
     m_str80Ref(m___fprime_ac_str80Ref_buffer, sizeof m___fprime_ac_str80Ref_buffer),
+    m_str0(m___fprime_ac_str0_buffer, sizeof m___fprime_ac_str0_buffer),
+    m_str0Ref(m___fprime_ac_str0Ref_buffer, sizeof m___fprime_ac_str0Ref_buffer),
     m_str100(m___fprime_ac_str100_buffer, sizeof m___fprime_ac_str100_buffer),
     m_str100Ref(m___fprime_ac_str100Ref_buffer, sizeof m___fprime_ac_str100Ref_buffer)
 {
@@ -36,6 +38,12 @@ Fw::SerializeStatus StringPortSerializer ::
     _status = _buffer.deserializeTo(m_str80Ref);
   }
   if (_status == Fw::FW_SERIALIZE_OK) {
+    _status = _buffer.deserializeTo(m_str0);
+  }
+  if (_status == Fw::FW_SERIALIZE_OK) {
+    _status = _buffer.deserializeTo(m_str0Ref);
+  }
+  if (_status == Fw::FW_SERIALIZE_OK) {
     _status = _buffer.deserializeTo(m_str100);
   }
   if (_status == Fw::FW_SERIALIZE_OK) {
@@ -52,6 +60,8 @@ Fw::SerializeStatus StringPortSerializer ::
   serializePortArgs(
       const Fw::StringBase& str80,
       Fw::StringBase& str80Ref,
+      const Fw::StringBase& str0,
+      Fw::StringBase& str0Ref,
       const Fw::StringBase& str100,
       Fw::StringBase& str100Ref,
       Fw::SerialBufferBase& _buffer
@@ -63,6 +73,12 @@ Fw::SerializeStatus StringPortSerializer ::
   }
   if (_status == Fw::FW_SERIALIZE_OK) {
     _status = _buffer.serializeFrom(str80Ref);
+  }
+  if (_status == Fw::FW_SERIALIZE_OK) {
+    _status = _buffer.serializeFrom(str0);
+  }
+  if (_status == Fw::FW_SERIALIZE_OK) {
+    _status = _buffer.serializeFrom(str0Ref);
   }
   if (_status == Fw::FW_SERIALIZE_OK) {
     _status = _buffer.serializeFrom(str100);
@@ -115,6 +131,8 @@ void InputStringPort ::
   invoke(
       const Fw::StringBase& str80,
       Fw::StringBase& str80Ref,
+      const Fw::StringBase& str0,
+      Fw::StringBase& str0Ref,
       const Fw::StringBase& str100,
       Fw::StringBase& str100Ref
   )
@@ -126,7 +144,7 @@ void InputStringPort ::
   FW_ASSERT(this->m_comp != nullptr);
   FW_ASSERT(this->m_func != nullptr);
 
-  return this->m_func(this->m_comp, this->m_portNum, str80, str80Ref, str100, str100Ref);
+  return this->m_func(this->m_comp, this->m_portNum, str80, str80Ref, str0, str0Ref, str100, str100Ref);
 }
 
 // ----------------------------------------------------------------------
@@ -151,7 +169,7 @@ Fw::SerializeStatus InputStringPort ::
     return _status;
   }
 
-  this->m_func(this->m_comp, this->m_portNum, _serializer.m_str80, _serializer.m_str80Ref, _serializer.m_str100, _serializer.m_str100Ref);
+  this->m_func(this->m_comp, this->m_portNum, _serializer.m_str80, _serializer.m_str80Ref, _serializer.m_str0, _serializer.m_str0Ref, _serializer.m_str100, _serializer.m_str100Ref);
 
   return Fw::FW_SERIALIZE_OK;
 }
@@ -197,6 +215,8 @@ void OutputStringPort ::
   invoke(
       const Fw::StringBase& str80,
       Fw::StringBase& str80Ref,
+      const Fw::StringBase& str0,
+      Fw::StringBase& str0Ref,
       const Fw::StringBase& str100,
       Fw::StringBase& str100Ref
   ) const
@@ -209,13 +229,13 @@ void OutputStringPort ::
   FW_ASSERT((this->m_port != nullptr) || (this->m_serPort != nullptr));
 
   if (this->m_port != nullptr) {
-    this->m_port->invoke(str80, str80Ref, str100, str100Ref);
+    this->m_port->invoke(str80, str80Ref, str0, str0Ref, str100, str100Ref);
   }
   else {
     Fw::SerializeStatus _status;
     StringPortBuffer _buffer;
 
-    _status = StringPortSerializer::serializePortArgs(str80, str80Ref, str100, str100Ref, _buffer);
+    _status = StringPortSerializer::serializePortArgs(str80, str80Ref, str0, str0Ref, str100, str100Ref, _buffer);
     FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
     _status = this->m_serPort->invokeSerial(_buffer);
@@ -223,7 +243,7 @@ void OutputStringPort ::
   }
 #else
   FW_ASSERT(this->m_port != nullptr);
-  this->m_port->invoke(str80, str80Ref, str100, str100Ref);
+  this->m_port->invoke(str80, str80Ref, str0, str0Ref, str100, str100Ref);
 #endif
 }
 

--- a/compiler/tools/fpp-to-cpp/test/port/StringPortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/StringPortAc.ref.hpp
@@ -34,6 +34,8 @@ class StringPortBuffer :
     static constexpr FwSizeType CAPACITY =
       Fw::StringBase::STATIC_SERIALIZED_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)) +
       Fw::StringBase::STATIC_SERIALIZED_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)) +
+      Fw::StringBase::STATIC_SERIALIZED_SIZE(0) +
+      Fw::StringBase::STATIC_SERIALIZED_SIZE(0) +
       Fw::StringBase::STATIC_SERIALIZED_SIZE(100) +
       Fw::StringBase::STATIC_SERIALIZED_SIZE(100);
 
@@ -105,6 +107,8 @@ class StringPortSerializer {
     static Fw::SerializeStatus serializePortArgs(
         const Fw::StringBase& str80, //!< A string of size 80
         Fw::StringBase& str80Ref,
+        const Fw::StringBase& str0, //!< A string of size 0
+        Fw::StringBase& str0Ref,
         const Fw::StringBase& str100, //!< A string of size 100
         Fw::StringBase& str100Ref,
         Fw::SerialBufferBase& _buffer //!< The serial buffer
@@ -118,6 +122,8 @@ class StringPortSerializer {
 
     char m___fprime_ac_str80_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
     char m___fprime_ac_str80Ref_buffer[Fw::StringBase::BUFFER_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE))];
+    char m___fprime_ac_str0_buffer[Fw::StringBase::BUFFER_SIZE(0)];
+    char m___fprime_ac_str0Ref_buffer[Fw::StringBase::BUFFER_SIZE(0)];
     char m___fprime_ac_str100_buffer[Fw::StringBase::BUFFER_SIZE(100)];
     char m___fprime_ac_str100Ref_buffer[Fw::StringBase::BUFFER_SIZE(100)];
 
@@ -129,6 +135,8 @@ class StringPortSerializer {
 
     Fw::ExternalString m_str80;
     Fw::ExternalString m_str80Ref;
+    Fw::ExternalString m_str0;
+    Fw::ExternalString m_str0Ref;
     Fw::ExternalString m_str100;
     Fw::ExternalString m_str100Ref;
 
@@ -154,6 +162,8 @@ class InputStringPort :
       FwIndexType portNum,
       const Fw::StringBase& str80,
       Fw::StringBase& str80Ref,
+      const Fw::StringBase& str0,
+      Fw::StringBase& str0Ref,
       const Fw::StringBase& str100,
       Fw::StringBase& str100Ref
     );
@@ -186,6 +196,8 @@ class InputStringPort :
     void invoke(
         const Fw::StringBase& str80, //!< A string of size 80
         Fw::StringBase& str80Ref,
+        const Fw::StringBase& str0, //!< A string of size 0
+        Fw::StringBase& str0Ref,
         const Fw::StringBase& str100, //!< A string of size 100
         Fw::StringBase& str100Ref
     );
@@ -250,6 +262,8 @@ class OutputStringPort :
     void invoke(
         const Fw::StringBase& str80, //!< A string of size 80
         Fw::StringBase& str80Ref,
+        const Fw::StringBase& str0, //!< A string of size 0
+        Fw::StringBase& str0Ref,
         const Fw::StringBase& str100, //!< A string of size 100
         Fw::StringBase& str100Ref
     ) const;

--- a/compiler/tools/fpp-to-cpp/test/port/string.fpp
+++ b/compiler/tools/fpp-to-cpp/test/port/string.fpp
@@ -2,6 +2,8 @@
 port String(
   str80: string, @< A string of size 80
   ref str80Ref: string,
+  str0: string size 0, @< A string of size 0
+  ref str0Ref: string size 0,
   str100: string size 100, @< A string of size 100
   ref str100Ref: string size 100
 )

--- a/compiler/tools/fpp-to-cpp/test/struct/AliasTypeSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/AliasTypeSerializableAc.ref.cpp
@@ -23,13 +23,20 @@ AliasType ::
     // Set the array value
     this->m_z[i] = Fw::String("");
   }
+  for (FwSizeType i = 0; i < 10; i++) {
+    // Initialize the external string
+    this->m_z0[i].setBuffer(&m___fprime_ac_z0_buffer[i][0], sizeof m___fprime_ac_z0_buffer[i]);
+    // Set the array value
+    this->m_z0[i] = Fw::String("");
+  }
 }
 
 AliasType ::
   AliasType(
       U16Alias x,
       const TAlias& y,
-      const Type_of_z& z
+      const Type_of_z& z,
+      const Type_of_z0& z0
   ) :
     Serializable(),
     m_x(x),
@@ -40,6 +47,12 @@ AliasType ::
     this->m_z[i].setBuffer(&m___fprime_ac_z_buffer[i][0], sizeof m___fprime_ac_z_buffer[i]);
     // Set the array value
     this->m_z[i] = z[i];
+  }
+  for (FwSizeType i = 0; i < 10; i++) {
+    // Initialize the external string
+    this->m_z0[i].setBuffer(&m___fprime_ac_z0_buffer[i][0], sizeof m___fprime_ac_z0_buffer[i]);
+    // Set the array value
+    this->m_z0[i] = z0[i];
   }
 }
 
@@ -55,13 +68,20 @@ AliasType ::
     // Set the array value
     this->m_z[i] = obj.m_z[i];
   }
+  for (FwSizeType i = 0; i < 10; i++) {
+    // Initialize the external string
+    this->m_z0[i].setBuffer(&m___fprime_ac_z0_buffer[i][0], sizeof m___fprime_ac_z0_buffer[i]);
+    // Set the array value
+    this->m_z0[i] = obj.m_z0[i];
+  }
 }
 
 AliasType ::
   AliasType(
       U16Alias x,
       const TAlias& y,
-      const Fw::StringBase& z
+      const Fw::StringBase& z,
+      const Fw::StringBase& z0
   ) :
     Serializable(),
     m_x(x),
@@ -72,6 +92,12 @@ AliasType ::
     this->m_z[i].setBuffer(&m___fprime_ac_z_buffer[i][0], sizeof m___fprime_ac_z_buffer[i]);
     // Set the array value
     this->m_z[i] = z;
+  }
+  for (FwSizeType i = 0; i < 10; i++) {
+    // Initialize the external string
+    this->m_z0[i].setBuffer(&m___fprime_ac_z0_buffer[i][0], sizeof m___fprime_ac_z0_buffer[i]);
+    // Set the array value
+    this->m_z0[i] = z0;
   }
 }
 
@@ -86,7 +112,7 @@ AliasType& AliasType ::
     return *this;
   }
 
-  set(obj.m_x, obj.m_y, obj.m_z);
+  set(obj.m_x, obj.m_y, obj.m_z, obj.m_z0);
   return *this;
 }
 
@@ -106,6 +132,11 @@ bool AliasType ::
   // Compare array members
   for (FwSizeType i = 0; i < 10; i++) {
     if (!(this->m_z[i] == obj.m_z[i])) {
+      return false;
+    }
+  }
+  for (FwSizeType i = 0; i < 10; i++) {
+    if (!(this->m_z0[i] == obj.m_z0[i])) {
       return false;
     }
   }
@@ -156,6 +187,12 @@ Fw::SerializeStatus AliasType ::
       return status;
     }
   }
+  for (FwSizeType i = 0; i < 10; i++) {
+    status = buffer.serializeFrom(this->m_z0[i], mode);
+    if (status != Fw::FW_SERIALIZE_OK) {
+      return status;
+    }
+  }
 
   return status;
 }
@@ -182,6 +219,12 @@ Fw::SerializeStatus AliasType ::
       return status;
     }
   }
+  for (FwSizeType i = 0; i < 10; i++) {
+    status = buffer.deserializeTo(this->m_z0[i], mode);
+    if (status != Fw::FW_SERIALIZE_OK) {
+      return status;
+    }
+  }
 
   return status;
 }
@@ -194,6 +237,9 @@ FwSizeType AliasType ::
   size += TAlias::SERIALIZED_SIZE;
   for (U32 index = 0; index < 10; index++) {
     size += this->m_z[index].serializedSize();
+  }
+  for (U32 index = 0; index < 10; index++) {
+    size += this->m_z0[index].serializedSize();
   }
   return size;
 }
@@ -229,6 +275,19 @@ void AliasType ::
     sb += tmp;
   }
   sb += " ]";
+  sb += ", ";
+
+  // Format z0
+  sb += "z0 = ";
+  sb += "[ ";
+  for (FwSizeType i = 0; i < 10; i++) {
+    tmp = this->m_z0[i];
+    if (i > 0) {
+      sb += ", ";
+    }
+    sb += tmp;
+  }
+  sb += " ]";
   sb += " )";
 }
 
@@ -242,7 +301,8 @@ void AliasType ::
   set(
       U16Alias x,
       const TAlias& y,
-      const Type_of_z& z
+      const Type_of_z& z,
+      const Type_of_z0& z0
   )
 {
   this->m_x = x;
@@ -253,6 +313,12 @@ void AliasType ::
     this->m_z[i].setBuffer(&m___fprime_ac_z_buffer[i][0], sizeof m___fprime_ac_z_buffer[i]);
     // Set the array value
     this->m_z[i] = z[i];
+  }
+  for (FwSizeType i = 0; i < 10; i++) {
+    // Initialize the external string
+    this->m_z0[i].setBuffer(&m___fprime_ac_z0_buffer[i][0], sizeof m___fprime_ac_z0_buffer[i]);
+    // Set the array value
+    this->m_z0[i] = z0[i];
   }
 }
 
@@ -273,5 +339,13 @@ void AliasType ::
 {
   for (FwSizeType i = 0; i < 10; i++) {
     this->m_z[i] = z[i];
+  }
+}
+
+void AliasType ::
+  set_z0(const Type_of_z0& z0)
+{
+  for (FwSizeType i = 0; i < 10; i++) {
+    this->m_z0[i] = z0[i];
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/struct/AliasTypeSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/AliasTypeSerializableAc.ref.hpp
@@ -12,6 +12,7 @@
 #include "Fw/Types/Serializable.hpp"
 #include "Fw/Types/String.hpp"
 #include "SAliasAliasAc.hpp"
+#include "SAliasZeroAliasAc.hpp"
 #include "TAliasAliasAc.hpp"
 #include "U16AliasAliasAc.hpp"
 
@@ -28,6 +29,9 @@ class AliasType :
     //! The type of z
     using Type_of_z = Fw::ExternalString[10];
 
+    //! The type of z0
+    using Type_of_z0 = Fw::ExternalString[10];
+
   public:
 
     // ----------------------------------------------------------------------
@@ -39,7 +43,8 @@ class AliasType :
       SERIALIZED_SIZE =
         sizeof(U16Alias) +
         TAlias::SERIALIZED_SIZE +
-        Fw::StringBase::STATIC_SERIALIZED_SIZE(50) * 10
+        Fw::StringBase::STATIC_SERIALIZED_SIZE(50) * 10 +
+        Fw::StringBase::STATIC_SERIALIZED_SIZE(0) * 10
     };
 
   public:
@@ -55,7 +60,8 @@ class AliasType :
     AliasType(
         U16Alias x,
         const TAlias& y,
-        const Type_of_z& z
+        const Type_of_z& z,
+        const Type_of_z0& z0
     );
 
     //! Copy constructor
@@ -67,7 +73,8 @@ class AliasType :
     AliasType(
         U16Alias x,
         const TAlias& y,
-        const Fw::StringBase& z
+        const Fw::StringBase& z,
+        const Fw::StringBase& z0
     );
 
   public:
@@ -165,6 +172,18 @@ class AliasType :
       return this->m_z;
     }
 
+    //! Get member z0
+    Type_of_z0& get_z0()
+    {
+      return this->m_z0;
+    }
+
+    //! Get member z0 (const)
+    const Type_of_z0& get_z0() const
+    {
+      return this->m_z0;
+    }
+
     // ----------------------------------------------------------------------
     // Setter functions
     // ----------------------------------------------------------------------
@@ -173,7 +192,8 @@ class AliasType :
     void set(
         U16Alias x,
         const TAlias& y,
-        const Type_of_z& z
+        const Type_of_z& z,
+        const Type_of_z0& z0
     );
 
     //! Set member x
@@ -185,6 +205,9 @@ class AliasType :
     //! Set member z
     void set_z(const Type_of_z& z);
 
+    //! Set member z0
+    void set_z0(const Type_of_z0& z0);
+
   protected:
 
     // ----------------------------------------------------------------------
@@ -195,6 +218,8 @@ class AliasType :
     TAlias m_y;
     char m___fprime_ac_z_buffer[10][Fw::StringBase::BUFFER_SIZE(50)];
     Fw::ExternalString m_z[10];
+    char m___fprime_ac_z0_buffer[10][Fw::StringBase::BUFFER_SIZE(0)];
+    Fw::ExternalString m_z0[10];
 
 };
 

--- a/compiler/tools/fpp-to-cpp/test/struct/DefaultSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/DefaultSerializableAc.ref.cpp
@@ -16,6 +16,7 @@ Default ::
     Serializable(),
     m_mU32(54),
     m_mS1(m___fprime_ac_mS1_buffer, sizeof m___fprime_ac_mS1_buffer, Fw::String("hello")),
+    m_mS0(m___fprime_ac_mS0_buffer, sizeof m___fprime_ac_mS0_buffer, Fw::String("")),
     m_mF64()
 {
 
@@ -25,11 +26,13 @@ Default ::
   Default(
       U32 mU32,
       const Fw::StringBase& mS1,
+      const Fw::StringBase& mS0,
       F64 mF64
   ) :
     Serializable(),
     m_mU32(mU32),
     m_mS1(m___fprime_ac_mS1_buffer, sizeof m___fprime_ac_mS1_buffer, mS1),
+    m_mS0(m___fprime_ac_mS0_buffer, sizeof m___fprime_ac_mS0_buffer, mS0),
     m_mF64(mF64)
 {
 
@@ -40,6 +43,7 @@ Default ::
     Serializable(),
     m_mU32(obj.m_mU32),
     m_mS1(m___fprime_ac_mS1_buffer, sizeof m___fprime_ac_mS1_buffer, obj.m_mS1),
+    m_mS0(m___fprime_ac_mS0_buffer, sizeof m___fprime_ac_mS0_buffer, obj.m_mS0),
     m_mF64(obj.m_mF64)
 {
 
@@ -56,7 +60,7 @@ Default& Default ::
     return *this;
   }
 
-  set(obj.m_mU32, obj.m_mS1, obj.m_mF64);
+  set(obj.m_mU32, obj.m_mS1, obj.m_mS0, obj.m_mF64);
   return *this;
 }
 
@@ -67,6 +71,7 @@ bool Default ::
   return (
     (this->m_mU32 == obj.m_mU32) &&
     (this->m_mS1 == obj.m_mS1) &&
+    (this->m_mS0 == obj.m_mS0) &&
     (this->m_mF64 == obj.m_mF64)
   );
 }
@@ -108,6 +113,10 @@ Fw::SerializeStatus Default ::
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
+  status = buffer.serializeFrom(this->m_mS0, mode);
+  if (status != Fw::FW_SERIALIZE_OK) {
+    return status;
+  }
   status = buffer.serializeFrom(this->m_mF64, mode);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
@@ -132,6 +141,10 @@ Fw::SerializeStatus Default ::
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
+  status = buffer.deserializeTo(this->m_mS0, mode);
+  if (status != Fw::FW_SERIALIZE_OK) {
+    return status;
+  }
   status = buffer.deserializeTo(this->m_mF64, mode);
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
@@ -146,6 +159,7 @@ FwSizeType Default ::
   FwSizeType size = 0;
   size += sizeof(U32);
   size += this->m_mS1.serializedSize();
+  size += this->m_mS0.serializedSize();
   size += sizeof(F64);
   return size;
 }
@@ -169,6 +183,11 @@ void Default ::
   sb += this->m_mS1;
   sb += ", ";
 
+  // Format mS0
+  sb += "mS0 = ";
+  sb += this->m_mS0;
+  sb += ", ";
+
   // Format mF64
   sb += "mF64 = ";
   tmp.format("%f", this->m_mF64);
@@ -186,11 +205,13 @@ void Default ::
   set(
       U32 mU32,
       const Fw::StringBase& mS1,
+      const Fw::StringBase& mS0,
       F64 mF64
   )
 {
   this->m_mU32 = mU32;
   this->m_mS1 = mS1;
+  this->m_mS0 = mS0;
   this->m_mF64 = mF64;
 }
 
@@ -204,6 +225,12 @@ void Default ::
   set_mS1(const Fw::StringBase& mS1)
 {
   this->m_mS1 = mS1;
+}
+
+void Default ::
+  set_mS0(const Fw::StringBase& mS0)
+{
+  this->m_mS0 = mS0;
 }
 
 void Default ::

--- a/compiler/tools/fpp-to-cpp/test/struct/DefaultSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/DefaultSerializableAc.ref.hpp
@@ -28,6 +28,7 @@ class Default :
       SERIALIZED_SIZE =
         sizeof(U32) +
         Fw::StringBase::STATIC_SERIALIZED_SIZE(40) +
+        Fw::StringBase::STATIC_SERIALIZED_SIZE(0) +
         sizeof(F64)
     };
 
@@ -44,6 +45,7 @@ class Default :
     Default(
         U32 mU32,
         const Fw::StringBase& mS1,
+        const Fw::StringBase& mS0,
         F64 mF64
     );
 
@@ -135,6 +137,18 @@ class Default :
       return this->m_mS1;
     }
 
+    //! Get member mS0
+    Fw::ExternalString& get_mS0()
+    {
+      return this->m_mS0;
+    }
+
+    //! Get member mS0 (const)
+    const Fw::ExternalString& get_mS0() const
+    {
+      return this->m_mS0;
+    }
+
     //! Get member mF64
     F64 get_mF64() const
     {
@@ -149,6 +163,7 @@ class Default :
     void set(
         U32 mU32,
         const Fw::StringBase& mS1,
+        const Fw::StringBase& mS0,
         F64 mF64
     );
 
@@ -157,6 +172,9 @@ class Default :
 
     //! Set member mS1
     void set_mS1(const Fw::StringBase& mS1);
+
+    //! Set member mS0
+    void set_mS0(const Fw::StringBase& mS0);
 
     //! Set member mF64
     void set_mF64(F64 mF64);
@@ -170,6 +188,8 @@ class Default :
     U32 m_mU32;
     char m___fprime_ac_mS1_buffer[Fw::StringBase::BUFFER_SIZE(40)];
     Fw::ExternalString m_mS1;
+    char m___fprime_ac_mS0_buffer[Fw::StringBase::BUFFER_SIZE(0)];
+    Fw::ExternalString m_mS0;
     F64 m_mF64;
 
 };

--- a/compiler/tools/fpp-to-cpp/test/struct/StringArraySerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/StringArraySerializableAc.ref.cpp
@@ -22,12 +22,19 @@ StringArray ::
     // Set the array value
     this->m_s2[i] = Fw::String("");
   }
+  for (FwSizeType i = 0; i < 16; i++) {
+    // Initialize the external string
+    this->m_s0[i].setBuffer(&m___fprime_ac_s0_buffer[i][0], sizeof m___fprime_ac_s0_buffer[i]);
+    // Set the array value
+    this->m_s0[i] = Fw::String("");
+  }
 }
 
 StringArray ::
   StringArray(
       const Fw::StringBase& s1,
-      const Type_of_s2& s2
+      const Type_of_s2& s2,
+      const Type_of_s0& s0
   ) :
     Serializable(),
     m_s1(m___fprime_ac_s1_buffer, sizeof m___fprime_ac_s1_buffer, s1)
@@ -37,6 +44,12 @@ StringArray ::
     this->m_s2[i].setBuffer(&m___fprime_ac_s2_buffer[i][0], sizeof m___fprime_ac_s2_buffer[i]);
     // Set the array value
     this->m_s2[i] = s2[i];
+  }
+  for (FwSizeType i = 0; i < 16; i++) {
+    // Initialize the external string
+    this->m_s0[i].setBuffer(&m___fprime_ac_s0_buffer[i][0], sizeof m___fprime_ac_s0_buffer[i]);
+    // Set the array value
+    this->m_s0[i] = s0[i];
   }
 }
 
@@ -51,12 +64,19 @@ StringArray ::
     // Set the array value
     this->m_s2[i] = obj.m_s2[i];
   }
+  for (FwSizeType i = 0; i < 16; i++) {
+    // Initialize the external string
+    this->m_s0[i].setBuffer(&m___fprime_ac_s0_buffer[i][0], sizeof m___fprime_ac_s0_buffer[i]);
+    // Set the array value
+    this->m_s0[i] = obj.m_s0[i];
+  }
 }
 
 StringArray ::
   StringArray(
       const Fw::StringBase& s1,
-      const Fw::StringBase& s2
+      const Fw::StringBase& s2,
+      const Fw::StringBase& s0
   ) :
     Serializable(),
     m_s1(m___fprime_ac_s1_buffer, sizeof m___fprime_ac_s1_buffer, s1)
@@ -66,6 +86,12 @@ StringArray ::
     this->m_s2[i].setBuffer(&m___fprime_ac_s2_buffer[i][0], sizeof m___fprime_ac_s2_buffer[i]);
     // Set the array value
     this->m_s2[i] = s2;
+  }
+  for (FwSizeType i = 0; i < 16; i++) {
+    // Initialize the external string
+    this->m_s0[i].setBuffer(&m___fprime_ac_s0_buffer[i][0], sizeof m___fprime_ac_s0_buffer[i]);
+    // Set the array value
+    this->m_s0[i] = s0;
   }
 }
 
@@ -80,7 +106,7 @@ StringArray& StringArray ::
     return *this;
   }
 
-  set(obj.m_s1, obj.m_s2);
+  set(obj.m_s1, obj.m_s2, obj.m_s0);
   return *this;
 }
 
@@ -97,6 +123,11 @@ bool StringArray ::
   // Compare array members
   for (FwSizeType i = 0; i < 16; i++) {
     if (!(this->m_s2[i] == obj.m_s2[i])) {
+      return false;
+    }
+  }
+  for (FwSizeType i = 0; i < 16; i++) {
+    if (!(this->m_s0[i] == obj.m_s0[i])) {
       return false;
     }
   }
@@ -143,6 +174,12 @@ Fw::SerializeStatus StringArray ::
       return status;
     }
   }
+  for (FwSizeType i = 0; i < 16; i++) {
+    status = buffer.serializeFrom(this->m_s0[i], mode);
+    if (status != Fw::FW_SERIALIZE_OK) {
+      return status;
+    }
+  }
 
   return status;
 }
@@ -165,6 +202,12 @@ Fw::SerializeStatus StringArray ::
       return status;
     }
   }
+  for (FwSizeType i = 0; i < 16; i++) {
+    status = buffer.deserializeTo(this->m_s0[i], mode);
+    if (status != Fw::FW_SERIALIZE_OK) {
+      return status;
+    }
+  }
 
   return status;
 }
@@ -176,6 +219,9 @@ FwSizeType StringArray ::
   size += this->m_s1.serializedSize();
   for (U32 index = 0; index < 16; index++) {
     size += this->m_s2[index].serializedSize();
+  }
+  for (U32 index = 0; index < 16; index++) {
+    size += this->m_s0[index].serializedSize();
   }
   return size;
 }
@@ -204,6 +250,19 @@ void StringArray ::
     sb += tmp;
   }
   sb += " ]";
+  sb += ", ";
+
+  // Format s0
+  sb += "s0 = ";
+  sb += "[ ";
+  for (FwSizeType i = 0; i < 16; i++) {
+    tmp = this->m_s0[i];
+    if (i > 0) {
+      sb += ", ";
+    }
+    sb += tmp;
+  }
+  sb += " ]";
   sb += " )";
 }
 
@@ -216,7 +275,8 @@ void StringArray ::
 void StringArray ::
   set(
       const Fw::StringBase& s1,
-      const Type_of_s2& s2
+      const Type_of_s2& s2,
+      const Type_of_s0& s0
   )
 {
   this->m_s1 = s1;
@@ -226,6 +286,12 @@ void StringArray ::
     this->m_s2[i].setBuffer(&m___fprime_ac_s2_buffer[i][0], sizeof m___fprime_ac_s2_buffer[i]);
     // Set the array value
     this->m_s2[i] = s2[i];
+  }
+  for (FwSizeType i = 0; i < 16; i++) {
+    // Initialize the external string
+    this->m_s0[i].setBuffer(&m___fprime_ac_s0_buffer[i][0], sizeof m___fprime_ac_s0_buffer[i]);
+    // Set the array value
+    this->m_s0[i] = s0[i];
   }
 }
 
@@ -240,5 +306,13 @@ void StringArray ::
 {
   for (FwSizeType i = 0; i < 16; i++) {
     this->m_s2[i] = s2[i];
+  }
+}
+
+void StringArray ::
+  set_s0(const Type_of_s0& s0)
+{
+  for (FwSizeType i = 0; i < 16; i++) {
+    this->m_s0[i] = s0[i];
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/struct/StringArraySerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/StringArraySerializableAc.ref.hpp
@@ -26,6 +26,9 @@ class StringArray :
     //! The type of s2
     using Type_of_s2 = Fw::ExternalString[16];
 
+    //! The type of s0
+    using Type_of_s0 = Fw::ExternalString[16];
+
   public:
 
     // ----------------------------------------------------------------------
@@ -36,7 +39,8 @@ class StringArray :
       //! The size of the serial representation
       SERIALIZED_SIZE =
         Fw::StringBase::STATIC_SERIALIZED_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)) +
-        Fw::StringBase::STATIC_SERIALIZED_SIZE(40) * 16
+        Fw::StringBase::STATIC_SERIALIZED_SIZE(40) * 16 +
+        Fw::StringBase::STATIC_SERIALIZED_SIZE(0) * 16
     };
 
   public:
@@ -51,7 +55,8 @@ class StringArray :
     //! Member constructor
     StringArray(
         const Fw::StringBase& s1,
-        const Type_of_s2& s2
+        const Type_of_s2& s2,
+        const Type_of_s0& s0
     );
 
     //! Copy constructor
@@ -62,7 +67,8 @@ class StringArray :
     //! Member constructor (scalar values for arrays)
     StringArray(
         const Fw::StringBase& s1,
-        const Fw::StringBase& s2
+        const Fw::StringBase& s2,
+        const Fw::StringBase& s0
     );
 
   public:
@@ -154,6 +160,18 @@ class StringArray :
       return this->m_s2;
     }
 
+    //! Get member s0
+    Type_of_s0& get_s0()
+    {
+      return this->m_s0;
+    }
+
+    //! Get member s0 (const)
+    const Type_of_s0& get_s0() const
+    {
+      return this->m_s0;
+    }
+
     // ----------------------------------------------------------------------
     // Setter functions
     // ----------------------------------------------------------------------
@@ -161,7 +179,8 @@ class StringArray :
     //! Set all members
     void set(
         const Fw::StringBase& s1,
-        const Type_of_s2& s2
+        const Type_of_s2& s2,
+        const Type_of_s0& s0
     );
 
     //! Set member s1
@@ -169,6 +188,9 @@ class StringArray :
 
     //! Set member s2
     void set_s2(const Type_of_s2& s2);
+
+    //! Set member s0
+    void set_s0(const Type_of_s0& s0);
 
   protected:
 
@@ -180,6 +202,8 @@ class StringArray :
     Fw::ExternalString m_s1;
     char m___fprime_ac_s2_buffer[16][Fw::StringBase::BUFFER_SIZE(40)];
     Fw::ExternalString m_s2[16];
+    char m___fprime_ac_s0_buffer[16][Fw::StringBase::BUFFER_SIZE(0)];
+    Fw::ExternalString m_s0[16];
 
 };
 

--- a/compiler/tools/fpp-to-cpp/test/struct/StringSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/StringSerializableAc.ref.cpp
@@ -15,7 +15,8 @@ String ::
   String() :
     Serializable(),
     m_s1(m___fprime_ac_s1_buffer, sizeof m___fprime_ac_s1_buffer, Fw::String("hello")),
-    m_s2(m___fprime_ac_s2_buffer, sizeof m___fprime_ac_s2_buffer, Fw::String(""))
+    m_s2(m___fprime_ac_s2_buffer, sizeof m___fprime_ac_s2_buffer, Fw::String("")),
+    m_s0(m___fprime_ac_s0_buffer, sizeof m___fprime_ac_s0_buffer, Fw::String(""))
 {
 
 }
@@ -23,11 +24,13 @@ String ::
 String ::
   String(
       const Fw::StringBase& s1,
-      const Fw::StringBase& s2
+      const Fw::StringBase& s2,
+      const Fw::StringBase& s0
   ) :
     Serializable(),
     m_s1(m___fprime_ac_s1_buffer, sizeof m___fprime_ac_s1_buffer, s1),
-    m_s2(m___fprime_ac_s2_buffer, sizeof m___fprime_ac_s2_buffer, s2)
+    m_s2(m___fprime_ac_s2_buffer, sizeof m___fprime_ac_s2_buffer, s2),
+    m_s0(m___fprime_ac_s0_buffer, sizeof m___fprime_ac_s0_buffer, s0)
 {
 
 }
@@ -36,7 +39,8 @@ String ::
   String(const String& obj) :
     Serializable(),
     m_s1(m___fprime_ac_s1_buffer, sizeof m___fprime_ac_s1_buffer, obj.m_s1),
-    m_s2(m___fprime_ac_s2_buffer, sizeof m___fprime_ac_s2_buffer, obj.m_s2)
+    m_s2(m___fprime_ac_s2_buffer, sizeof m___fprime_ac_s2_buffer, obj.m_s2),
+    m_s0(m___fprime_ac_s0_buffer, sizeof m___fprime_ac_s0_buffer, obj.m_s0)
 {
 
 }
@@ -52,7 +56,7 @@ String& String ::
     return *this;
   }
 
-  set(obj.m_s1, obj.m_s2);
+  set(obj.m_s1, obj.m_s2, obj.m_s0);
   return *this;
 }
 
@@ -62,7 +66,8 @@ bool String ::
   if (this == &obj) { return true; }
   return (
     (this->m_s1 == obj.m_s1) &&
-    (this->m_s2 == obj.m_s2)
+    (this->m_s2 == obj.m_s2) &&
+    (this->m_s0 == obj.m_s0)
   );
 }
 
@@ -103,6 +108,10 @@ Fw::SerializeStatus String ::
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
+  status = buffer.serializeFrom(this->m_s0, mode);
+  if (status != Fw::FW_SERIALIZE_OK) {
+    return status;
+  }
 
   return status;
 }
@@ -123,6 +132,10 @@ Fw::SerializeStatus String ::
   if (status != Fw::FW_SERIALIZE_OK) {
     return status;
   }
+  status = buffer.deserializeTo(this->m_s0, mode);
+  if (status != Fw::FW_SERIALIZE_OK) {
+    return status;
+  }
 
   return status;
 }
@@ -133,6 +146,7 @@ FwSizeType String ::
   FwSizeType size = 0;
   size += this->m_s1.serializedSize();
   size += this->m_s2.serializedSize();
+  size += this->m_s0.serializedSize();
   return size;
 }
 
@@ -151,6 +165,11 @@ void String ::
   // Format s2
   sb += "s2 = ";
   sb += this->m_s2;
+  sb += ", ";
+
+  // Format s0
+  sb += "s0 = ";
+  sb += this->m_s0;
   sb += " )";
 }
 
@@ -163,11 +182,13 @@ void String ::
 void String ::
   set(
       const Fw::StringBase& s1,
-      const Fw::StringBase& s2
+      const Fw::StringBase& s2,
+      const Fw::StringBase& s0
   )
 {
   this->m_s1 = s1;
   this->m_s2 = s2;
+  this->m_s0 = s0;
 }
 
 void String ::
@@ -180,4 +201,10 @@ void String ::
   set_s2(const Fw::StringBase& s2)
 {
   this->m_s2 = s2;
+}
+
+void String ::
+  set_s0(const Fw::StringBase& s0)
+{
+  this->m_s0 = s0;
 }

--- a/compiler/tools/fpp-to-cpp/test/struct/StringSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/StringSerializableAc.ref.hpp
@@ -27,7 +27,8 @@ class String :
       //! The size of the serial representation
       SERIALIZED_SIZE =
         Fw::StringBase::STATIC_SERIALIZED_SIZE(static_cast<FwSizeType>(FW_FIXED_LENGTH_STRING_SIZE)) +
-        Fw::StringBase::STATIC_SERIALIZED_SIZE(40)
+        Fw::StringBase::STATIC_SERIALIZED_SIZE(40) +
+        Fw::StringBase::STATIC_SERIALIZED_SIZE(0)
     };
 
   public:
@@ -42,7 +43,8 @@ class String :
     //! Member constructor
     String(
         const Fw::StringBase& s1,
-        const Fw::StringBase& s2
+        const Fw::StringBase& s2,
+        const Fw::StringBase& s0
     );
 
     //! Copy constructor
@@ -139,6 +141,18 @@ class String :
       return this->m_s2;
     }
 
+    //! Get member s0
+    Fw::ExternalString& get_s0()
+    {
+      return this->m_s0;
+    }
+
+    //! Get member s0 (const)
+    const Fw::ExternalString& get_s0() const
+    {
+      return this->m_s0;
+    }
+
     // ----------------------------------------------------------------------
     // Setter functions
     // ----------------------------------------------------------------------
@@ -146,7 +160,8 @@ class String :
     //! Set all members
     void set(
         const Fw::StringBase& s1,
-        const Fw::StringBase& s2
+        const Fw::StringBase& s2,
+        const Fw::StringBase& s0
     );
 
     //! Set member s1
@@ -154,6 +169,9 @@ class String :
 
     //! Set member s2
     void set_s2(const Fw::StringBase& s2);
+
+    //! Set member s0
+    void set_s0(const Fw::StringBase& s0);
 
   protected:
 
@@ -165,6 +183,8 @@ class String :
     Fw::ExternalString m_s1;
     char m___fprime_ac_s2_buffer[Fw::StringBase::BUFFER_SIZE(40)];
     Fw::ExternalString m_s2;
+    char m___fprime_ac_s0_buffer[Fw::StringBase::BUFFER_SIZE(0)];
+    Fw::ExternalString m_s0;
 
 };
 

--- a/compiler/tools/fpp-to-cpp/test/struct/alias_type.fpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/alias_type.fpp
@@ -2,8 +2,10 @@ type U16Alias = U16
 type T
 type TAlias = T
 type SAlias = string size 50
+type SAliasZero = string size 0
 struct AliasType {
     x: U16Alias,
     y: TAlias,
     z: [10] SAlias
+    z0: [10] SAliasZero
 }

--- a/compiler/tools/fpp-to-cpp/test/struct/default.fpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/default.fpp
@@ -1,5 +1,6 @@
 struct Default {
   mU32: U32
   mS1: string size 40
+  mS0: string size 0
   mF64: F64 
 } default { mU32 = 54, mS1 = "hello" }

--- a/compiler/tools/fpp-to-cpp/test/struct/string.fpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/string.fpp
@@ -1,9 +1,11 @@
 struct String {
   s1: string
   s2: string size 40
+  s0: string size 0
 } default {s1 = "hello"}
 
 struct StringArray {
   s1: string
   s2: [16] string size 40
+  s0: [16] string size 0
 }

--- a/docs/fpp-spec.html
+++ b/docs/fpp-spec.html
@@ -9042,7 +9042,7 @@ string size 256</code></pre>
 <p>The optional expression following the keyword <code>size</code> is called the <strong>size
 expression</strong> of the string type name.  If present, it must have a
 <a href="#Types_Internal-Types_Numeric-Types">numeric type</a>, and it must
-evaluate to a value in the range [1,2<sup>31</sup>) after conversion to
+evaluate to a value in the range [0,2<sup>31</sup>) after conversion to
 <a href="#Types_Internal-Types_Integer"><em>Integer</em></a>.</p>
 </div>
 <div class="paragraph">
@@ -11114,7 +11114,8 @@ are called the <strong>primitive types</strong>.</p>
 <p>The <strong>string types</strong> correspond to the
 <a href="#Type-Names_String-Type-Names">string type names</a>.
 A string type is written <code>string</code> or <code>string size</code> <em>n</em>,
-where <em>n</em> is an integer value in the range [1,2^31-1].
+where <em>n</em> is an integer value in the range [0,2^31).
+Note that strings of size zero are allowed.
 There is one string type <code>string</code> and one string type <code>string size</code> <em>n</em>
 for each legal value of <em>n</em>.
 The string type names map to the string types in the following way:</p>
@@ -13229,7 +13230,7 @@ equivalent.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-06-09 11:34:05 -0700
+Last updated 2026-07-30 10:07:32 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-users-guide.html
+++ b/docs/fpp-users-guide.html
@@ -17104,7 +17104,7 @@ serialized according to its
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-06-09 11:34:09 -0700
+Last updated 2026-07-30 10:03:00 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-users-guide.html
+++ b/docs/fpp-users-guide.html
@@ -2330,6 +2330,16 @@ its element type; this situation is discussed further below.</p>
 </ul>
 </div>
 <div class="paragraph">
+<p>The maximum size of a string type is the maximum 32-bit signed integer
+value (2<sup>31</sup> - 1).
+The minimum value is zero.
+String types of size zero can&#8217;t store any string data.
+However, it is occasionally useful to set the size to zero,
+for example, to configure the size of a string that
+is required to exist in a library but will never actually be used in
+a particular application that uses the library.</p>
+</div>
+<div class="paragraph">
 <p>An array type definition may not refer to itself (array type definitions are not
 recursive). For example, this definition is illegal:</p>
 </div>
@@ -17104,7 +17114,7 @@ serialized according to its
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-07-30 10:03:00 -0700
+Last updated 2026-07-30 10:19:08 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.20">
+<meta name="generator" content="Asciidoctor 2.0.26">
 <title>F Prime Prime (FPP)</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
@@ -116,7 +116,6 @@ h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title str
 :not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
 pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
 pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
-pre>code{display:block}
 pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
 em em{font-style:normal}
 strong strong{font-weight:400}
@@ -140,7 +139,7 @@ p a>code:hover{color:rgba(0,0,0,.9)}
 #content::before{content:none}
 #header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
 #header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
-#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
+#header>h1:only-child{border-bottom:1px solid #dddddf;padding-bottom:8px}
 #header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
 #header .details span:first-child{margin-left:-.125em}
 #header .details span.email a{color:rgba(0,0,0,.85)}
@@ -162,6 +161,7 @@ p a>code:hover{color:rgba(0,0,0,.9)}
 #toctitle{color:#7a2518;font-size:1.2em}
 @media screen and (min-width:768px){#toctitle{font-size:1.375em}
 body.toc2{padding-left:15em;padding-right:0}
+body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
 #toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
 #toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
 #toc.toc2>ul{font-size:.9em;margin-bottom:0}
@@ -218,6 +218,7 @@ table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
 .literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class=highlight],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
 .literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
 .listingblock>.content{position:relative}
+.listingblock pre>code{display:block}
 .listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
 .listingblock:hover code[data-lang]::before{display:block}
 .listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
@@ -327,7 +328,7 @@ a.image{text-decoration:none;display:inline-block}
 a.image object{pointer-events:none}
 sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
 sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+sup.footnote a:active,sup.footnoteref a:active,#footnotes .footnote a:first-of-type:active{text-decoration:underline}
 #footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
 #footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
 #footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
@@ -463,7 +464,7 @@ generated code.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2025-02-18 09:43:03 -0800
+Last updated 2026-07-27 11:45:03 -0700
 </div>
 </div>
 </body>

--- a/docs/spec/Type-Names.adoc
+++ b/docs/spec/Type-Names.adoc
@@ -50,7 +50,7 @@ string size 256
 The optional expression following the keyword `size` is called the *size
 expression* of the string type name.  If present, it must have a
 <<Types_Internal-Types_Numeric-Types,numeric type>>, and it must
-evaluate to a value in the range [1,2^31^) after conversion to
+evaluate to a value in the range [0,2^31^) after conversion to
 <<Types_Internal-Types_Integer,_Integer_>>.
 
 At each point in the model where a string type name appears, the following

--- a/docs/spec/Types.adoc
+++ b/docs/spec/Types.adoc
@@ -40,7 +40,8 @@ are called the *primitive types*.
 The *string types* correspond to the
 <<Type-Names_String-Type-Names,string type names>>.
 A string type is written `string` or `string size` _n_,
-where _n_ is an integer value in the range [1,2^31-1].
+where _n_ is an integer value in the range [0,2^31).
+Note that strings of size zero are allowed.
 There is one string type `string` and one string type `string size` _n_
 for each legal value of _n_.
 The string type names map to the string types in the following way:

--- a/docs/users-guide/Defining-Types.adoc
+++ b/docs/users-guide/Defining-Types.adoc
@@ -120,6 +120,15 @@ use the definition `FW_FIXED_LENGTH_STRING_SIZE`.
 In particular, an array definition may have another array definition as
 its element type; this situation is discussed further below.
 
+The maximum size of a string type is the maximum 32-bit signed integer
+value (2^31^ - 1).
+The minimum value is zero.
+String types of size zero can't store any string data.
+However, it is occasionally useful to set the size to zero,
+for example, to configure the size of a string that
+is required to exist in a library but will never actually be used in
+a particular application that uses the library.
+
 An array type definition may not refer to itself (array type definitions are not
 recursive). For example, this definition is illegal:
 


### PR DESCRIPTION
Closes #878.\n\nAccepts string size 0 and adds generated-C++ coverage for zero-capacity strings in aliases, arrays, structs, ports, component types, and defaults.\n\nIntegration coverage: https://github.com/nasa/fprime/pull/5508\n\nValidation:\n- compiler fpp-sbt test (586 tests)\n- fpp-check type suite (12 tests)\n- fpp-to-cpp generator suite\n- fpp-to-cpp generated C++ compilation sweep