### PR TITLE
Pin published wheel version to the release tag via SETUPTOOLS_SCM_PRETEND_VERSION

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -191,6 +191,10 @@ jobs:
           name: build-jar
           path:  ${{ inputs.output-directory }}
       - name: "Run Builder"
+        env:
+          # Pin the version to the release tag; `git describe` may pick an older
+          # tag on the same commit. Empty (non-release) values are ignored.
+          SETUPTOOLS_SCM_PRETEND_VERSION: ${{ github.event.release.tag_name }}
         run: |
           pip install build
           cp -vr ${{ inputs.output-directory }}/*.jar python/fprime_fpp/


### PR DESCRIPTION
This PR solves the issue where publishing the same release with two tags may pick the wrong PIP version for our python packages. This solves it by supplying an explicit version keyed to the release supplied by the CI system.