### PR TITLE
Update version stamp to v3.3.0

### DIFF
--- a/docs/fpp-spec.html
+++ b/docs/fpp-spec.html
@@ -5,7 +5,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="Asciidoctor 2.0.26">
-<title>The F Prime Prime (FPP) Language Specification, Unreleased, after v3.2.0</title>
+<title>The F Prime Prime (FPP) Language Specification, v3.3.0</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
 /*! Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
@@ -437,7 +437,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </head>
 <body class="article toc2 toc-left">
 <div id="header">
-<h1>The F Prime Prime (FPP) Language Specification, Unreleased, after v3.2.0</h1>
+<h1>The F Prime Prime (FPP) Language Specification, v3.3.0</h1>
 <div id="toc" class="toc2">
 <div id="toctitle">Table of Contents</div>
 <ul class="sectlevel1">
@@ -13309,7 +13309,7 @@ equivalent.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-08-13 13:22:11 -0700
+Last updated 2026-08-19 10:10:16 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-users-guide.html
+++ b/docs/fpp-users-guide.html
@@ -5,7 +5,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="Asciidoctor 2.0.26">
-<title>The F Prime Prime (FPP) User&#8217;s Guide, Unreleased, after v3.2.0</title>
+<title>The F Prime Prime (FPP) User&#8217;s Guide, v3.3.0</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
 /*! Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
@@ -437,7 +437,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </head>
 <body class="article toc2 toc-left">
 <div id="header">
-<h1>The F Prime Prime (FPP) User&#8217;s Guide, Unreleased, after v3.2.0</h1>
+<h1>The F Prime Prime (FPP) User&#8217;s Guide, v3.3.0</h1>
 <div id="toc" class="toc2">
 <div id="toctitle">Table of Contents</div>
 <ul class="sectlevel1">
@@ -17353,7 +17353,7 @@ serialized according to its
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-08-13 13:24:04 -0700
+Last updated 2026-08-19 10:11:01 -0700
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/version.sh
+++ b/version.sh
@@ -2,4 +2,4 @@
 # The FPP version
 # ----------------------------------------------------------------------
 
-export VERSION="Unreleased, after v3.2.0"
+export VERSION="v3.3.0"


### PR DESCRIPTION
I already created the v3.3.0 release against the release branch, so the version stamp won't be on the tag of the release. That was an oversight. However, this PR will put the v3.3.0 stamp on the docs that are visible from the wiki.