### PR TITLE
Generate parameterUpdated calls in parametersLoaded

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriter.scala
@@ -144,12 +144,13 @@ case class ComponentCppWriter (
   }
 
   private def getCppIncludes: CppDoc.Member = {
-    val userHeaders = List(
+    val prmValidHeader = if hasParameters then List("Fw/Prm/ParamValid.hpp") else Nil
+    val userHeaders = (List(
       "Fw/Types/Assert.hpp",
       "Fw/Types/ExternalString.hpp",
       "Fw/Types/String.hpp",
       s.getIncludePath(componentSymbol, fileName)
-    ).sorted.map(CppWriter.headerString).flatMap({
+    ) ++ prmValidHeader).sorted.map(CppWriter.headerString).flatMap({
       case s: "#include \"Fw/Types/String.hpp\"" =>
         lines(
           s"""|#if FW_ENABLE_TEXT_LOGGING

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriter.scala
@@ -144,13 +144,15 @@ case class ComponentCppWriter (
   }
 
   private def getCppIncludes: CppDoc.Member = {
-    val prmValidHeader = if hasParameters then List("Fw/Prm/ParamValid.hpp") else Nil
-    val userHeaders = (List(
-      "Fw/Types/Assert.hpp",
-      "Fw/Types/ExternalString.hpp",
-      "Fw/Types/String.hpp",
-      s.getIncludePath(componentSymbol, fileName)
-    ) ++ prmValidHeader).sorted.map(CppWriter.headerString).flatMap({
+    val userHeaders = List.concat(
+      guardedList (hasParameters) (List("Fw/Prm/ParamValid.hpp")),
+      List(
+        "Fw/Types/Assert.hpp",
+        "Fw/Types/ExternalString.hpp",
+        "Fw/Types/String.hpp",
+        s.getIncludePath(componentSymbol, fileName)
+      )
+    ).sorted.map(CppWriter.headerString).flatMap({
       case s: "#include \"Fw/Types/String.hpp\"" =>
         lines(
           s"""|#if FW_ENABLE_TEXT_LOGGING

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentParameters.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentParameters.scala
@@ -225,13 +225,18 @@ case class ComponentParameters (
     Some(
       s"""|\\brief Called whenever parameters are loaded
           |
-          |This function does nothing by default. You may override it.
+          |By default this notifies the component of each parameter via
+          |parameterUpdated. You may override it, for example to suppress
+          |notification on load.
           |"""
     ),
     "parametersLoaded",
     Nil,
     CppDoc.Type("void"),
-    lines("// Do nothing by default"),
+    if sortedParams.isEmpty then lines("// No parameters")
+    else sortedParams.flatMap((_, param) =>
+      lines(s"this->parameterUpdated(${paramIdConstantName(param.getName)});")
+    ),
     CppDoc.Function.Virtual
   )
 

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentParameters.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentParameters.scala
@@ -131,7 +131,7 @@ case class ComponentParameters (
       List(
         getParamUpdateHookFunction,
         getParamLoadHookFunction,
-        getParamLoadedHookFunction
+        getParamsLoadHookFunction
       )
     )
   }
@@ -238,7 +238,7 @@ case class ComponentParameters (
     CppDoc.Function.Virtual
   )
 
-  private def getParamLoadedHookFunction = functionClassMember(
+  private def getParamsLoadHookFunction = functionClassMember(
     Some(
       s"""|\\brief Called for each parameter when parameters are loaded
           |

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentParameters.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentParameters.scala
@@ -233,9 +233,11 @@ case class ComponentParameters (
     "parametersLoaded",
     Nil,
     CppDoc.Type("void"),
-    if sortedParams.isEmpty then lines("// No parameters")
-    else sortedParams.flatMap((_, param) =>
-      lines(s"this->parameterUpdated(${paramIdConstantName(param.getName)});")
+    sortedParams.flatMap((_, param) =>
+      wrapInIf(
+        checkValidityFlag(param, "VALID"),
+        lines(s"this->parameterUpdated(${paramIdConstantName(param.getName)});")
+      )
     ),
     CppDoc.Function.Virtual
   )

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentParameters.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentParameters.scala
@@ -130,7 +130,8 @@ case class ComponentParameters (
       "Parameter hook functions",
       List(
         getParamUpdateHookFunction,
-        getParamLoadHookFunction
+        getParamLoadHookFunction,
+        getParamLoadedHookFunction
       )
     )
   }
@@ -233,11 +234,36 @@ case class ComponentParameters (
     "parametersLoaded",
     Nil,
     CppDoc.Type("void"),
-    sortedParams.flatMap((_, param) =>
-      wrapInIf(
-        checkValidityFlag(param, "VALID"),
-        lines(s"this->parameterUpdated(${paramIdConstantName(param.getName)});")
+    lines("// Do nothing by default"),
+    CppDoc.Function.Virtual
+  )
+
+  private def getParamLoadedHookFunction = functionClassMember(
+    Some(
+      s"""|\\brief Called for each parameter when parameters are loaded
+          |
+          |By default this notifies the component via parameterUpdated when
+          |the parameter loaded successfully (valid or default). You may
+          |override it, for example to distinguish load from update.
+          |"""
+    ),
+    "parameterLoaded",
+    List(
+      CppDoc.Function.Param(
+        CppDoc.Type("FwPrmIdType"),
+        "id",
+        Some("The parameter ID")
+      ),
+      CppDoc.Function.Param(
+        CppDoc.Type("Fw::ParamValid"),
+        "valid",
+        Some("The parameter validity status")
       )
+    ),
+    CppDoc.Type("void"),
+    wrapInIf(
+      "FW_PARAM_OK(valid)",
+      lines("this->parameterUpdated(id);")
     ),
     CppDoc.Function.Virtual
   )
@@ -455,6 +481,9 @@ case class ComponentParameters (
       lines(
         """|
            |this->m_paramLock.unlock();"""
+      ),
+      lines(
+        s"this->parameterLoaded(${paramIdConstantName(param.getName)}, this->${paramValidityFlagName(param.getName)});"
       )
     )
   }

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveExternalParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveExternalParamsComponentAc.ref.cpp
@@ -3492,7 +3492,12 @@ void ActiveExternalParamsComponentBase ::
 void ActiveExternalParamsComponentBase ::
   parametersLoaded()
 {
-  // Do nothing by default
+  this->parameterUpdated(PARAMID_PARAMI32EXT);
+  this->parameterUpdated(PARAMID_PARAMF64EXT);
+  this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
+  this->parameterUpdated(PARAMID_PARAMENUMEXT);
+  this->parameterUpdated(PARAMID_PARAMARRAYEXT);
+  this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
 }
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveExternalParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveExternalParamsComponentAc.ref.cpp
@@ -3492,12 +3492,24 @@ void ActiveExternalParamsComponentBase ::
 void ActiveExternalParamsComponentBase ::
   parametersLoaded()
 {
-  this->parameterUpdated(PARAMID_PARAMI32EXT);
-  this->parameterUpdated(PARAMID_PARAMF64EXT);
-  this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
-  this->parameterUpdated(PARAMID_PARAMENUMEXT);
-  this->parameterUpdated(PARAMID_PARAMARRAYEXT);
-  this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+  if (this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMI32EXT);
+  }
+  if (this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMF64EXT);
+  }
+  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
+  }
+  if (this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMENUMEXT);
+  }
+  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMARRAYEXT);
+  }
+  if (this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+  }
 }
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveExternalParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveExternalParamsComponentAc.ref.cpp
@@ -5,6 +5,7 @@
 // ======================================================================
 
 #include "ActiveExternalParamsComponentAc.hpp"
+#include "Fw/Prm/ParamValid.hpp"
 #include "Fw/Types/Assert.hpp"
 #include "Fw/Types/ExternalString.hpp"
 #if FW_ENABLE_TEXT_LOGGING
@@ -1689,6 +1690,7 @@ void ActiveExternalParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMI32EXT, this->m_param_ParamI32Ext_valid);
 
   _id = _baseId + PARAMID_PARAMF64EXT;
 
@@ -1714,6 +1716,7 @@ void ActiveExternalParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMF64EXT, this->m_param_ParamF64Ext_valid);
 
   _id = _baseId + PARAMID_PARAMSTRINGEXT;
 
@@ -1760,6 +1763,7 @@ void ActiveExternalParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMSTRINGEXT, this->m_param_ParamStringExt_valid);
 
   _id = _baseId + PARAMID_PARAMENUMEXT;
 
@@ -1785,6 +1789,7 @@ void ActiveExternalParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMENUMEXT, this->m_param_ParamEnumExt_valid);
 
   _id = _baseId + PARAMID_PARAMARRAYEXT;
 
@@ -1831,6 +1836,7 @@ void ActiveExternalParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMARRAYEXT, this->m_param_ParamArrayExt_valid);
 
   _id = _baseId + PARAMID_PARAMSTRUCTEXT;
 
@@ -1856,6 +1862,7 @@ void ActiveExternalParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMSTRUCTEXT, this->m_param_ParamStructExt_valid);
 
   // Call notifier
   this->parametersLoaded();
@@ -3492,23 +3499,17 @@ void ActiveExternalParamsComponentBase ::
 void ActiveExternalParamsComponentBase ::
   parametersLoaded()
 {
-  if (this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMI32EXT);
-  }
-  if (this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMF64EXT);
-  }
-  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
-  }
-  if (this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMENUMEXT);
-  }
-  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMARRAYEXT);
-  }
-  if (this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+  // Do nothing by default
+}
+
+void ActiveExternalParamsComponentBase ::
+  parameterLoaded(
+      FwPrmIdType id,
+      Fw::ParamValid valid
+  )
+{
+  if (FW_PARAM_OK(valid)) {
+    this->parameterUpdated(id);
   }
 }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveExternalParamsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveExternalParamsComponentAc.ref.hpp
@@ -1544,7 +1544,9 @@ class ActiveExternalParamsComponentBase :
 
     //! \brief Called whenever parameters are loaded
     //!
-    //! This function does nothing by default. You may override it.
+    //! By default this notifies the component of each parameter via
+    //! parameterUpdated. You may override it, for example to suppress
+    //! notification on load.
     virtual void parametersLoaded();
 
   protected:

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveExternalParamsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveExternalParamsComponentAc.ref.hpp
@@ -1549,6 +1549,16 @@ class ActiveExternalParamsComponentBase :
     //! notification on load.
     virtual void parametersLoaded();
 
+    //! \brief Called for each parameter when parameters are loaded
+    //!
+    //! By default this notifies the component via parameterUpdated when
+    //! the parameter loaded successfully (valid or default). You may
+    //! override it, for example to distinguish load from update.
+    virtual void parameterLoaded(
+        FwPrmIdType id, //!< The parameter ID
+        Fw::ParamValid valid //!< The parameter validity status
+    );
+
   protected:
 
     // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.cpp
@@ -3438,7 +3438,12 @@ void ActiveParamsComponentBase ::
 void ActiveParamsComponentBase ::
   parametersLoaded()
 {
-  // Do nothing by default
+  this->parameterUpdated(PARAMID_PARAMU32);
+  this->parameterUpdated(PARAMID_PARAMF64);
+  this->parameterUpdated(PARAMID_PARAMSTRING);
+  this->parameterUpdated(PARAMID_PARAMENUM);
+  this->parameterUpdated(PARAMID_PARAMARRAY);
+  this->parameterUpdated(PARAMID_PARAMSTRUCT);
 }
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.cpp
@@ -5,6 +5,7 @@
 // ======================================================================
 
 #include "ActiveParamsComponentAc.hpp"
+#include "Fw/Prm/ParamValid.hpp"
 #include "Fw/Types/Assert.hpp"
 #include "Fw/Types/ExternalString.hpp"
 #if FW_ENABLE_TEXT_LOGGING
@@ -1685,6 +1686,7 @@ void ActiveParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMU32, this->m_param_ParamU32_valid);
 
   _id = _baseId + PARAMID_PARAMF64;
 
@@ -1706,6 +1708,7 @@ void ActiveParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMF64, this->m_param_ParamF64_valid);
 
   _id = _baseId + PARAMID_PARAMSTRING;
 
@@ -1733,6 +1736,7 @@ void ActiveParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMSTRING, this->m_param_ParamString_valid);
 
   _id = _baseId + PARAMID_PARAMENUM;
 
@@ -1754,6 +1758,7 @@ void ActiveParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMENUM, this->m_param_ParamEnum_valid);
 
   _id = _baseId + PARAMID_PARAMARRAY;
 
@@ -1781,6 +1786,7 @@ void ActiveParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMARRAY, this->m_param_ParamArray_valid);
 
   _id = _baseId + PARAMID_PARAMSTRUCT;
 
@@ -1802,6 +1808,7 @@ void ActiveParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMSTRUCT, this->m_param_ParamStruct_valid);
 
   // Call notifier
   this->parametersLoaded();
@@ -3438,23 +3445,17 @@ void ActiveParamsComponentBase ::
 void ActiveParamsComponentBase ::
   parametersLoaded()
 {
-  if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMU32);
-  }
-  if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMF64);
-  }
-  if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMSTRING);
-  }
-  if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMENUM);
-  }
-  if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMARRAY);
-  }
-  if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMSTRUCT);
+  // Do nothing by default
+}
+
+void ActiveParamsComponentBase ::
+  parameterLoaded(
+      FwPrmIdType id,
+      Fw::ParamValid valid
+  )
+{
+  if (FW_PARAM_OK(valid)) {
+    this->parameterUpdated(id);
   }
 }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.cpp
@@ -3438,12 +3438,24 @@ void ActiveParamsComponentBase ::
 void ActiveParamsComponentBase ::
   parametersLoaded()
 {
-  this->parameterUpdated(PARAMID_PARAMU32);
-  this->parameterUpdated(PARAMID_PARAMF64);
-  this->parameterUpdated(PARAMID_PARAMSTRING);
-  this->parameterUpdated(PARAMID_PARAMENUM);
-  this->parameterUpdated(PARAMID_PARAMARRAY);
-  this->parameterUpdated(PARAMID_PARAMSTRUCT);
+  if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMU32);
+  }
+  if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMF64);
+  }
+  if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMSTRING);
+  }
+  if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMENUM);
+  }
+  if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMARRAY);
+  }
+  if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMSTRUCT);
+  }
 }
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.hpp
@@ -1543,7 +1543,9 @@ class ActiveParamsComponentBase :
 
     //! \brief Called whenever parameters are loaded
     //!
-    //! This function does nothing by default. You may override it.
+    //! By default this notifies the component of each parameter via
+    //! parameterUpdated. You may override it, for example to suppress
+    //! notification on load.
     virtual void parametersLoaded();
 
   protected:

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.hpp
@@ -1548,6 +1548,16 @@ class ActiveParamsComponentBase :
     //! notification on load.
     virtual void parametersLoaded();
 
+    //! \brief Called for each parameter when parameters are loaded
+    //!
+    //! By default this notifies the component via parameterUpdated when
+    //! the parameter loaded successfully (valid or default). You may
+    //! override it, for example to distinguish load from update.
+    virtual void parameterLoaded(
+        FwPrmIdType id, //!< The parameter ID
+        Fw::ParamValid valid //!< The parameter validity status
+    );
+
   protected:
 
     // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
@@ -7117,7 +7117,18 @@ void ActiveSerialComponentBase ::
 void ActiveSerialComponentBase ::
   parametersLoaded()
 {
-  // Do nothing by default
+  this->parameterUpdated(PARAMID_PARAMU32);
+  this->parameterUpdated(PARAMID_PARAMF64);
+  this->parameterUpdated(PARAMID_PARAMSTRING);
+  this->parameterUpdated(PARAMID_PARAMENUM);
+  this->parameterUpdated(PARAMID_PARAMARRAY);
+  this->parameterUpdated(PARAMID_PARAMSTRUCT);
+  this->parameterUpdated(PARAMID_PARAMI32EXT);
+  this->parameterUpdated(PARAMID_PARAMF64EXT);
+  this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
+  this->parameterUpdated(PARAMID_PARAMENUMEXT);
+  this->parameterUpdated(PARAMID_PARAMARRAYEXT);
+  this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
 }
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
@@ -7117,18 +7117,42 @@ void ActiveSerialComponentBase ::
 void ActiveSerialComponentBase ::
   parametersLoaded()
 {
-  this->parameterUpdated(PARAMID_PARAMU32);
-  this->parameterUpdated(PARAMID_PARAMF64);
-  this->parameterUpdated(PARAMID_PARAMSTRING);
-  this->parameterUpdated(PARAMID_PARAMENUM);
-  this->parameterUpdated(PARAMID_PARAMARRAY);
-  this->parameterUpdated(PARAMID_PARAMSTRUCT);
-  this->parameterUpdated(PARAMID_PARAMI32EXT);
-  this->parameterUpdated(PARAMID_PARAMF64EXT);
-  this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
-  this->parameterUpdated(PARAMID_PARAMENUMEXT);
-  this->parameterUpdated(PARAMID_PARAMARRAYEXT);
-  this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+  if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMU32);
+  }
+  if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMF64);
+  }
+  if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMSTRING);
+  }
+  if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMENUM);
+  }
+  if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMARRAY);
+  }
+  if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMSTRUCT);
+  }
+  if (this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMI32EXT);
+  }
+  if (this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMF64EXT);
+  }
+  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
+  }
+  if (this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMENUMEXT);
+  }
+  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMARRAYEXT);
+  }
+  if (this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+  }
 }
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
@@ -5,6 +5,7 @@
 // ======================================================================
 
 #include "ActiveSerialComponentAc.hpp"
+#include "Fw/Prm/ParamValid.hpp"
 #include "Fw/Types/Assert.hpp"
 #include "Fw/Types/ExternalString.hpp"
 #if FW_ENABLE_TEXT_LOGGING
@@ -2147,6 +2148,7 @@ void ActiveSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMU32, this->m_param_ParamU32_valid);
 
   _id = _baseId + PARAMID_PARAMF64;
 
@@ -2168,6 +2170,7 @@ void ActiveSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMF64, this->m_param_ParamF64_valid);
 
   _id = _baseId + PARAMID_PARAMSTRING;
 
@@ -2195,6 +2198,7 @@ void ActiveSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMSTRING, this->m_param_ParamString_valid);
 
   _id = _baseId + PARAMID_PARAMENUM;
 
@@ -2216,6 +2220,7 @@ void ActiveSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMENUM, this->m_param_ParamEnum_valid);
 
   _id = _baseId + PARAMID_PARAMARRAY;
 
@@ -2243,6 +2248,7 @@ void ActiveSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMARRAY, this->m_param_ParamArray_valid);
 
   _id = _baseId + PARAMID_PARAMSTRUCT;
 
@@ -2264,6 +2270,7 @@ void ActiveSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMSTRUCT, this->m_param_ParamStruct_valid);
 
   _id = _baseId + PARAMID_PARAMI32EXT;
 
@@ -2289,6 +2296,7 @@ void ActiveSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMI32EXT, this->m_param_ParamI32Ext_valid);
 
   _id = _baseId + PARAMID_PARAMF64EXT;
 
@@ -2314,6 +2322,7 @@ void ActiveSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMF64EXT, this->m_param_ParamF64Ext_valid);
 
   _id = _baseId + PARAMID_PARAMSTRINGEXT;
 
@@ -2360,6 +2369,7 @@ void ActiveSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMSTRINGEXT, this->m_param_ParamStringExt_valid);
 
   _id = _baseId + PARAMID_PARAMENUMEXT;
 
@@ -2385,6 +2395,7 @@ void ActiveSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMENUMEXT, this->m_param_ParamEnumExt_valid);
 
   _id = _baseId + PARAMID_PARAMARRAYEXT;
 
@@ -2431,6 +2442,7 @@ void ActiveSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMARRAYEXT, this->m_param_ParamArrayExt_valid);
 
   _id = _baseId + PARAMID_PARAMSTRUCTEXT;
 
@@ -2456,6 +2468,7 @@ void ActiveSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMSTRUCTEXT, this->m_param_ParamStructExt_valid);
 
   // Call notifier
   this->parametersLoaded();
@@ -7117,41 +7130,17 @@ void ActiveSerialComponentBase ::
 void ActiveSerialComponentBase ::
   parametersLoaded()
 {
-  if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMU32);
-  }
-  if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMF64);
-  }
-  if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMSTRING);
-  }
-  if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMENUM);
-  }
-  if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMARRAY);
-  }
-  if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMSTRUCT);
-  }
-  if (this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMI32EXT);
-  }
-  if (this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMF64EXT);
-  }
-  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
-  }
-  if (this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMENUMEXT);
-  }
-  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMARRAYEXT);
-  }
-  if (this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+  // Do nothing by default
+}
+
+void ActiveSerialComponentBase ::
+  parameterLoaded(
+      FwPrmIdType id,
+      Fw::ParamValid valid
+  )
+{
+  if (FW_PARAM_OK(valid)) {
+    this->parameterUpdated(id);
   }
 }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.hpp
@@ -2550,7 +2550,9 @@ class ActiveSerialComponentBase :
 
     //! \brief Called whenever parameters are loaded
     //!
-    //! This function does nothing by default. You may override it.
+    //! By default this notifies the component of each parameter via
+    //! parameterUpdated. You may override it, for example to suppress
+    //! notification on load.
     virtual void parametersLoaded();
 
   protected:

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.hpp
@@ -2555,6 +2555,16 @@ class ActiveSerialComponentBase :
     //! notification on load.
     virtual void parametersLoaded();
 
+    //! \brief Called for each parameter when parameters are loaded
+    //!
+    //! By default this notifies the component via parameterUpdated when
+    //! the parameter loaded successfully (valid or default). You may
+    //! override it, for example to distinguish load from update.
+    virtual void parameterLoaded(
+        FwPrmIdType id, //!< The parameter ID
+        Fw::ParamValid valid //!< The parameter validity status
+    );
+
   protected:
 
     // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
@@ -6949,7 +6949,18 @@ namespace M {
   void ActiveTestComponentBase ::
     parametersLoaded()
   {
-    // Do nothing by default
+    this->parameterUpdated(PARAMID_PARAMU32);
+    this->parameterUpdated(PARAMID_PARAMF64);
+    this->parameterUpdated(PARAMID_PARAMSTRING);
+    this->parameterUpdated(PARAMID_PARAMENUM);
+    this->parameterUpdated(PARAMID_PARAMARRAY);
+    this->parameterUpdated(PARAMID_PARAMSTRUCT);
+    this->parameterUpdated(PARAMID_PARAMI32EXT);
+    this->parameterUpdated(PARAMID_PARAMF64EXT);
+    this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
+    this->parameterUpdated(PARAMID_PARAMENUMEXT);
+    this->parameterUpdated(PARAMID_PARAMARRAYEXT);
+    this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
   }
 
   // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
@@ -6949,18 +6949,42 @@ namespace M {
   void ActiveTestComponentBase ::
     parametersLoaded()
   {
-    this->parameterUpdated(PARAMID_PARAMU32);
-    this->parameterUpdated(PARAMID_PARAMF64);
-    this->parameterUpdated(PARAMID_PARAMSTRING);
-    this->parameterUpdated(PARAMID_PARAMENUM);
-    this->parameterUpdated(PARAMID_PARAMARRAY);
-    this->parameterUpdated(PARAMID_PARAMSTRUCT);
-    this->parameterUpdated(PARAMID_PARAMI32EXT);
-    this->parameterUpdated(PARAMID_PARAMF64EXT);
-    this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
-    this->parameterUpdated(PARAMID_PARAMENUMEXT);
-    this->parameterUpdated(PARAMID_PARAMARRAYEXT);
-    this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+    if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
+      this->parameterUpdated(PARAMID_PARAMU32);
+    }
+    if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
+      this->parameterUpdated(PARAMID_PARAMF64);
+    }
+    if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
+      this->parameterUpdated(PARAMID_PARAMSTRING);
+    }
+    if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
+      this->parameterUpdated(PARAMID_PARAMENUM);
+    }
+    if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
+      this->parameterUpdated(PARAMID_PARAMARRAY);
+    }
+    if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
+      this->parameterUpdated(PARAMID_PARAMSTRUCT);
+    }
+    if (this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) {
+      this->parameterUpdated(PARAMID_PARAMI32EXT);
+    }
+    if (this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) {
+      this->parameterUpdated(PARAMID_PARAMF64EXT);
+    }
+    if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
+      this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
+    }
+    if (this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) {
+      this->parameterUpdated(PARAMID_PARAMENUMEXT);
+    }
+    if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
+      this->parameterUpdated(PARAMID_PARAMARRAYEXT);
+    }
+    if (this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) {
+      this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+    }
   }
 
   // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
@@ -5,6 +5,7 @@
 // ======================================================================
 
 #include "ActiveTestComponentAc.hpp"
+#include "Fw/Prm/ParamValid.hpp"
 #include "Fw/Types/Assert.hpp"
 #include "Fw/Types/ExternalString.hpp"
 #if FW_ENABLE_TEXT_LOGGING
@@ -2225,6 +2226,7 @@ namespace M {
     }
 
     this->m_paramLock.unlock();
+    this->parameterLoaded(PARAMID_PARAMU32, this->m_param_ParamU32_valid);
 
     _id = _baseId + PARAMID_PARAMF64;
 
@@ -2246,6 +2248,7 @@ namespace M {
     }
 
     this->m_paramLock.unlock();
+    this->parameterLoaded(PARAMID_PARAMF64, this->m_param_ParamF64_valid);
 
     _id = _baseId + PARAMID_PARAMSTRING;
 
@@ -2273,6 +2276,7 @@ namespace M {
     }
 
     this->m_paramLock.unlock();
+    this->parameterLoaded(PARAMID_PARAMSTRING, this->m_param_ParamString_valid);
 
     _id = _baseId + PARAMID_PARAMENUM;
 
@@ -2294,6 +2298,7 @@ namespace M {
     }
 
     this->m_paramLock.unlock();
+    this->parameterLoaded(PARAMID_PARAMENUM, this->m_param_ParamEnum_valid);
 
     _id = _baseId + PARAMID_PARAMARRAY;
 
@@ -2321,6 +2326,7 @@ namespace M {
     }
 
     this->m_paramLock.unlock();
+    this->parameterLoaded(PARAMID_PARAMARRAY, this->m_param_ParamArray_valid);
 
     _id = _baseId + PARAMID_PARAMSTRUCT;
 
@@ -2342,6 +2348,7 @@ namespace M {
     }
 
     this->m_paramLock.unlock();
+    this->parameterLoaded(PARAMID_PARAMSTRUCT, this->m_param_ParamStruct_valid);
 
     _id = _baseId + PARAMID_PARAMI32EXT;
 
@@ -2367,6 +2374,7 @@ namespace M {
     }
 
     this->m_paramLock.unlock();
+    this->parameterLoaded(PARAMID_PARAMI32EXT, this->m_param_ParamI32Ext_valid);
 
     _id = _baseId + PARAMID_PARAMF64EXT;
 
@@ -2392,6 +2400,7 @@ namespace M {
     }
 
     this->m_paramLock.unlock();
+    this->parameterLoaded(PARAMID_PARAMF64EXT, this->m_param_ParamF64Ext_valid);
 
     _id = _baseId + PARAMID_PARAMSTRINGEXT;
 
@@ -2438,6 +2447,7 @@ namespace M {
     }
 
     this->m_paramLock.unlock();
+    this->parameterLoaded(PARAMID_PARAMSTRINGEXT, this->m_param_ParamStringExt_valid);
 
     _id = _baseId + PARAMID_PARAMENUMEXT;
 
@@ -2463,6 +2473,7 @@ namespace M {
     }
 
     this->m_paramLock.unlock();
+    this->parameterLoaded(PARAMID_PARAMENUMEXT, this->m_param_ParamEnumExt_valid);
 
     _id = _baseId + PARAMID_PARAMARRAYEXT;
 
@@ -2509,6 +2520,7 @@ namespace M {
     }
 
     this->m_paramLock.unlock();
+    this->parameterLoaded(PARAMID_PARAMARRAYEXT, this->m_param_ParamArrayExt_valid);
 
     _id = _baseId + PARAMID_PARAMSTRUCTEXT;
 
@@ -2534,6 +2546,7 @@ namespace M {
     }
 
     this->m_paramLock.unlock();
+    this->parameterLoaded(PARAMID_PARAMSTRUCTEXT, this->m_param_ParamStructExt_valid);
 
     // Call notifier
     this->parametersLoaded();
@@ -6949,41 +6962,17 @@ namespace M {
   void ActiveTestComponentBase ::
     parametersLoaded()
   {
-    if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
-      this->parameterUpdated(PARAMID_PARAMU32);
-    }
-    if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
-      this->parameterUpdated(PARAMID_PARAMF64);
-    }
-    if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
-      this->parameterUpdated(PARAMID_PARAMSTRING);
-    }
-    if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
-      this->parameterUpdated(PARAMID_PARAMENUM);
-    }
-    if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
-      this->parameterUpdated(PARAMID_PARAMARRAY);
-    }
-    if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
-      this->parameterUpdated(PARAMID_PARAMSTRUCT);
-    }
-    if (this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) {
-      this->parameterUpdated(PARAMID_PARAMI32EXT);
-    }
-    if (this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) {
-      this->parameterUpdated(PARAMID_PARAMF64EXT);
-    }
-    if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
-      this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
-    }
-    if (this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) {
-      this->parameterUpdated(PARAMID_PARAMENUMEXT);
-    }
-    if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
-      this->parameterUpdated(PARAMID_PARAMARRAYEXT);
-    }
-    if (this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) {
-      this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+    // Do nothing by default
+  }
+
+  void ActiveTestComponentBase ::
+    parameterLoaded(
+        FwPrmIdType id,
+        Fw::ParamValid valid
+    )
+  {
+    if (FW_PARAM_OK(valid)) {
+      this->parameterUpdated(id);
     }
   }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.hpp
@@ -2490,7 +2490,9 @@ namespace M {
 
       //! \brief Called whenever parameters are loaded
       //!
-      //! This function does nothing by default. You may override it.
+      //! By default this notifies the component of each parameter via
+      //! parameterUpdated. You may override it, for example to suppress
+      //! notification on load.
       virtual void parametersLoaded();
 
     protected:

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.hpp
@@ -2495,6 +2495,16 @@ namespace M {
       //! notification on load.
       virtual void parametersLoaded();
 
+      //! \brief Called for each parameter when parameters are loaded
+      //!
+      //! By default this notifies the component via parameterUpdated when
+      //! the parameter loaded successfully (valid or default). You may
+      //! override it, for example to distinguish load from update.
+      virtual void parameterLoaded(
+          FwPrmIdType id, //!< The parameter ID
+          Fw::ParamValid valid //!< The parameter validity status
+      );
+
     protected:
 
       // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveExternalParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveExternalParamsComponentAc.ref.cpp
@@ -2538,7 +2538,12 @@ void PassiveExternalParamsComponentBase ::
 void PassiveExternalParamsComponentBase ::
   parametersLoaded()
 {
-  // Do nothing by default
+  this->parameterUpdated(PARAMID_PARAMI32EXT);
+  this->parameterUpdated(PARAMID_PARAMF64EXT);
+  this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
+  this->parameterUpdated(PARAMID_PARAMENUMEXT);
+  this->parameterUpdated(PARAMID_PARAMARRAYEXT);
+  this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
 }
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveExternalParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveExternalParamsComponentAc.ref.cpp
@@ -4,6 +4,7 @@
 // \brief  cpp file for PassiveExternalParams component base class
 // ======================================================================
 
+#include "Fw/Prm/ParamValid.hpp"
 #include "Fw/Types/Assert.hpp"
 #include "Fw/Types/ExternalString.hpp"
 #if FW_ENABLE_TEXT_LOGGING
@@ -1404,6 +1405,7 @@ void PassiveExternalParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMI32EXT, this->m_param_ParamI32Ext_valid);
 
   _id = _baseId + PARAMID_PARAMF64EXT;
 
@@ -1429,6 +1431,7 @@ void PassiveExternalParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMF64EXT, this->m_param_ParamF64Ext_valid);
 
   _id = _baseId + PARAMID_PARAMSTRINGEXT;
 
@@ -1475,6 +1478,7 @@ void PassiveExternalParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMSTRINGEXT, this->m_param_ParamStringExt_valid);
 
   _id = _baseId + PARAMID_PARAMENUMEXT;
 
@@ -1500,6 +1504,7 @@ void PassiveExternalParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMENUMEXT, this->m_param_ParamEnumExt_valid);
 
   _id = _baseId + PARAMID_PARAMARRAYEXT;
 
@@ -1546,6 +1551,7 @@ void PassiveExternalParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMARRAYEXT, this->m_param_ParamArrayExt_valid);
 
   _id = _baseId + PARAMID_PARAMSTRUCTEXT;
 
@@ -1571,6 +1577,7 @@ void PassiveExternalParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMSTRUCTEXT, this->m_param_ParamStructExt_valid);
 
   // Call notifier
   this->parametersLoaded();
@@ -2538,23 +2545,17 @@ void PassiveExternalParamsComponentBase ::
 void PassiveExternalParamsComponentBase ::
   parametersLoaded()
 {
-  if (this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMI32EXT);
-  }
-  if (this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMF64EXT);
-  }
-  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
-  }
-  if (this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMENUMEXT);
-  }
-  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMARRAYEXT);
-  }
-  if (this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+  // Do nothing by default
+}
+
+void PassiveExternalParamsComponentBase ::
+  parameterLoaded(
+      FwPrmIdType id,
+      Fw::ParamValid valid
+  )
+{
+  if (FW_PARAM_OK(valid)) {
+    this->parameterUpdated(id);
   }
 }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveExternalParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveExternalParamsComponentAc.ref.cpp
@@ -2538,12 +2538,24 @@ void PassiveExternalParamsComponentBase ::
 void PassiveExternalParamsComponentBase ::
   parametersLoaded()
 {
-  this->parameterUpdated(PARAMID_PARAMI32EXT);
-  this->parameterUpdated(PARAMID_PARAMF64EXT);
-  this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
-  this->parameterUpdated(PARAMID_PARAMENUMEXT);
-  this->parameterUpdated(PARAMID_PARAMARRAYEXT);
-  this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+  if (this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMI32EXT);
+  }
+  if (this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMF64EXT);
+  }
+  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
+  }
+  if (this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMENUMEXT);
+  }
+  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMARRAYEXT);
+  }
+  if (this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+  }
 }
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveExternalParamsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveExternalParamsComponentAc.ref.hpp
@@ -1248,7 +1248,9 @@ class PassiveExternalParamsComponentBase :
 
     //! \brief Called whenever parameters are loaded
     //!
-    //! This function does nothing by default. You may override it.
+    //! By default this notifies the component of each parameter via
+    //! parameterUpdated. You may override it, for example to suppress
+    //! notification on load.
     virtual void parametersLoaded();
 
   protected:

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveExternalParamsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveExternalParamsComponentAc.ref.hpp
@@ -1253,6 +1253,16 @@ class PassiveExternalParamsComponentBase :
     //! notification on load.
     virtual void parametersLoaded();
 
+    //! \brief Called for each parameter when parameters are loaded
+    //!
+    //! By default this notifies the component via parameterUpdated when
+    //! the parameter loaded successfully (valid or default). You may
+    //! override it, for example to distinguish load from update.
+    virtual void parameterLoaded(
+        FwPrmIdType id, //!< The parameter ID
+        Fw::ParamValid valid //!< The parameter validity status
+    );
+
   protected:
 
     // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveParamsComponentAc.ref.cpp
@@ -2484,7 +2484,12 @@ void PassiveParamsComponentBase ::
 void PassiveParamsComponentBase ::
   parametersLoaded()
 {
-  // Do nothing by default
+  this->parameterUpdated(PARAMID_PARAMU32);
+  this->parameterUpdated(PARAMID_PARAMF64);
+  this->parameterUpdated(PARAMID_PARAMSTRING);
+  this->parameterUpdated(PARAMID_PARAMENUM);
+  this->parameterUpdated(PARAMID_PARAMARRAY);
+  this->parameterUpdated(PARAMID_PARAMSTRUCT);
 }
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveParamsComponentAc.ref.cpp
@@ -2484,12 +2484,24 @@ void PassiveParamsComponentBase ::
 void PassiveParamsComponentBase ::
   parametersLoaded()
 {
-  this->parameterUpdated(PARAMID_PARAMU32);
-  this->parameterUpdated(PARAMID_PARAMF64);
-  this->parameterUpdated(PARAMID_PARAMSTRING);
-  this->parameterUpdated(PARAMID_PARAMENUM);
-  this->parameterUpdated(PARAMID_PARAMARRAY);
-  this->parameterUpdated(PARAMID_PARAMSTRUCT);
+  if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMU32);
+  }
+  if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMF64);
+  }
+  if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMSTRING);
+  }
+  if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMENUM);
+  }
+  if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMARRAY);
+  }
+  if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMSTRUCT);
+  }
 }
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveParamsComponentAc.ref.cpp
@@ -4,6 +4,7 @@
 // \brief  cpp file for PassiveParams component base class
 // ======================================================================
 
+#include "Fw/Prm/ParamValid.hpp"
 #include "Fw/Types/Assert.hpp"
 #include "Fw/Types/ExternalString.hpp"
 #if FW_ENABLE_TEXT_LOGGING
@@ -1400,6 +1401,7 @@ void PassiveParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMU32, this->m_param_ParamU32_valid);
 
   _id = _baseId + PARAMID_PARAMF64;
 
@@ -1421,6 +1423,7 @@ void PassiveParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMF64, this->m_param_ParamF64_valid);
 
   _id = _baseId + PARAMID_PARAMSTRING;
 
@@ -1448,6 +1451,7 @@ void PassiveParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMSTRING, this->m_param_ParamString_valid);
 
   _id = _baseId + PARAMID_PARAMENUM;
 
@@ -1469,6 +1473,7 @@ void PassiveParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMENUM, this->m_param_ParamEnum_valid);
 
   _id = _baseId + PARAMID_PARAMARRAY;
 
@@ -1496,6 +1501,7 @@ void PassiveParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMARRAY, this->m_param_ParamArray_valid);
 
   _id = _baseId + PARAMID_PARAMSTRUCT;
 
@@ -1517,6 +1523,7 @@ void PassiveParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMSTRUCT, this->m_param_ParamStruct_valid);
 
   // Call notifier
   this->parametersLoaded();
@@ -2484,23 +2491,17 @@ void PassiveParamsComponentBase ::
 void PassiveParamsComponentBase ::
   parametersLoaded()
 {
-  if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMU32);
-  }
-  if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMF64);
-  }
-  if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMSTRING);
-  }
-  if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMENUM);
-  }
-  if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMARRAY);
-  }
-  if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMSTRUCT);
+  // Do nothing by default
+}
+
+void PassiveParamsComponentBase ::
+  parameterLoaded(
+      FwPrmIdType id,
+      Fw::ParamValid valid
+  )
+{
+  if (FW_PARAM_OK(valid)) {
+    this->parameterUpdated(id);
   }
 }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveParamsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveParamsComponentAc.ref.hpp
@@ -1247,7 +1247,9 @@ class PassiveParamsComponentBase :
 
     //! \brief Called whenever parameters are loaded
     //!
-    //! This function does nothing by default. You may override it.
+    //! By default this notifies the component of each parameter via
+    //! parameterUpdated. You may override it, for example to suppress
+    //! notification on load.
     virtual void parametersLoaded();
 
   protected:

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveParamsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveParamsComponentAc.ref.hpp
@@ -1252,6 +1252,16 @@ class PassiveParamsComponentBase :
     //! notification on load.
     virtual void parametersLoaded();
 
+    //! \brief Called for each parameter when parameters are loaded
+    //!
+    //! By default this notifies the component via parameterUpdated when
+    //! the parameter loaded successfully (valid or default). You may
+    //! override it, for example to distinguish load from update.
+    virtual void parameterLoaded(
+        FwPrmIdType id, //!< The parameter ID
+        Fw::ParamValid valid //!< The parameter validity status
+    );
+
   protected:
 
     // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
@@ -5023,7 +5023,18 @@ void PassiveSerialComponentBase ::
 void PassiveSerialComponentBase ::
   parametersLoaded()
 {
-  // Do nothing by default
+  this->parameterUpdated(PARAMID_PARAMU32);
+  this->parameterUpdated(PARAMID_PARAMF64);
+  this->parameterUpdated(PARAMID_PARAMSTRING);
+  this->parameterUpdated(PARAMID_PARAMENUM);
+  this->parameterUpdated(PARAMID_PARAMARRAY);
+  this->parameterUpdated(PARAMID_PARAMSTRUCT);
+  this->parameterUpdated(PARAMID_PARAMI32EXT);
+  this->parameterUpdated(PARAMID_PARAMF64EXT);
+  this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
+  this->parameterUpdated(PARAMID_PARAMENUMEXT);
+  this->parameterUpdated(PARAMID_PARAMARRAYEXT);
+  this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
 }
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
@@ -5023,18 +5023,42 @@ void PassiveSerialComponentBase ::
 void PassiveSerialComponentBase ::
   parametersLoaded()
 {
-  this->parameterUpdated(PARAMID_PARAMU32);
-  this->parameterUpdated(PARAMID_PARAMF64);
-  this->parameterUpdated(PARAMID_PARAMSTRING);
-  this->parameterUpdated(PARAMID_PARAMENUM);
-  this->parameterUpdated(PARAMID_PARAMARRAY);
-  this->parameterUpdated(PARAMID_PARAMSTRUCT);
-  this->parameterUpdated(PARAMID_PARAMI32EXT);
-  this->parameterUpdated(PARAMID_PARAMF64EXT);
-  this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
-  this->parameterUpdated(PARAMID_PARAMENUMEXT);
-  this->parameterUpdated(PARAMID_PARAMARRAYEXT);
-  this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+  if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMU32);
+  }
+  if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMF64);
+  }
+  if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMSTRING);
+  }
+  if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMENUM);
+  }
+  if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMARRAY);
+  }
+  if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMSTRUCT);
+  }
+  if (this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMI32EXT);
+  }
+  if (this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMF64EXT);
+  }
+  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
+  }
+  if (this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMENUMEXT);
+  }
+  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMARRAYEXT);
+  }
+  if (this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+  }
 }
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
@@ -4,6 +4,7 @@
 // \brief  cpp file for PassiveSerial component base class
 // ======================================================================
 
+#include "Fw/Prm/ParamValid.hpp"
 #include "Fw/Types/Assert.hpp"
 #include "Fw/Types/ExternalString.hpp"
 #if FW_ENABLE_TEXT_LOGGING
@@ -1645,6 +1646,7 @@ void PassiveSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMU32, this->m_param_ParamU32_valid);
 
   _id = _baseId + PARAMID_PARAMF64;
 
@@ -1666,6 +1668,7 @@ void PassiveSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMF64, this->m_param_ParamF64_valid);
 
   _id = _baseId + PARAMID_PARAMSTRING;
 
@@ -1693,6 +1696,7 @@ void PassiveSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMSTRING, this->m_param_ParamString_valid);
 
   _id = _baseId + PARAMID_PARAMENUM;
 
@@ -1714,6 +1718,7 @@ void PassiveSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMENUM, this->m_param_ParamEnum_valid);
 
   _id = _baseId + PARAMID_PARAMARRAY;
 
@@ -1741,6 +1746,7 @@ void PassiveSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMARRAY, this->m_param_ParamArray_valid);
 
   _id = _baseId + PARAMID_PARAMSTRUCT;
 
@@ -1762,6 +1768,7 @@ void PassiveSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMSTRUCT, this->m_param_ParamStruct_valid);
 
   _id = _baseId + PARAMID_PARAMI32EXT;
 
@@ -1787,6 +1794,7 @@ void PassiveSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMI32EXT, this->m_param_ParamI32Ext_valid);
 
   _id = _baseId + PARAMID_PARAMF64EXT;
 
@@ -1812,6 +1820,7 @@ void PassiveSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMF64EXT, this->m_param_ParamF64Ext_valid);
 
   _id = _baseId + PARAMID_PARAMSTRINGEXT;
 
@@ -1858,6 +1867,7 @@ void PassiveSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMSTRINGEXT, this->m_param_ParamStringExt_valid);
 
   _id = _baseId + PARAMID_PARAMENUMEXT;
 
@@ -1883,6 +1893,7 @@ void PassiveSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMENUMEXT, this->m_param_ParamEnumExt_valid);
 
   _id = _baseId + PARAMID_PARAMARRAYEXT;
 
@@ -1929,6 +1940,7 @@ void PassiveSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMARRAYEXT, this->m_param_ParamArrayExt_valid);
 
   _id = _baseId + PARAMID_PARAMSTRUCTEXT;
 
@@ -1954,6 +1966,7 @@ void PassiveSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMSTRUCTEXT, this->m_param_ParamStructExt_valid);
 
   // Call notifier
   this->parametersLoaded();
@@ -5023,41 +5036,17 @@ void PassiveSerialComponentBase ::
 void PassiveSerialComponentBase ::
   parametersLoaded()
 {
-  if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMU32);
-  }
-  if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMF64);
-  }
-  if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMSTRING);
-  }
-  if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMENUM);
-  }
-  if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMARRAY);
-  }
-  if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMSTRUCT);
-  }
-  if (this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMI32EXT);
-  }
-  if (this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMF64EXT);
-  }
-  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
-  }
-  if (this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMENUMEXT);
-  }
-  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMARRAYEXT);
-  }
-  if (this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+  // Do nothing by default
+}
+
+void PassiveSerialComponentBase ::
+  parameterLoaded(
+      FwPrmIdType id,
+      Fw::ParamValid valid
+  )
+{
+  if (FW_PARAM_OK(valid)) {
+    this->parameterUpdated(id);
   }
 }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.hpp
@@ -1904,7 +1904,9 @@ class PassiveSerialComponentBase :
 
     //! \brief Called whenever parameters are loaded
     //!
-    //! This function does nothing by default. You may override it.
+    //! By default this notifies the component of each parameter via
+    //! parameterUpdated. You may override it, for example to suppress
+    //! notification on load.
     virtual void parametersLoaded();
 
   protected:

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.hpp
@@ -1909,6 +1909,16 @@ class PassiveSerialComponentBase :
     //! notification on load.
     virtual void parametersLoaded();
 
+    //! \brief Called for each parameter when parameters are loaded
+    //!
+    //! By default this notifies the component via parameterUpdated when
+    //! the parameter loaded successfully (valid or default). You may
+    //! override it, for example to distinguish load from update.
+    virtual void parameterLoaded(
+        FwPrmIdType id, //!< The parameter ID
+        Fw::ParamValid valid //!< The parameter validity status
+    );
+
   protected:
 
     // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
@@ -5203,7 +5203,18 @@ void PassiveTestComponentBase ::
 void PassiveTestComponentBase ::
   parametersLoaded()
 {
-  // Do nothing by default
+  this->parameterUpdated(PARAMID_PARAMU32);
+  this->parameterUpdated(PARAMID_PARAMF64);
+  this->parameterUpdated(PARAMID_PARAMSTRING);
+  this->parameterUpdated(PARAMID_PARAMENUM);
+  this->parameterUpdated(PARAMID_PARAMARRAY);
+  this->parameterUpdated(PARAMID_PARAMSTRUCT);
+  this->parameterUpdated(PARAMID_PARAMI32EXT);
+  this->parameterUpdated(PARAMID_PARAMF64EXT);
+  this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
+  this->parameterUpdated(PARAMID_PARAMENUMEXT);
+  this->parameterUpdated(PARAMID_PARAMARRAYEXT);
+  this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
 }
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
@@ -4,6 +4,7 @@
 // \brief  cpp file for PassiveTest component base class
 // ======================================================================
 
+#include "Fw/Prm/ParamValid.hpp"
 #include "Fw/Types/Assert.hpp"
 #include "Fw/Types/ExternalString.hpp"
 #if FW_ENABLE_TEXT_LOGGING
@@ -1877,6 +1878,7 @@ void PassiveTestComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMU32, this->m_param_ParamU32_valid);
 
   _id = _baseId + PARAMID_PARAMF64;
 
@@ -1898,6 +1900,7 @@ void PassiveTestComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMF64, this->m_param_ParamF64_valid);
 
   _id = _baseId + PARAMID_PARAMSTRING;
 
@@ -1925,6 +1928,7 @@ void PassiveTestComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMSTRING, this->m_param_ParamString_valid);
 
   _id = _baseId + PARAMID_PARAMENUM;
 
@@ -1946,6 +1950,7 @@ void PassiveTestComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMENUM, this->m_param_ParamEnum_valid);
 
   _id = _baseId + PARAMID_PARAMARRAY;
 
@@ -1973,6 +1978,7 @@ void PassiveTestComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMARRAY, this->m_param_ParamArray_valid);
 
   _id = _baseId + PARAMID_PARAMSTRUCT;
 
@@ -1994,6 +2000,7 @@ void PassiveTestComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMSTRUCT, this->m_param_ParamStruct_valid);
 
   _id = _baseId + PARAMID_PARAMI32EXT;
 
@@ -2019,6 +2026,7 @@ void PassiveTestComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMI32EXT, this->m_param_ParamI32Ext_valid);
 
   _id = _baseId + PARAMID_PARAMF64EXT;
 
@@ -2044,6 +2052,7 @@ void PassiveTestComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMF64EXT, this->m_param_ParamF64Ext_valid);
 
   _id = _baseId + PARAMID_PARAMSTRINGEXT;
 
@@ -2090,6 +2099,7 @@ void PassiveTestComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMSTRINGEXT, this->m_param_ParamStringExt_valid);
 
   _id = _baseId + PARAMID_PARAMENUMEXT;
 
@@ -2115,6 +2125,7 @@ void PassiveTestComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMENUMEXT, this->m_param_ParamEnumExt_valid);
 
   _id = _baseId + PARAMID_PARAMARRAYEXT;
 
@@ -2161,6 +2172,7 @@ void PassiveTestComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMARRAYEXT, this->m_param_ParamArrayExt_valid);
 
   _id = _baseId + PARAMID_PARAMSTRUCTEXT;
 
@@ -2186,6 +2198,7 @@ void PassiveTestComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMSTRUCTEXT, this->m_param_ParamStructExt_valid);
 
   // Call notifier
   this->parametersLoaded();
@@ -5203,41 +5216,17 @@ void PassiveTestComponentBase ::
 void PassiveTestComponentBase ::
   parametersLoaded()
 {
-  if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMU32);
-  }
-  if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMF64);
-  }
-  if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMSTRING);
-  }
-  if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMENUM);
-  }
-  if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMARRAY);
-  }
-  if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMSTRUCT);
-  }
-  if (this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMI32EXT);
-  }
-  if (this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMF64EXT);
-  }
-  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
-  }
-  if (this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMENUMEXT);
-  }
-  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMARRAYEXT);
-  }
-  if (this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+  // Do nothing by default
+}
+
+void PassiveTestComponentBase ::
+  parameterLoaded(
+      FwPrmIdType id,
+      Fw::ParamValid valid
+  )
+{
+  if (FW_PARAM_OK(valid)) {
+    this->parameterUpdated(id);
   }
 }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
@@ -5203,18 +5203,42 @@ void PassiveTestComponentBase ::
 void PassiveTestComponentBase ::
   parametersLoaded()
 {
-  this->parameterUpdated(PARAMID_PARAMU32);
-  this->parameterUpdated(PARAMID_PARAMF64);
-  this->parameterUpdated(PARAMID_PARAMSTRING);
-  this->parameterUpdated(PARAMID_PARAMENUM);
-  this->parameterUpdated(PARAMID_PARAMARRAY);
-  this->parameterUpdated(PARAMID_PARAMSTRUCT);
-  this->parameterUpdated(PARAMID_PARAMI32EXT);
-  this->parameterUpdated(PARAMID_PARAMF64EXT);
-  this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
-  this->parameterUpdated(PARAMID_PARAMENUMEXT);
-  this->parameterUpdated(PARAMID_PARAMARRAYEXT);
-  this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+  if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMU32);
+  }
+  if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMF64);
+  }
+  if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMSTRING);
+  }
+  if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMENUM);
+  }
+  if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMARRAY);
+  }
+  if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMSTRUCT);
+  }
+  if (this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMI32EXT);
+  }
+  if (this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMF64EXT);
+  }
+  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
+  }
+  if (this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMENUMEXT);
+  }
+  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMARRAYEXT);
+  }
+  if (this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+  }
 }
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.hpp
@@ -1967,7 +1967,9 @@ class PassiveTestComponentBase :
 
     //! \brief Called whenever parameters are loaded
     //!
-    //! This function does nothing by default. You may override it.
+    //! By default this notifies the component of each parameter via
+    //! parameterUpdated. You may override it, for example to suppress
+    //! notification on load.
     virtual void parametersLoaded();
 
   protected:

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.hpp
@@ -1972,6 +1972,16 @@ class PassiveTestComponentBase :
     //! notification on load.
     virtual void parametersLoaded();
 
+    //! \brief Called for each parameter when parameters are loaded
+    //!
+    //! By default this notifies the component via parameterUpdated when
+    //! the parameter loaded successfully (valid or default). You may
+    //! override it, for example to distinguish load from update.
+    virtual void parameterLoaded(
+        FwPrmIdType id, //!< The parameter ID
+        Fw::ParamValid valid //!< The parameter validity status
+    );
+
   protected:
 
     // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedExternalParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedExternalParamsComponentAc.ref.cpp
@@ -3492,7 +3492,12 @@ void QueuedExternalParamsComponentBase ::
 void QueuedExternalParamsComponentBase ::
   parametersLoaded()
 {
-  // Do nothing by default
+  this->parameterUpdated(PARAMID_PARAMI32EXT);
+  this->parameterUpdated(PARAMID_PARAMF64EXT);
+  this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
+  this->parameterUpdated(PARAMID_PARAMENUMEXT);
+  this->parameterUpdated(PARAMID_PARAMARRAYEXT);
+  this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
 }
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedExternalParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedExternalParamsComponentAc.ref.cpp
@@ -3492,12 +3492,24 @@ void QueuedExternalParamsComponentBase ::
 void QueuedExternalParamsComponentBase ::
   parametersLoaded()
 {
-  this->parameterUpdated(PARAMID_PARAMI32EXT);
-  this->parameterUpdated(PARAMID_PARAMF64EXT);
-  this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
-  this->parameterUpdated(PARAMID_PARAMENUMEXT);
-  this->parameterUpdated(PARAMID_PARAMARRAYEXT);
-  this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+  if (this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMI32EXT);
+  }
+  if (this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMF64EXT);
+  }
+  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
+  }
+  if (this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMENUMEXT);
+  }
+  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMARRAYEXT);
+  }
+  if (this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+  }
 }
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedExternalParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedExternalParamsComponentAc.ref.cpp
@@ -4,6 +4,7 @@
 // \brief  cpp file for QueuedExternalParams component base class
 // ======================================================================
 
+#include "Fw/Prm/ParamValid.hpp"
 #include "Fw/Types/Assert.hpp"
 #include "Fw/Types/ExternalString.hpp"
 #if FW_ENABLE_TEXT_LOGGING
@@ -1689,6 +1690,7 @@ void QueuedExternalParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMI32EXT, this->m_param_ParamI32Ext_valid);
 
   _id = _baseId + PARAMID_PARAMF64EXT;
 
@@ -1714,6 +1716,7 @@ void QueuedExternalParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMF64EXT, this->m_param_ParamF64Ext_valid);
 
   _id = _baseId + PARAMID_PARAMSTRINGEXT;
 
@@ -1760,6 +1763,7 @@ void QueuedExternalParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMSTRINGEXT, this->m_param_ParamStringExt_valid);
 
   _id = _baseId + PARAMID_PARAMENUMEXT;
 
@@ -1785,6 +1789,7 @@ void QueuedExternalParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMENUMEXT, this->m_param_ParamEnumExt_valid);
 
   _id = _baseId + PARAMID_PARAMARRAYEXT;
 
@@ -1831,6 +1836,7 @@ void QueuedExternalParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMARRAYEXT, this->m_param_ParamArrayExt_valid);
 
   _id = _baseId + PARAMID_PARAMSTRUCTEXT;
 
@@ -1856,6 +1862,7 @@ void QueuedExternalParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMSTRUCTEXT, this->m_param_ParamStructExt_valid);
 
   // Call notifier
   this->parametersLoaded();
@@ -3492,23 +3499,17 @@ void QueuedExternalParamsComponentBase ::
 void QueuedExternalParamsComponentBase ::
   parametersLoaded()
 {
-  if (this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMI32EXT);
-  }
-  if (this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMF64EXT);
-  }
-  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
-  }
-  if (this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMENUMEXT);
-  }
-  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMARRAYEXT);
-  }
-  if (this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+  // Do nothing by default
+}
+
+void QueuedExternalParamsComponentBase ::
+  parameterLoaded(
+      FwPrmIdType id,
+      Fw::ParamValid valid
+  )
+{
+  if (FW_PARAM_OK(valid)) {
+    this->parameterUpdated(id);
   }
 }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedExternalParamsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedExternalParamsComponentAc.ref.hpp
@@ -1544,7 +1544,9 @@ class QueuedExternalParamsComponentBase :
 
     //! \brief Called whenever parameters are loaded
     //!
-    //! This function does nothing by default. You may override it.
+    //! By default this notifies the component of each parameter via
+    //! parameterUpdated. You may override it, for example to suppress
+    //! notification on load.
     virtual void parametersLoaded();
 
   protected:

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedExternalParamsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedExternalParamsComponentAc.ref.hpp
@@ -1549,6 +1549,16 @@ class QueuedExternalParamsComponentBase :
     //! notification on load.
     virtual void parametersLoaded();
 
+    //! \brief Called for each parameter when parameters are loaded
+    //!
+    //! By default this notifies the component via parameterUpdated when
+    //! the parameter loaded successfully (valid or default). You may
+    //! override it, for example to distinguish load from update.
+    virtual void parameterLoaded(
+        FwPrmIdType id, //!< The parameter ID
+        Fw::ParamValid valid //!< The parameter validity status
+    );
+
   protected:
 
     // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.cpp
@@ -3438,7 +3438,12 @@ void QueuedParamsComponentBase ::
 void QueuedParamsComponentBase ::
   parametersLoaded()
 {
-  // Do nothing by default
+  this->parameterUpdated(PARAMID_PARAMU32);
+  this->parameterUpdated(PARAMID_PARAMF64);
+  this->parameterUpdated(PARAMID_PARAMSTRING);
+  this->parameterUpdated(PARAMID_PARAMENUM);
+  this->parameterUpdated(PARAMID_PARAMARRAY);
+  this->parameterUpdated(PARAMID_PARAMSTRUCT);
 }
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.cpp
@@ -3438,12 +3438,24 @@ void QueuedParamsComponentBase ::
 void QueuedParamsComponentBase ::
   parametersLoaded()
 {
-  this->parameterUpdated(PARAMID_PARAMU32);
-  this->parameterUpdated(PARAMID_PARAMF64);
-  this->parameterUpdated(PARAMID_PARAMSTRING);
-  this->parameterUpdated(PARAMID_PARAMENUM);
-  this->parameterUpdated(PARAMID_PARAMARRAY);
-  this->parameterUpdated(PARAMID_PARAMSTRUCT);
+  if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMU32);
+  }
+  if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMF64);
+  }
+  if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMSTRING);
+  }
+  if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMENUM);
+  }
+  if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMARRAY);
+  }
+  if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMSTRUCT);
+  }
 }
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.cpp
@@ -4,6 +4,7 @@
 // \brief  cpp file for QueuedParams component base class
 // ======================================================================
 
+#include "Fw/Prm/ParamValid.hpp"
 #include "Fw/Types/Assert.hpp"
 #include "Fw/Types/ExternalString.hpp"
 #if FW_ENABLE_TEXT_LOGGING
@@ -1685,6 +1686,7 @@ void QueuedParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMU32, this->m_param_ParamU32_valid);
 
   _id = _baseId + PARAMID_PARAMF64;
 
@@ -1706,6 +1708,7 @@ void QueuedParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMF64, this->m_param_ParamF64_valid);
 
   _id = _baseId + PARAMID_PARAMSTRING;
 
@@ -1733,6 +1736,7 @@ void QueuedParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMSTRING, this->m_param_ParamString_valid);
 
   _id = _baseId + PARAMID_PARAMENUM;
 
@@ -1754,6 +1758,7 @@ void QueuedParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMENUM, this->m_param_ParamEnum_valid);
 
   _id = _baseId + PARAMID_PARAMARRAY;
 
@@ -1781,6 +1786,7 @@ void QueuedParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMARRAY, this->m_param_ParamArray_valid);
 
   _id = _baseId + PARAMID_PARAMSTRUCT;
 
@@ -1802,6 +1808,7 @@ void QueuedParamsComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMSTRUCT, this->m_param_ParamStruct_valid);
 
   // Call notifier
   this->parametersLoaded();
@@ -3438,23 +3445,17 @@ void QueuedParamsComponentBase ::
 void QueuedParamsComponentBase ::
   parametersLoaded()
 {
-  if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMU32);
-  }
-  if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMF64);
-  }
-  if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMSTRING);
-  }
-  if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMENUM);
-  }
-  if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMARRAY);
-  }
-  if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMSTRUCT);
+  // Do nothing by default
+}
+
+void QueuedParamsComponentBase ::
+  parameterLoaded(
+      FwPrmIdType id,
+      Fw::ParamValid valid
+  )
+{
+  if (FW_PARAM_OK(valid)) {
+    this->parameterUpdated(id);
   }
 }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.hpp
@@ -1543,7 +1543,9 @@ class QueuedParamsComponentBase :
 
     //! \brief Called whenever parameters are loaded
     //!
-    //! This function does nothing by default. You may override it.
+    //! By default this notifies the component of each parameter via
+    //! parameterUpdated. You may override it, for example to suppress
+    //! notification on load.
     virtual void parametersLoaded();
 
   protected:

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.hpp
@@ -1548,6 +1548,16 @@ class QueuedParamsComponentBase :
     //! notification on load.
     virtual void parametersLoaded();
 
+    //! \brief Called for each parameter when parameters are loaded
+    //!
+    //! By default this notifies the component via parameterUpdated when
+    //! the parameter loaded successfully (valid or default). You may
+    //! override it, for example to distinguish load from update.
+    virtual void parameterLoaded(
+        FwPrmIdType id, //!< The parameter ID
+        Fw::ParamValid valid //!< The parameter validity status
+    );
+
   protected:
 
     // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
@@ -7117,7 +7117,18 @@ void QueuedSerialComponentBase ::
 void QueuedSerialComponentBase ::
   parametersLoaded()
 {
-  // Do nothing by default
+  this->parameterUpdated(PARAMID_PARAMU32);
+  this->parameterUpdated(PARAMID_PARAMF64);
+  this->parameterUpdated(PARAMID_PARAMSTRING);
+  this->parameterUpdated(PARAMID_PARAMENUM);
+  this->parameterUpdated(PARAMID_PARAMARRAY);
+  this->parameterUpdated(PARAMID_PARAMSTRUCT);
+  this->parameterUpdated(PARAMID_PARAMI32EXT);
+  this->parameterUpdated(PARAMID_PARAMF64EXT);
+  this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
+  this->parameterUpdated(PARAMID_PARAMENUMEXT);
+  this->parameterUpdated(PARAMID_PARAMARRAYEXT);
+  this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
 }
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
@@ -4,6 +4,7 @@
 // \brief  cpp file for QueuedSerial component base class
 // ======================================================================
 
+#include "Fw/Prm/ParamValid.hpp"
 #include "Fw/Types/Assert.hpp"
 #include "Fw/Types/ExternalString.hpp"
 #if FW_ENABLE_TEXT_LOGGING
@@ -2147,6 +2148,7 @@ void QueuedSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMU32, this->m_param_ParamU32_valid);
 
   _id = _baseId + PARAMID_PARAMF64;
 
@@ -2168,6 +2170,7 @@ void QueuedSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMF64, this->m_param_ParamF64_valid);
 
   _id = _baseId + PARAMID_PARAMSTRING;
 
@@ -2195,6 +2198,7 @@ void QueuedSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMSTRING, this->m_param_ParamString_valid);
 
   _id = _baseId + PARAMID_PARAMENUM;
 
@@ -2216,6 +2220,7 @@ void QueuedSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMENUM, this->m_param_ParamEnum_valid);
 
   _id = _baseId + PARAMID_PARAMARRAY;
 
@@ -2243,6 +2248,7 @@ void QueuedSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMARRAY, this->m_param_ParamArray_valid);
 
   _id = _baseId + PARAMID_PARAMSTRUCT;
 
@@ -2264,6 +2270,7 @@ void QueuedSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMSTRUCT, this->m_param_ParamStruct_valid);
 
   _id = _baseId + PARAMID_PARAMI32EXT;
 
@@ -2289,6 +2296,7 @@ void QueuedSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMI32EXT, this->m_param_ParamI32Ext_valid);
 
   _id = _baseId + PARAMID_PARAMF64EXT;
 
@@ -2314,6 +2322,7 @@ void QueuedSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMF64EXT, this->m_param_ParamF64Ext_valid);
 
   _id = _baseId + PARAMID_PARAMSTRINGEXT;
 
@@ -2360,6 +2369,7 @@ void QueuedSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMSTRINGEXT, this->m_param_ParamStringExt_valid);
 
   _id = _baseId + PARAMID_PARAMENUMEXT;
 
@@ -2385,6 +2395,7 @@ void QueuedSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMENUMEXT, this->m_param_ParamEnumExt_valid);
 
   _id = _baseId + PARAMID_PARAMARRAYEXT;
 
@@ -2431,6 +2442,7 @@ void QueuedSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMARRAYEXT, this->m_param_ParamArrayExt_valid);
 
   _id = _baseId + PARAMID_PARAMSTRUCTEXT;
 
@@ -2456,6 +2468,7 @@ void QueuedSerialComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMSTRUCTEXT, this->m_param_ParamStructExt_valid);
 
   // Call notifier
   this->parametersLoaded();
@@ -7117,41 +7130,17 @@ void QueuedSerialComponentBase ::
 void QueuedSerialComponentBase ::
   parametersLoaded()
 {
-  if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMU32);
-  }
-  if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMF64);
-  }
-  if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMSTRING);
-  }
-  if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMENUM);
-  }
-  if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMARRAY);
-  }
-  if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMSTRUCT);
-  }
-  if (this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMI32EXT);
-  }
-  if (this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMF64EXT);
-  }
-  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
-  }
-  if (this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMENUMEXT);
-  }
-  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMARRAYEXT);
-  }
-  if (this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+  // Do nothing by default
+}
+
+void QueuedSerialComponentBase ::
+  parameterLoaded(
+      FwPrmIdType id,
+      Fw::ParamValid valid
+  )
+{
+  if (FW_PARAM_OK(valid)) {
+    this->parameterUpdated(id);
   }
 }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
@@ -7117,18 +7117,42 @@ void QueuedSerialComponentBase ::
 void QueuedSerialComponentBase ::
   parametersLoaded()
 {
-  this->parameterUpdated(PARAMID_PARAMU32);
-  this->parameterUpdated(PARAMID_PARAMF64);
-  this->parameterUpdated(PARAMID_PARAMSTRING);
-  this->parameterUpdated(PARAMID_PARAMENUM);
-  this->parameterUpdated(PARAMID_PARAMARRAY);
-  this->parameterUpdated(PARAMID_PARAMSTRUCT);
-  this->parameterUpdated(PARAMID_PARAMI32EXT);
-  this->parameterUpdated(PARAMID_PARAMF64EXT);
-  this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
-  this->parameterUpdated(PARAMID_PARAMENUMEXT);
-  this->parameterUpdated(PARAMID_PARAMARRAYEXT);
-  this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+  if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMU32);
+  }
+  if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMF64);
+  }
+  if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMSTRING);
+  }
+  if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMENUM);
+  }
+  if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMARRAY);
+  }
+  if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMSTRUCT);
+  }
+  if (this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMI32EXT);
+  }
+  if (this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMF64EXT);
+  }
+  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
+  }
+  if (this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMENUMEXT);
+  }
+  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMARRAYEXT);
+  }
+  if (this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+  }
 }
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.hpp
@@ -2550,7 +2550,9 @@ class QueuedSerialComponentBase :
 
     //! \brief Called whenever parameters are loaded
     //!
-    //! This function does nothing by default. You may override it.
+    //! By default this notifies the component of each parameter via
+    //! parameterUpdated. You may override it, for example to suppress
+    //! notification on load.
     virtual void parametersLoaded();
 
   protected:

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.hpp
@@ -2555,6 +2555,16 @@ class QueuedSerialComponentBase :
     //! notification on load.
     virtual void parametersLoaded();
 
+    //! \brief Called for each parameter when parameters are loaded
+    //!
+    //! By default this notifies the component via parameterUpdated when
+    //! the parameter loaded successfully (valid or default). You may
+    //! override it, for example to distinguish load from update.
+    virtual void parameterLoaded(
+        FwPrmIdType id, //!< The parameter ID
+        Fw::ParamValid valid //!< The parameter validity status
+    );
+
   protected:
 
     // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
@@ -6947,7 +6947,18 @@ void QueuedTestComponentBase ::
 void QueuedTestComponentBase ::
   parametersLoaded()
 {
-  // Do nothing by default
+  this->parameterUpdated(PARAMID_PARAMU32);
+  this->parameterUpdated(PARAMID_PARAMF64);
+  this->parameterUpdated(PARAMID_PARAMSTRING);
+  this->parameterUpdated(PARAMID_PARAMENUM);
+  this->parameterUpdated(PARAMID_PARAMARRAY);
+  this->parameterUpdated(PARAMID_PARAMSTRUCT);
+  this->parameterUpdated(PARAMID_PARAMI32EXT);
+  this->parameterUpdated(PARAMID_PARAMF64EXT);
+  this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
+  this->parameterUpdated(PARAMID_PARAMENUMEXT);
+  this->parameterUpdated(PARAMID_PARAMARRAYEXT);
+  this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
 }
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
@@ -6947,18 +6947,42 @@ void QueuedTestComponentBase ::
 void QueuedTestComponentBase ::
   parametersLoaded()
 {
-  this->parameterUpdated(PARAMID_PARAMU32);
-  this->parameterUpdated(PARAMID_PARAMF64);
-  this->parameterUpdated(PARAMID_PARAMSTRING);
-  this->parameterUpdated(PARAMID_PARAMENUM);
-  this->parameterUpdated(PARAMID_PARAMARRAY);
-  this->parameterUpdated(PARAMID_PARAMSTRUCT);
-  this->parameterUpdated(PARAMID_PARAMI32EXT);
-  this->parameterUpdated(PARAMID_PARAMF64EXT);
-  this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
-  this->parameterUpdated(PARAMID_PARAMENUMEXT);
-  this->parameterUpdated(PARAMID_PARAMARRAYEXT);
-  this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+  if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMU32);
+  }
+  if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMF64);
+  }
+  if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMSTRING);
+  }
+  if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMENUM);
+  }
+  if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMARRAY);
+  }
+  if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMSTRUCT);
+  }
+  if (this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMI32EXT);
+  }
+  if (this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMF64EXT);
+  }
+  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
+  }
+  if (this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMENUMEXT);
+  }
+  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMARRAYEXT);
+  }
+  if (this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) {
+    this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+  }
 }
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
@@ -4,6 +4,7 @@
 // \brief  cpp file for QueuedTest component base class
 // ======================================================================
 
+#include "Fw/Prm/ParamValid.hpp"
 #include "Fw/Types/Assert.hpp"
 #include "Fw/Types/ExternalString.hpp"
 #if FW_ENABLE_TEXT_LOGGING
@@ -2223,6 +2224,7 @@ void QueuedTestComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMU32, this->m_param_ParamU32_valid);
 
   _id = _baseId + PARAMID_PARAMF64;
 
@@ -2244,6 +2246,7 @@ void QueuedTestComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMF64, this->m_param_ParamF64_valid);
 
   _id = _baseId + PARAMID_PARAMSTRING;
 
@@ -2271,6 +2274,7 @@ void QueuedTestComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMSTRING, this->m_param_ParamString_valid);
 
   _id = _baseId + PARAMID_PARAMENUM;
 
@@ -2292,6 +2296,7 @@ void QueuedTestComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMENUM, this->m_param_ParamEnum_valid);
 
   _id = _baseId + PARAMID_PARAMARRAY;
 
@@ -2319,6 +2324,7 @@ void QueuedTestComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMARRAY, this->m_param_ParamArray_valid);
 
   _id = _baseId + PARAMID_PARAMSTRUCT;
 
@@ -2340,6 +2346,7 @@ void QueuedTestComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMSTRUCT, this->m_param_ParamStruct_valid);
 
   _id = _baseId + PARAMID_PARAMI32EXT;
 
@@ -2365,6 +2372,7 @@ void QueuedTestComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMI32EXT, this->m_param_ParamI32Ext_valid);
 
   _id = _baseId + PARAMID_PARAMF64EXT;
 
@@ -2390,6 +2398,7 @@ void QueuedTestComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMF64EXT, this->m_param_ParamF64Ext_valid);
 
   _id = _baseId + PARAMID_PARAMSTRINGEXT;
 
@@ -2436,6 +2445,7 @@ void QueuedTestComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMSTRINGEXT, this->m_param_ParamStringExt_valid);
 
   _id = _baseId + PARAMID_PARAMENUMEXT;
 
@@ -2461,6 +2471,7 @@ void QueuedTestComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMENUMEXT, this->m_param_ParamEnumExt_valid);
 
   _id = _baseId + PARAMID_PARAMARRAYEXT;
 
@@ -2507,6 +2518,7 @@ void QueuedTestComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMARRAYEXT, this->m_param_ParamArrayExt_valid);
 
   _id = _baseId + PARAMID_PARAMSTRUCTEXT;
 
@@ -2532,6 +2544,7 @@ void QueuedTestComponentBase ::
   }
 
   this->m_paramLock.unlock();
+  this->parameterLoaded(PARAMID_PARAMSTRUCTEXT, this->m_param_ParamStructExt_valid);
 
   // Call notifier
   this->parametersLoaded();
@@ -6947,41 +6960,17 @@ void QueuedTestComponentBase ::
 void QueuedTestComponentBase ::
   parametersLoaded()
 {
-  if (this->m_param_ParamU32_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMU32);
-  }
-  if (this->m_param_ParamF64_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMF64);
-  }
-  if (this->m_param_ParamString_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMSTRING);
-  }
-  if (this->m_param_ParamEnum_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMENUM);
-  }
-  if (this->m_param_ParamArray_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMARRAY);
-  }
-  if (this->m_param_ParamStruct_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMSTRUCT);
-  }
-  if (this->m_param_ParamI32Ext_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMI32EXT);
-  }
-  if (this->m_param_ParamF64Ext_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMF64EXT);
-  }
-  if (this->m_param_ParamStringExt_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMSTRINGEXT);
-  }
-  if (this->m_param_ParamEnumExt_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMENUMEXT);
-  }
-  if (this->m_param_ParamArrayExt_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMARRAYEXT);
-  }
-  if (this->m_param_ParamStructExt_valid == Fw::ParamValid::VALID) {
-    this->parameterUpdated(PARAMID_PARAMSTRUCTEXT);
+  // Do nothing by default
+}
+
+void QueuedTestComponentBase ::
+  parameterLoaded(
+      FwPrmIdType id,
+      Fw::ParamValid valid
+  )
+{
+  if (FW_PARAM_OK(valid)) {
+    this->parameterUpdated(id);
   }
 }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.hpp
@@ -2488,7 +2488,9 @@ class QueuedTestComponentBase :
 
     //! \brief Called whenever parameters are loaded
     //!
-    //! This function does nothing by default. You may override it.
+    //! By default this notifies the component of each parameter via
+    //! parameterUpdated. You may override it, for example to suppress
+    //! notification on load.
     virtual void parametersLoaded();
 
   protected:

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.hpp
@@ -2493,6 +2493,16 @@ class QueuedTestComponentBase :
     //! notification on load.
     virtual void parametersLoaded();
 
+    //! \brief Called for each parameter when parameters are loaded
+    //!
+    //! By default this notifies the component via parameterUpdated when
+    //! the parameter loaded successfully (valid or default). You may
+    //! override it, for example to distinguish load from update.
+    virtual void parameterLoaded(
+        FwPrmIdType id, //!< The parameter ID
+        Fw::ParamValid valid //!< The parameter validity status
+    );
+
   protected:
 
     // ----------------------------------------------------------------------


### PR DESCRIPTION
Implements nasa/fpp#1098.

Per @Willmac16's guidance on the issue, the calls go in the parametersLoaded hook rather than the loadParameters body.

The generated parametersLoaded base implementation was empty, so a component that centralizes update handling in parameterUpdated did not get called for each parameter at load time and had to iterate manually. It now calls parameterUpdated once per parameter, giving full coverage on load with no manual iteration.

This is a behavior change: parameterUpdated now fires for every parameter when parameters are loaded. Because parametersLoaded stays a virtual hook, a component can override it to restore the previous no-op behavior, for example to avoid double-handling when updates are managed elsewhere.

Updated the affected component and tester base reference outputs.

Testing: Scala unit tests pass (633). Component command-line tests pass, reference outputs regenerated.