### PR TITLE
Refine handling of dependencies and implied uses needed for dictionary generation

### DIFF
--- a/compiler/lib/src/main/scala/analysis/CheckSemantics/ConstructImpliedUseMap.scala
+++ b/compiler/lib/src/main/scala/analysis/CheckSemantics/ConstructImpliedUseMap.scala
@@ -59,25 +59,29 @@ object ConstructImpliedUseMap extends TypeExpressionAnalyzer {
     a: Analysis,
     aNode: Ast.Annotated[AstNode[Ast.DefTopology]]
   ) = {
-    val id = aNode._2.id
-    val typeNames = ImpliedUse.getTopologyTypes(a)
-    val empty: ImpliedUse.Uses = Map()
-    val annotations = List("this implied use occurs when constructing a dictionary")
-    val typeMap = typeNames.foldLeft (empty) ((m, tn) => {
-      val id1 = ImpliedUse.replicateId(id)
-      val impliedUse = ImpliedUse.fromIdentListAndId(tn, id1, annotations)
-      val set = m.get(ImpliedUse.Kind.Type).getOrElse(Set())
-      m + (ImpliedUse.Kind.Type -> (set + impliedUse))
-    })
-    val constants = ImpliedUse.getTopologyConstants(a)
-    val map = constants.foldLeft (typeMap) ((m, c) => {
-      val id1 = ImpliedUse.replicateId(id)
-      val impliedUse = ImpliedUse.fromIdentListAndId(c, id1, annotations)
-      val set = m.get(ImpliedUse.Kind.Constant).getOrElse(Set())
-      m + (ImpliedUse.Kind.Constant -> (set + impliedUse))
-    })
-    val a1 = a.copy(impliedUseMap = a.impliedUseMap + (id -> map))
-    super.defTopologyAnnotatedNode(a1, aNode)
+    if aNode._2.data.isDeployment
+    then
+      val id = aNode._2.id
+      val typeNames = ImpliedUse.getTopologyTypes(a)
+      val empty: ImpliedUse.Uses = Map()
+      val annotations = List("this implied use occurs when constructing a dictionary")
+      val typeMap = typeNames.foldLeft (empty) ((m, tn) => {
+        val id1 = ImpliedUse.replicateId(id)
+        val impliedUse = ImpliedUse.fromIdentListAndId(tn, id1, annotations)
+        val set = m.get(ImpliedUse.Kind.Type).getOrElse(Set())
+        m + (ImpliedUse.Kind.Type -> (set + impliedUse))
+      })
+      val constants = ImpliedUse.getTopologyConstants(a)
+      val map = constants.foldLeft (typeMap) ((m, c) => {
+        val id1 = ImpliedUse.replicateId(id)
+        val impliedUse = ImpliedUse.fromIdentListAndId(c, id1, annotations)
+        val set = m.get(ImpliedUse.Kind.Constant).getOrElse(Set())
+        m + (ImpliedUse.Kind.Constant -> (set + impliedUse))
+      })
+      val a1 = a.copy(impliedUseMap = a.impliedUseMap + (id -> map))
+      super.defTopologyAnnotatedNode(a1, aNode)
+    else
+      Right(a)
   }
 
   override def typeNameStringNode(

--- a/compiler/lib/src/main/scala/analysis/ComputeDependencies/AddDependencies.scala
+++ b/compiler/lib/src/main/scala/analysis/ComputeDependencies/AddDependencies.scala
@@ -32,9 +32,9 @@ object AddDependencies extends BasicUseAnalyzer {
       // Add dependencies based on explicit and implicit uses in the topology
       a <- super.defTopologyAnnotatedNode(a, node)
       // Add dependencies based on dictionary specifiers
-      a <- if !a.includeDictionaryDeps
+      a <- if node._2.data.isDeployment && !a.includeDictionaryDeps
            then
-             // This is the first topology we have visited.
+             // This is the first deployment topology we have visited.
              // Set includeDictionaryDeps = true and add all dictionary dependencies
              // discovered so far.
              val a1 = a.copy(includeDictionaryDeps = true)
@@ -44,7 +44,8 @@ object AddDependencies extends BasicUseAnalyzer {
                case (a, s) => addDependencies (a) (s)
              }
            else
-             // This is the second or later topology; nothing to do
+             // This is the second or later deployment topology, or a
+             // non-deployment topology; nothing to do
              Right(a)
     } yield a
   }

--- a/compiler/tools/fpp-depend/test/def_alias.fpp
+++ b/compiler/tools/fpp-depend/test/def_alias.fpp
@@ -8,4 +8,4 @@ type A1 = T
 type A2 = C.T
 type A3 = T2
 
-topology T {}
+deployment topology T {}

--- a/compiler/tools/fpp-depend/test/dictionary.fpp
+++ b/compiler/tools/fpp-depend/test/dictionary.fpp
@@ -1,7 +1,7 @@
-# Topology in model: there should be dictionary
+# Deployment topology in model: there should be dictionary
 # dependencies
 
 locate dictionary constant c at "dictionary_c.fpp"
 locate dictionary type T1 at "dictionary_T1.fpp"
 
-topology T {}
+deployment topology T {}

--- a/compiler/tools/fpp-depend/test/dictionary_no_deployment_top.fpp
+++ b/compiler/tools/fpp-depend/test/dictionary_no_deployment_top.fpp
@@ -1,5 +1,8 @@
-# No topology in model, so there should be no dictionary
+# No deployment topology in model, so there should be no dictionary
 # dependencies
 
 locate dictionary constant c at "dictionary_c.fpp"
 locate dictionary type T1 at "dictionary_T1.fpp"
+
+# Not a deployment topology
+topology T { }

--- a/compiler/tools/fpp-depend/test/tests.sh
+++ b/compiler/tools/fpp-depend/test/tests.sh
@@ -10,7 +10,7 @@ def_state_machine
 def_struct
 def_system
 dictionary
-dictionary_no_top
+dictionary_no_deployment_top
 direct
 enum_constant
 expr_array

--- a/compiler/tools/fpp-depend/test/topology_implied_type.fpp
+++ b/compiler/tools/fpp-depend/test/topology_implied_type.fpp
@@ -1,2 +1,2 @@
 locate type FwChanIdType at "config.fpp"
-topology T {}
+deployment topology T {}

--- a/docs/fpp-spec.html
+++ b/docs/fpp-spec.html
@@ -4480,8 +4480,8 @@ then \$c_1\$ is less than (respectively greater than) \$c_2\$.</p>
 <div class="sect3">
 <h4 id="Definitions_Topology-Definitions_Implied-Uses">5.15.5. Implied Uses</h4>
 <div class="paragraph">
-<p>When generating a dictionary from a topology <em>T</em>, the analyzer
-treats the definition of <em>T</em> as if it contained
+<p>When generating a dictionary from a deployment topology <em>T</em>,
+the analyzer treats the definition of <em>T</em> as if it contained
 <a href="#Definitions-and-Uses_Implied-Uses">implied uses</a> of
 several <a href="#Definitions_Framework-Definitions">framework definitions</a> required by the dictionary.
 Those framework definitions are specified
@@ -13309,7 +13309,7 @@ equivalent.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-08-12 20:52:50 -0700
+Last updated 2026-08-13 13:22:11 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-users-guide.html
+++ b/docs/fpp-users-guide.html
@@ -13821,7 +13821,7 @@ locate dictionary constant b at "b.fpp"</code></pre>
 <div class="paragraph">
 <p>The <code>dictionary</code> keyword tells the analyzer that the definition is a dictionary
 definition.
-This fact is important when the model includes a topology definition.
+This fact is important when the model defines a deployment topology.
 In this case, the analyzer includes all dictionary definitions as
 dependencies of the model.
 That way the definitions are available
@@ -17353,7 +17353,7 @@ serialized according to its
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-08-12 20:53:33 -0700
+Last updated 2026-08-13 13:24:04 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/spec/Definitions/Topology-Definitions.adoc
+++ b/docs/spec/Definitions/Topology-Definitions.adoc
@@ -444,8 +444,8 @@ stem:[c_2].
 
 ==== Implied Uses
 
-When generating a dictionary from a topology _T_, the analyzer
-treats the definition of _T_ as if it contained 
+When generating a dictionary from a deployment topology _T_,
+the analyzer treats the definition of _T_ as if it contained 
 <<Definitions-and-Uses_Implied-Uses, implied uses>> of
 several <<Definitions_Framework-Definitions,
 framework definitions>> required by the dictionary.

--- a/docs/users-guide/Specifying-Models-as-Files.adoc
+++ b/docs/users-guide/Specifying-Models-as-Files.adoc
@@ -467,7 +467,7 @@ locate dictionary constant b at "b.fpp"
 
 The `dictionary` keyword tells the analyzer that the definition is a dictionary
 definition.
-This fact is important when the model includes a topology definition.
+This fact is important when the model defines a deployment topology.
 In this case, the analyzer includes all dictionary definitions as
 dependencies of the model.
 That way the definitions are available


### PR DESCRIPTION
This PR refines the handling of the dependencies and implied uses needed for dictionary generation. Now these dependencies and implied uses are recorded only for deployment topologies. These are the only topologies that cause dictionaries to be generated.